### PR TITLE
Chore: Use 'latest' tag for Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=match,pattern=v(.*),group=1
-            type=ref,event=branch
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha
 
       - name: Build and push Docker image


### PR DESCRIPTION
This PR replaces the branch-based tagging (`main`) with the standard `latest` tag, only enabled when pushing to the `main` branch.