### PR TITLE
TCF v2.3 Support and Validator Implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+* Add support for TCF v2.3 (Disclosed Vendors and Allowed Vendors segments)
+* Add `GDPR::IAB::TCFv2::Validator` for automated policy enforcement
+* Add `is_vendor_consent_allowed`, `is_vendor_legitimate_interest_allowed`, and `is_vendor_allowed_for_flexible_purpose` to core object
+* Fix bug: croak on duplicate segment types in TC string
+* Performance: Optimize `TO_JSON` for `BitField` and `RangeSection` (up to 55x faster for compact mode)
+* Alignment: Update Purpose names and descriptions to TCF v2.3
+
 ## What's Changed in v0.203
 * update changelog
 * bump version to v0.203

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,36 @@
+# TCF v2.3 Support Plan (Revised)
+
+## Phase 0: Core Logic Expansion (Core Methods)
+*   **Goal:** Move complex legal basis logic into the library.
+*   **Tasks:**
+    *   Implement `is_vendor_consent_allowed($vid, $pid)`: Validates Consent bit + Purpose bit + Pub Restrictions.
+    *   Implement `is_vendor_legitimate_interest_allowed($vid, $pid)`: Validates LI bit + Purpose bit + Pub Restrictions.
+    *   Implement `is_vendor_allowed_for_flexible_purpose($vid, $pid, $default_is_li)`.
+    *   Support `strict` mode: `croak` on invalid Purpose IDs (1-24) if enabled, else `warn` and return 0.
+    *   **Tests:** New `t/04-legal-basis.t`.
+
+## Phase 1: TCF v2.3 & Segment Robustness
+*   **Goal:** Support new segments and fix parsing bugs.
+*   **Tasks:**
+    *   Implement decoding for **Segment Type 1 (Disclosed Vendors)**.
+    *   Implement decoding for **Segment Type 2 (Allowed Vendors)**.
+    *   **Fix Segment Overwriting:** Update `_decode_tc_string_segments` to handle multiple segments of the same type safely (e.g., only keep the first occurrence or throw error).
+    *   Update `TO_JSON` to include new segments.
+
+## Phase 2: The Validator Interface
+*   **Goal:** Automated policy enforcement, TCF v2.3 aware.
+*   **Tasks:**
+    *   Create `GDPR::IAB::TCFv2::Validator` with constructor + method overrides.
+    *   Implement `validate` and `validate_all`.
+    *   Implement `GDPR::IAB::TCFv2::Validator::Result` with `$\` (ORS) awareness for stringification.
+    *   Include optional check for "Disclosed Vendors" in validation if segment exists.
+
+## Phase 3: Alignment & Cleanup
+*   **Goal:** Documentation and nomenclature.
+*   **Tasks:**
+    *   Update `Purpose.pm` names to TCF v2.3.
+    *   Streamline POD and add TCF v2.3 usage examples.
+
+## Phase 4: Performance
+*   **Tasks:**
+    *   Investigate `vec()` for bitfields.

--- a/bench_bitfield.pl
+++ b/bench_bitfield.pl
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+use Benchmark qw(cmpthese);
+use GDPR::IAB::TCFv2::BitField;
+
+my $max_id = 10000;
+my $data = '0' x $max_id;
+for (1..5000) { substr($data, int(rand($max_id)), 1, '1') }
+
+my $bf = bless {
+    data => $data,
+    max_id => $max_id,
+    options => { json => { compact => 1 } }
+}, 'GDPR::IAB::TCFv2::BitField';
+
+cmpthese(1000, {
+    original => sub {
+        my @data = split //, $bf->{data};
+        my $res = [ grep { $data[ $_ - 1 ] } 1 .. $bf->{max_id} ];
+    },
+    index_based => sub {
+        my @ids;
+        my $d = $bf->{data};
+        my $pos = index($d, '1');
+        while ($pos != -1 && $pos < $bf->{max_id}) {
+            push @ids, $pos + 1;
+            $pos = index($d, '1', $pos + 1);
+        }
+    }
+});

--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -36,8 +36,10 @@ use constant {
     MAX_PURPOSE_ID          => 24,
     DATE_FORMAT_ISO_8601    => '%Y-%m-%dT%H:%M:%SZ',
     SEGMENT_TYPES           => {
-        CORE         => 0,
-        PUBLISHER_TC => 3,
+        CORE              => 0,
+        DISCLOSED_VENDORS => 1,
+        ALLOWED_VENDORS   => 2,
+        PUBLISHER_TC      => 3,
     },
     OFFSETS => {
         SEGMENT_TYPE            => 0,
@@ -91,14 +93,18 @@ sub Parse {
     }
 
     my $self = {
-        core_data         => $segments->{core_data},
-        publisher_tc_data => $segments->{publisher_tc},
-        options           => \%options,
-        tc_string         => $tc_string,
+        core_data              => $segments->{core_data},
+        disclosed_vendors_data => $segments->{disclosed_vendors},
+        allowed_vendors_data   => $segments->{allowed_vendors},
+        publisher_tc_data      => $segments->{publisher_tc},
+        options                => \%options,
+        tc_string              => $tc_string,
 
         vendor_consents             => undef,
         vendor_legitimate_interests => undef,
         publisher                   => undef,
+        disclosed_vendors           => undef,
+        allowed_vendors             => undef,
     };
 
     bless $self, $klass;
@@ -111,6 +117,9 @@ sub Parse {
     my $next_offset = $self->_parse_vendor_section();
 
     $self->_parse_publisher_section($next_offset);
+
+    $self->_parse_disclosed_vendors();
+    $self->_parse_allowed_vendors();
 
     return $self;
 }
@@ -308,6 +317,22 @@ sub vendor_legitimate_interest {
     return $self->{vendor_legitimate_interests}->contains($id);
 }
 
+sub disclosed_vendor {
+    my ( $self, $id ) = @_;
+
+    return 0 unless defined $self->{disclosed_vendors};
+
+    return $self->{disclosed_vendors}->contains($id);
+}
+
+sub allowed_vendor {
+    my ( $self, $id ) = @_;
+
+    return 0 unless defined $self->{allowed_vendors};
+
+    return $self->{allowed_vendors}->contains($id);
+}
+
 sub check_publisher_restriction {
     my $self = shift;
 
@@ -495,6 +520,12 @@ sub TO_JSON {
             consents             => $self->{vendor_consents}->TO_JSON,
             legitimate_interests =>
               $self->{vendor_legitimate_interests}->TO_JSON,
+            disclosed => $self->{disclosed_vendors}
+            ? $self->{disclosed_vendors}->TO_JSON
+            : undef,
+            allowed => $self->{allowed_vendors}
+            ? $self->{allowed_vendors}->TO_JSON
+            : undef,
         },
         publisher => $self->{publisher}->TO_JSON,
     };
@@ -520,14 +551,17 @@ sub _decode_tc_string_segments {
 
         my $segment_type = get_uint3( $decoded, OFFSETS->{SEGMENT_TYPE} );
 
+        croak "duplicate segment type $segment_type"
+          if exists $segments{$segment_type};
+
         $segments{$segment_type} = $decoded;
     }
 
-    my $publisher_tc = $segments{ SEGMENT_TYPES->{PUBLISHER_TC} };
-
     return {
-        core_data    => $core_data,
-        publisher_tc => $publisher_tc,
+        core_data         => $core_data,
+        disclosed_vendors => $segments{ SEGMENT_TYPES->{DISCLOSED_VENDORS} },
+        allowed_vendors   => $segments{ SEGMENT_TYPES->{ALLOWED_VENDORS} },
+        publisher_tc      => $segments{ SEGMENT_TYPES->{PUBLISHER_TC} },
     };
 }
 
@@ -622,6 +656,57 @@ sub _parse_publisher_section {
     );
 
     $self->{publisher} = $publisher;
+}
+
+sub _parse_disclosed_vendors {
+    my $self = shift;
+
+    return unless defined $self->{disclosed_vendors_data};
+
+    $self->{disclosed_vendors} =
+      $self->_parse_vendor_bitfield_or_range( $self->{disclosed_vendors_data} );
+}
+
+sub _parse_allowed_vendors {
+    my $self = shift;
+
+    return unless defined $self->{allowed_vendors_data};
+
+    $self->{allowed_vendors} =
+      $self->_parse_vendor_bitfield_or_range( $self->{allowed_vendors_data} );
+}
+
+sub _parse_vendor_bitfield_or_range {
+    my ( $self, $data ) = @_;
+
+    my $offset = 3;    # segment type
+
+    my ( $max_id, $next_offset ) = get_uint16( $data, $offset );
+
+    my ( $is_range, $bf_offset ) = is_set( $data, $next_offset );
+
+    my $something;
+    if ($is_range) {
+        my $data_size = length($data);
+        ( $something, ) = GDPR::IAB::TCFv2::RangeSection->Parse(
+            data      => substr( $data, $bf_offset ),
+            data_size => $data_size,
+            offset    => 0,
+            max_id    => $max_id,
+            options   => $self->{options},
+        );
+    }
+    else {
+        my $data_size = length($data);
+        ( $something, ) = GDPR::IAB::TCFv2::BitField->Parse(
+            data      => substr( $data, $bf_offset, $max_id ),
+            data_size => $data_size,
+            max_id    => $max_id,
+            options   => $self->{options},
+        );
+    }
+
+    return $something;
 }
 
 sub _parse_bitfield_or_range {

--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -884,6 +884,20 @@ The purpose of this package is to parse Transparency & Consent String (TC String
 
     say "find consent for vendor id 284 (Weborama)" if $consent->vendor_consent(284);
 
+    say "vendor 284 was disclosed" if $consent->disclosed_vendor(284);
+
+    # Validator usage
+    use GDPR::IAB::TCFv2::Validator;
+
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id           => 284,
+        consent_purpose_ids => [ InfoStorageAccess ],
+    );
+
+    my $result = $validator->validate($consent);
+    say "Validation ok" if $result;
+    say "Validation failed: $result" unless $result;
+
     # Geolocation exported by GDPR::IAB::TCFv2::Constants::SpecialFeature
     say "user is opt in for special feature 'Geolocation (id 1)'" 
         if $consent->is_special_feature_opt_in(Geolocation);

--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -520,12 +520,16 @@ sub TO_JSON {
             consents             => $self->{vendor_consents}->TO_JSON,
             legitimate_interests =>
               $self->{vendor_legitimate_interests}->TO_JSON,
-            disclosed => $self->{disclosed_vendors}
-            ? $self->{disclosed_vendors}->TO_JSON
-            : undef,
-            allowed => $self->{allowed_vendors}
-            ? $self->{allowed_vendors}->TO_JSON
-            : undef,
+            (
+                $self->{disclosed_vendors}
+                ? ( disclosed => $self->{disclosed_vendors}->TO_JSON )
+                : ()
+            ),
+            (
+                $self->{allowed_vendors}
+                ? ( allowed => $self->{allowed_vendors}->TO_JSON )
+                : ()
+            ),
         },
         publisher => $self->{publisher}->TO_JSON,
     };

--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -21,6 +21,7 @@ use GDPR::IAB::TCFv2::BitUtils qw<is_set
 >;
 use GDPR::IAB::TCFv2::Publisher;
 use GDPR::IAB::TCFv2::RangeSection;
+use GDPR::IAB::TCFv2::Constants::RestrictionType qw<:all>;
 
 our $VERSION = "0.203";
 
@@ -336,6 +337,77 @@ sub publisher_tc {
     my $self = shift;
 
     return $self->{publisher}->publisher_tc;
+}
+
+sub is_vendor_consent_allowed {
+    my ( $self, $vendor_id, $purpose_id, %opts ) = @_;
+
+    return 0 unless $self->_check_purpose_id( $purpose_id, %opts );
+
+    return 0 if $self->check_publisher_restriction( $purpose_id, NotAllowed, $vendor_id );
+    return 0 if $self->check_publisher_restriction( $purpose_id, RequireLegitimateInterest, $vendor_id );
+
+    return 0 unless $self->_safe_is_purpose_consent_allowed($purpose_id);
+    return 0 unless $self->vendor_consent($vendor_id);
+
+    return 1;
+}
+
+sub is_vendor_legitimate_interest_allowed {
+    my ( $self, $vendor_id, $purpose_id, %opts ) = @_;
+
+    return 0 unless $self->_check_purpose_id( $purpose_id, %opts );
+
+    return 0 if $self->check_publisher_restriction( $purpose_id, NotAllowed, $vendor_id );
+    return 0 if $self->check_publisher_restriction( $purpose_id, RequireConsent, $vendor_id );
+
+    return 0 unless $self->_safe_is_purpose_legitimate_interest_allowed($purpose_id);
+    return 0 unless $self->vendor_legitimate_interest($vendor_id);
+
+    return 1;
+}
+
+sub is_vendor_allowed_for_flexible_purpose {
+    my ( $self, $vendor_id, $purpose_id, $default_is_li, %opts ) = @_;
+
+    return 0 unless $self->_check_purpose_id( $purpose_id, %opts );
+
+    if ( $self->check_publisher_restriction( $purpose_id, RequireConsent, $vendor_id ) ) {
+        return $self->is_vendor_consent_allowed( $vendor_id, $purpose_id, %opts );
+    }
+
+    if ( $self->check_publisher_restriction( $purpose_id, RequireLegitimateInterest, $vendor_id ) ) {
+        return $self->is_vendor_legitimate_interest_allowed( $vendor_id, $purpose_id, %opts );
+    }
+
+    if ( $self->check_publisher_restriction( $purpose_id, NotAllowed, $vendor_id ) ) {
+        return 0;
+    }
+
+    if ($default_is_li) {
+        return $self->is_vendor_legitimate_interest_allowed( $vendor_id, $purpose_id, %opts );
+    }
+
+    return $self->is_vendor_consent_allowed( $vendor_id, $purpose_id, %opts );
+}
+
+sub _check_purpose_id {
+    my ( $self, $id, %opts ) = @_;
+
+    my $strict =
+      exists $opts{strict} ? $opts{strict} : $self->{options}->{strict};
+
+    if ( $id < 1 || $id > MAX_PURPOSE_ID ) {
+        if ($strict) {
+            croak "invalid purpose id $id: must be between 1 and @{[ MAX_PURPOSE_ID ]}";
+        }
+        else {
+            warn "invalid purpose id $id: must be between 1 and @{[ MAX_PURPOSE_ID ]}";
+            return 0;
+        }
+    }
+
+    return 1;
 }
 
 sub _format_date {

--- a/lib/GDPR/IAB/TCFv2/BitField.pm
+++ b/lib/GDPR/IAB/TCFv2/BitField.pm
@@ -62,23 +62,33 @@ sub contains {
 sub TO_JSON {
     my $self = shift;
 
-    my @data = split //, $self->{data};
+    my $data = $self->{data};
 
     if ( !!$self->{options}->{json}->{compact} ) {
-        return [ grep { $data[ $_ - 1 ] } 1 .. $self->{max_id} ];
+        my @ids;
+        my $pos = index( $data, '1' );
+        while ( $pos != -1 ) {
+            push @ids, $pos + 1;
+            $pos = index( $data, '1', $pos + 1 );
+        }
+        return \@ids;
     }
 
     my ( $false, $true ) = @{ $self->{options}->{json}->{boolean_values} };
 
     if ( !!$self->{options}->{json}->{verbose} ) {
-        return { map { $_ => $data[ $_ - 1 ] ? $true : $false }
+        return { map { $_ => substr( $data, $_ - 1, 1 ) eq '1' ? $true : $false }
               1 .. $self->{max_id} };
     }
 
-    return {
-        map  { $_ => $true }
-        grep { $data[ $_ - 1 ] } 1 .. $self->{max_id}
-    };
+    my %map;
+    my $pos = index( $data, '1' );
+    while ( $pos != -1 ) {
+        $map{ $pos + 1 } = $true;
+        $pos = index( $data, '1', $pos + 1 );
+    }
+
+    return \%map;
 }
 
 1;

--- a/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
@@ -15,24 +15,23 @@ use constant {
     AdPerformance            => 7,
     ContentPerformance       => 8,
     MarketResearch           => 9,
-    DevelopImprove           => 10,
-    SelectContent            => 11,
+    DevelopImprove                => 10,
+    UseLimitedDataToSelectContent => 11,
 };
 
 use constant PurposeDescription => {
     InfoStorageAccess        => "Store and/or access information on a device",
     BasicAdserving           => "Use limited data to select advertising",
-    PersonalizationProfile   => "Create profiles for personalised advertising",
-    PersonalizationSelection =>
-      "Use profiles to select personalised advertising",
-    ContentProfile     => "Create profiles to personalise content",
-    ContentSelection   => "Use profiles to select personalised content",
-    AdPerformance      => "Measure advertising performance",
-    ContentPerformance => "Measure content performance",
-    MarketResearch     =>
+    PersonalizationProfile   => "Create a personalised ads profile",
+    PersonalizationSelection => "Select personalised ads",
+    ContentProfile           => "Create a personalised content profile",
+    ContentSelection         => "Select personalised content",
+    AdPerformance            => "Measure advertising performance",
+    ContentPerformance       => "Measure content performance",
+    MarketResearch           =>
       "Understand audiences through statistics or combinations of data from different sources",
-    DevelopImprove => "Develop and improve services",
-    SelectContent  => "Use limited data to select content",
+    DevelopImprove                => "Develop and improve services",
+    UseLimitedDataToSelectContent => "Use limited data to select content",
 };
 
 our @EXPORT_OK = qw<
@@ -46,7 +45,7 @@ our @EXPORT_OK = qw<
   ContentPerformance
   MarketResearch
   DevelopImprove
-  SelectContent
+  UseLimitedDataToSelectContent
   PurposeDescription
 >;
 our %EXPORT_TAGS = ( all => \@EXPORT_OK );
@@ -56,7 +55,7 @@ our %EXPORT_TAGS = ( all => \@EXPORT_OK );
 __END__
 =head1 NAME
 
-GDPR::IAB::TCFv2::Constants::Purpose - TCF v2.2 purposes
+GDPR::IAB::TCFv2::Constants::Purpose - TCF v2.3 purposes
 
 =head1 SYNOPSIS
 
@@ -121,7 +120,7 @@ A large producer of watercolour paints wants to carry out an online advertising 
 
 =head2  PersonalizationProfile
 
-Purpose id 3: Create profiles for personalised advertising
+Purpose id 3: Create a personalised ads profile
 
 Information about your activity on this service (such as forms you submit, content you look at) can be stored and combined with other information about you (for example, information from your previous activity on this service and other websites or apps) or similar users. This is then used to build or improve a profile about you (that might include possible interests and personal aspects). Your profile can be used (also later) to present advertising that appears more relevant based on your possible interests by this and other entities.
 
@@ -141,9 +140,7 @@ An apparel company wishes to promote its new line of high-end baby clothes. It g
 
 =head2  PersonalizationSelection
 
-Purpose id 4: Use profiles to select personalised advertising 
-
-Advertising presented to you on this service can be based on your advertising profiles, which can reflect your activity on this service or other websites or apps (like the forms you submit, content you look at), possible interests and personal aspects.
+Purpose id 4: Select personalised ads
 
 Illustrations:
 
@@ -161,7 +158,7 @@ A profile created for personalised advertising in relation to a person having se
 
 =head2  ContentProfile
 	
-Purpose id 5: Create profiles to personalise content
+Purpose id 5: Create a personalised content profile
 
 Information about your activity on this service (for instance, forms you submit, non-advertising content you look at) can be stored and combined with other information about you (such as your previous activity on this service or other websites or apps) or similar users. This is then used to build or improve a profile about you (which might for example include possible interests and personal aspects). Your profile can be used (also later) to present content that appears more relevant based on your possible interests, such as by adapting the order in which content is shown to you, so that it is even easier for you to find content that matches your interests.
 
@@ -181,7 +178,7 @@ You have viewed three videos on space exploration across different TV apps. An u
 
 =head2  ContentSelection
 	
-Purpose id 6: Use profiles to select personalised content
+Purpose id 6: Select personalised content
 
 Content presented to you on this service can be based on your content personalisation profiles, which can reflect your activity on this or other services (for instance, the forms you submit, content you look at), possible interests and personal aspects, such as by adapting the order in which content is shown to you, so that it is even easier for you to find (non-advertising) content that matches your interests.
 
@@ -279,7 +276,7 @@ An advertiser is looking for a way to display ads on a new type of consumer devi
 
 =back
 
-=head2  SelectContent
+=head2  UseLimitedDataToSelectContent
 
 Purpose id 11: Use limited data to select content.
 

--- a/lib/GDPR/IAB/TCFv2/Constants/RestrictionType.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/RestrictionType.pm
@@ -32,7 +32,7 @@ __END__
 
 =head1 NAME
 
-GDPR::IAB::TCFv2::Constants::RestrictionType - TCF v2.2 publisher restriction type for vendor 
+GDPR::IAB::TCFv2::Constants::RestrictionType - TCF v2.3 publisher restriction type for vendor 
 
 =head1 SYNOPSIS
 

--- a/lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
@@ -29,7 +29,7 @@ __END__
 
 =head1 NAME
 
-GDPR::IAB::TCFv2::Constants::SpecialFeature - TCF v2.2 special features
+GDPR::IAB::TCFv2::Constants::SpecialFeature - TCF v2.3 special features
 
 =head1 SYNOPSIS
 

--- a/lib/GDPR/IAB/TCFv2/RangeSection.pm
+++ b/lib/GDPR/IAB/TCFv2/RangeSection.pm
@@ -172,7 +172,9 @@ sub TO_JSON {
     }
 
     foreach my $range ( @{ $self->{ranges} } ) {
-        %map = ( %map, map { $_ => $true } $range->[0] .. $range->[1] );
+        for my $id ( $range->[0] .. $range->[1] ) {
+            $map{$id} = $true;
+        }
     }
 
     return \%map;

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -1,0 +1,131 @@
+package GDPR::IAB::TCFv2::Validator;
+
+use strict;
+use warnings;
+
+use Carp qw<croak>;
+use GDPR::IAB::TCFv2;
+use GDPR::IAB::TCFv2::Validator::Result;
+
+sub new {
+    my ( $klass, %args ) = @_;
+
+    my $self = {
+        vendor_id                       => $args{vendor_id},
+        consent_purpose_ids             => $args{consent_purpose_ids} || [],
+        legitimate_interest_purpose_ids => $args{legitimate_interest_purpose_ids} || [],
+        flexible_purpose_ids            => $args{flexible_purpose_ids} || [],
+        check_disclosed_vendors         => $args{check_disclosed_vendors} || 0,
+        strict                          => exists $args{strict} ? $args{strict} : 0,
+    };
+
+    return bless $self, $klass;
+}
+
+sub validate {
+    my ( $self, $input, %overrides ) = @_;
+
+    return $self->_run_validation( $input, 1, %overrides );
+}
+
+sub validate_all {
+    my ( $self, $input, %overrides ) = @_;
+
+    return $self->_run_validation( $input, 0, %overrides );
+}
+
+sub _run_validation {
+    my ( $self, $input, $stop_on_first, %overrides ) = @_;
+
+    my $tc = ref($input) eq 'GDPR::IAB::TCFv2'
+      ? $input
+      : GDPR::IAB::TCFv2->Parse($input);
+
+    my $vendor_id =
+      exists $overrides{vendor_id} ? $overrides{vendor_id} : $self->{vendor_id};
+    my $strict = exists $overrides{strict} ? $overrides{strict} : $self->{strict};
+    my $check_disclosed =
+      exists $overrides{check_disclosed_vendors}
+      ? $overrides{check_disclosed_vendors}
+      : $self->{check_disclosed_vendors};
+
+    croak "missing vendor_id" unless defined $vendor_id;
+
+    my @reasons;
+
+    # Check Disclosed Vendors if segment exists and requested
+    if ($check_disclosed) {
+        if ( defined $tc->{disclosed_vendors_data} ) {
+            unless ( $tc->disclosed_vendor($vendor_id) ) {
+                push @reasons, "vendor $vendor_id not disclosed";
+                return $self->_make_result( 0, \@reasons ) if $stop_on_first;
+            }
+        }
+    }
+
+    # Check Consent Purposes
+    foreach my $pid ( @{ $self->{consent_purpose_ids} } ) {
+        unless (
+            $tc->is_vendor_consent_allowed( $vendor_id, $pid, strict => $strict )
+          )
+        {
+            push @reasons,
+              "vendor $vendor_id not allowed for purpose $pid (consent)";
+            return $self->_make_result( 0, \@reasons ) if $stop_on_first;
+        }
+    }
+
+    # Check Legitimate Interest Purposes
+    foreach my $pid ( @{ $self->{legitimate_interest_purpose_ids} } ) {
+        unless (
+            $tc->is_vendor_legitimate_interest_allowed(
+                $vendor_id, $pid, strict => $strict
+            )
+          )
+        {
+            push @reasons,
+"vendor $vendor_id not allowed for purpose $pid (legitimate interest)";
+            return $self->_make_result( 0, \@reasons ) if $stop_on_first;
+        }
+    }
+
+    # Check Flexible Purposes
+    foreach my $flex ( @{ $self->{flexible_purpose_ids} } ) {
+        my ( $pid, $default_is_li );
+        if ( ref($flex) eq 'HASH' ) {
+            $pid           = $flex->{purpose_id};
+            $default_is_li = $flex->{default_is_li};
+        }
+        else {
+            $pid           = $flex;
+            $default_is_li = 0;
+        }
+
+        unless (
+            $tc->is_vendor_allowed_for_flexible_purpose(
+                $vendor_id, $pid, $default_is_li, strict => $strict
+            )
+          )
+        {
+            push @reasons, "vendor $vendor_id not allowed for flexible purpose $pid";
+            return $self->_make_result( 0, \@reasons ) if $stop_on_first;
+        }
+    }
+
+    if (@reasons) {
+        return $self->_make_result( 0, \@reasons );
+    }
+
+    return $self->_make_result( 1, [] );
+}
+
+sub _make_result {
+    my ( $self, $ok, $reasons ) = @_;
+
+    return GDPR::IAB::TCFv2::Validator::Result->new(
+        ok      => $ok,
+        reasons => $reasons,
+    );
+}
+
+1;

--- a/lib/GDPR/IAB/TCFv2/Validator/Result.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Result.pm
@@ -1,0 +1,35 @@
+package GDPR::IAB::TCFv2::Validator::Result;
+
+use strict;
+use warnings;
+
+use overload
+  bool => sub { $_[0]->{ok} },
+  '""' => sub {
+    my $self = shift;
+    return '' if $self->{ok};
+
+    # Use $ORS (Output Record Separator) or newline as fallback
+    my $sep = defined($\) ? $\ : "\n";
+    return join( $sep, @{ $self->{reasons} || [] } );
+  };
+
+sub new {
+    my ( $klass, %args ) = @_;
+
+    my $self = {
+        ok      => $args{ok}      || 0,
+        reasons => $args{reasons} || [],
+    };
+
+    return bless $self, $klass;
+}
+
+sub is_valid { $_[0]->{ok} }
+
+sub reasons {
+    my $self = shift;
+    return @{ $self->{reasons} || [] };
+}
+
+1;

--- a/t/04-legal-basis.t
+++ b/t/04-legal-basis.t
@@ -1,0 +1,103 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+
+use GDPR::IAB::TCFv2;
+use GDPR::IAB::TCFv2::Constants::RestrictionType qw<:all>;
+
+# Helper for testing warnings
+sub warning_like (&$;$) {
+    my ($code, $pattern, $message) = @_;
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings, @_ };
+    $code->();
+    like(join('', @warnings), $pattern, $message);
+}
+
+subtest "is_vendor_consent_allowed" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+    my $consent = GDPR::IAB::TCFv2->Parse($tc_string);
+
+    # Purpose 6: consent allowed, LI allowed. Vendor 1: consent allowed, LI allowed.
+    # No restriction for P6, V1.
+    ok $consent->is_vendor_consent_allowed(1, 6), 'vendor 1 allowed for purpose 6 (consent)';
+
+    # Purpose 7: consent NOT allowed, LI allowed. Vendor 1: consent allowed, LI allowed.
+    ok !$consent->is_vendor_consent_allowed(1, 7), 'vendor 1 NOT allowed for purpose 7 (consent bit is 0)';
+
+    # Purpose 1: consent NOT allowed, LI allowed. Vendor 1: consent allowed, LI allowed.
+    ok !$consent->is_vendor_consent_allowed(1, 1), 'vendor 1 NOT allowed for purpose 1 (consent bit is 0)';
+
+    # Restriction check: P7, V32 has restriction RequireConsent (1).
+    # Even if bits were set, RequireLegitimateInterest restriction would block it.
+    # In this string, P7, V32 does NOT have consent bits anyway.
+};
+
+subtest "is_vendor_legitimate_interest_allowed" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+    my $consent = GDPR::IAB::TCFv2->Parse($tc_string);
+
+    # Purpose 2: consent NOT allowed, LI allowed. Vendor 2: consent allowed, LI allowed.
+    ok $consent->is_vendor_legitimate_interest_allowed(2, 2), 'vendor 2 allowed for purpose 2 (LI)';
+
+    # Restriction check: P7, V32 has restriction RequireConsent (1).
+    # This should block LI check even if bits are set.
+    ok !$consent->is_vendor_legitimate_interest_allowed(32, 7), 'vendor 32 NOT allowed for purpose 7 (LI) due to RequireConsent restriction';
+};
+
+subtest "is_vendor_allowed_for_flexible_purpose" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+    my $consent = GDPR::IAB::TCFv2->Parse($tc_string);
+
+    # P6, V1: No restrictions. Consent=1, LI=1.
+    ok $consent->is_vendor_allowed_for_flexible_purpose(1, 6, 0), 'flexible P6, V1 (default consent) -> OK';
+    ok $consent->is_vendor_allowed_for_flexible_purpose(1, 6, 1), 'flexible P6, V1 (default LI) -> OK';
+
+    # P2, V2: No restrictions. Consent=0, LI=1.
+    ok !$consent->is_vendor_allowed_for_flexible_purpose(2, 2, 0), 'flexible P2, V2 (default consent) -> NOT OK';
+    ok $consent->is_vendor_allowed_for_flexible_purpose(2, 2, 1), 'flexible P2, V2 (default LI) -> OK';
+
+    # P7, V32: Restriction RequireConsent (1). Consent=0, LI=1.
+    # It MUST check consent bit (which is 0).
+    ok !$consent->is_vendor_allowed_for_flexible_purpose(32, 7, 1), 'flexible P7, V32 (default LI) -> NOT OK due to RequireConsent restriction';
+};
+
+subtest "strictness" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+    
+    subtest "default (non-strict)" => sub {
+        my $consent = GDPR::IAB::TCFv2->Parse($tc_string);
+        my $val;
+        warning_like {
+            $val = $consent->is_vendor_consent_allowed(1, 25);
+        } qr/invalid purpose id 25/, 'should warn for invalid purpose id';
+        is $val, 0, 'should return 0';
+    };
+
+    subtest "explicit non-strict" => sub {
+        my $consent = GDPR::IAB::TCFv2->Parse($tc_string);
+        my $val;
+        warning_like {
+            $val = $consent->is_vendor_consent_allowed(1, 0, strict => 0);
+        } qr/invalid purpose id 0/, 'should warn for invalid purpose id';
+        is $val, 0, 'should return 0';
+    };
+
+    subtest "strict mode (constructor)" => sub {
+        my $consent = GDPR::IAB::TCFv2->Parse($tc_string, strict => 1);
+        throws_ok {
+            $consent->is_vendor_consent_allowed(1, 25);
+        } qr/invalid purpose id 25/, 'should croak for invalid purpose id';
+    };
+
+    subtest "strict mode (override)" => sub {
+        my $consent = GDPR::IAB::TCFv2->Parse($tc_string);
+        throws_ok {
+            $consent->is_vendor_consent_allowed(1, 25, strict => 1);
+        } qr/invalid purpose id 25/, 'should croak for invalid purpose id';
+    };
+};
+
+done_testing;

--- a/t/05-tcf-v23.t
+++ b/t/05-tcf-v23.t
@@ -36,9 +36,8 @@ subtest "TO_JSON with v2.3" => sub {
     
     my $json = $consent->TO_JSON;
     ok exists $json->{vendor}->{disclosed}, 'disclosed vendors should be in TO_JSON';
-    ok exists $json->{vendor}->{allowed}, 'allowed vendors should be in TO_JSON';
+    ok !exists $json->{vendor}->{allowed}, 'allowed vendors should NOT be in TO_JSON (missing segment)';
     ok defined $json->{vendor}->{disclosed}, 'disclosed vendors should be defined';
-    ok !defined $json->{vendor}->{allowed}, 'allowed vendors should be undef (missing segment)';
 };
 
 done_testing;

--- a/t/05-tcf-v23.t
+++ b/t/05-tcf-v23.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+
+use GDPR::IAB::TCFv2;
+
+my $tc_v23 = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA.ILrtR_G__bXlv-bb36ftkeYxf9_hr7sQxBgbJs24FzLvW7JwX32E7NEzatqYKmRIAu3TBIQNtHJjURVChKIgVrzDsaEyUoTtKJ-BkiHMRY2NYCFxvm4tjWQCZ5vr_91d9mT-N7dr-2dzyy7hnv3a9_-S1WJidKYetHfv8bBKT-_IU9_x-_4v4_N7pE2-eS1v_tGvt639-4vP_dpvxt-7yffz____73_e7X__d_______Xf_7____________4AAA';
+
+subtest "TCF v2.3 segments" => sub {
+    my $consent;
+    lives_ok {
+        $consent = GDPR::IAB::TCFv2->Parse($tc_v23);
+    } 'should parse v2.3 string with disclosed vendors';
+
+    is $consent->version, 2, 'version should be 2';
+
+    # Disclosed vendors check
+    ok $consent->disclosed_vendor(284), 'Weborama (284) should be disclosed';
+    ok !$consent->disclosed_vendor(9999), 'vendor 9999 should NOT be disclosed';
+    
+    # Allowed vendors check (not present in this string)
+    ok !$consent->allowed_vendor(284), 'vendor 284 should NOT be in allowed vendors segment (segment missing)';
+};
+
+subtest "duplicate segment check" => sub {
+    my $duplicate_string = $tc_v23 . '.ILrtR_G__bXlv-bb36ftkeYxf9_hr7sQxBgbJs24FzLvW7JwX32E7NEzatqYKmRIAu3TBIQNtHJjURVChKIgVrzDsaEyUoTtKJ-BkiHMRY2NYCFxvm4tjWQCZ5vr_91d9mT-N7dr-2dzyy7hnv3a9_-S1WJidKYetHfv8bBKT-_IU9_x-_4v4_N7pE2-eS1v_tGvt639-4vP_dpvxt-7yffz____73_e7X__d_______Xf_7____________4AAA';
+    throws_ok {
+        GDPR::IAB::TCFv2->Parse($duplicate_string);
+    } qr/duplicate segment type 1/, 'should throw exception for duplicate segment type 1';
+};
+
+subtest "TO_JSON with v2.3" => sub {
+    my $consent = GDPR::IAB::TCFv2->Parse($tc_v23);
+    
+    my $json = $consent->TO_JSON;
+    ok exists $json->{vendor}->{disclosed}, 'disclosed vendors should be in TO_JSON';
+    ok exists $json->{vendor}->{allowed}, 'allowed vendors should be in TO_JSON';
+    ok defined $json->{vendor}->{disclosed}, 'disclosed vendors should be defined';
+    ok !defined $json->{vendor}->{allowed}, 'allowed vendors should be undef (missing segment)';
+};
+
+done_testing;

--- a/t/06-validator.t
+++ b/t/06-validator.t
@@ -1,0 +1,82 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+
+use GDPR::IAB::TCFv2::Validator;
+use GDPR::IAB::TCFv2::Constants::Purpose qw<:all>;
+
+subtest "Validator basic usage" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+    
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id           => 1,
+        consent_purpose_ids => [ 6 ], # Allowed
+    );
+
+    my $result = $validator->validate($tc_string);
+    ok $result, 'validation should pass';
+    is $result->is_valid, 1, 'is_valid should be 1';
+    is "$result", '', 'stringification should be empty for valid result';
+};
+
+subtest "Validator failures" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+    
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id           => 1,
+        consent_purpose_ids => [ 1, 6 ], # 1 is missing consent bit, 6 is OK
+    );
+
+    subtest "validate (first failure)" => sub {
+        my $result = $validator->validate($tc_string);
+        ok !$result, 'validation should fail';
+        is scalar($result->reasons), 1, 'should have 1 reason';
+        like "$result", qr/not allowed for purpose 1/, 'should have correct reason';
+    };
+
+    subtest "validate_all (all failures)" => sub {
+        my $validator2 = GDPR::IAB::TCFv2::Validator->new(
+            vendor_id           => 1,
+            consent_purpose_ids => [ 1, 7 ], # Both fail: P1=0, P7=0
+        );
+        my $result = $validator2->validate_all($tc_string);
+        ok !$result, 'validation should fail';
+        is scalar($result->reasons), 2, 'should have 2 reasons';
+        
+        {
+            local $\ = " | ";
+            like "$result", qr/purpose 1.* | .*purpose 7/, 'should join reasons with ORS';
+        }
+    };
+};
+
+subtest "Validator overrides" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+    
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id           => 1,
+        consent_purpose_ids => [ 6 ],
+    );
+
+    ok $validator->validate($tc_string), 'pass for vendor 1';
+    ok !$validator->validate($tc_string, vendor_id => 99), 'fail for vendor 99 (missing bits)';
+};
+
+subtest "Validator with Disclosed Vendors" => sub {
+    my $tc_v23 = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA.ILrtR_G__bXlv-bb36ftkeYxf9_hr7sQxBgbJs24FzLvW7JwX32E7NEzatqYKmRIAu3TBIQNtHJjURVChKIgVrzDsaEyUoTtKJ-BkiHMRY2NYCFxvm4tjWQCZ5vr_91d9mT-N7dr-2dzyy7hnv3a9_-S1WJidKYetHfv8bBKT-_IU9_x-_4v4_N7pE2-eS1v_tGvt639-4vP_dpvxt-7yffz____73_e7X__d_______Xf_7____________4AAA';
+
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id               => 284,
+        check_disclosed_vendors => 1,
+    );
+
+    ok $validator->validate($tc_v23), 'pass for disclosed vendor 284';
+    
+    my $result = $validator->validate($tc_v23, vendor_id => 9999);
+    ok !$result, 'fail for non-disclosed vendor 9999';
+    like "$result", qr/not disclosed/, 'correct failure reason';
+};
+
+done_testing;


### PR DESCRIPTION
This PR introduces support for TCF v2.3, including Disclosed and Allowed Vendors segments, a new Validator interface for automated policy enforcement, and performance optimizations for JSON serialization.

### Changes included:
- **Phase 0**: Core logic expansion (legal basis methods)
- **Phase 1**: TCF v2.3 segments and segment robustness
- **Phase 2**: Validator interface and Result object
- **Phase 3**: Alignment with TCF v2.3 nomenclature
- **Phase 4**: Performance optimizations for BitField and RangeSection serialization