### PR TITLE
Vendor segment parser cleanup (stacked on #44)

### DIFF
--- a/docs/superpowers/plans/2026-05-06-vendor-segment-parser-cleanup.md
+++ b/docs/superpowers/plans/2026-05-06-vendor-segment-parser-cleanup.md
@@ -10,6 +10,8 @@
 
 **Operational note:** Per `AGENTS.md`, all work happens on a feature branch (`fix/vendor-segment-parser-cleanup`). Do not commit to `devel`/`main`, do not merge into them, do not create tags. Hand off via PR when complete.
 
+**Style strictness reminder:** CI runs `xt/critic.t` (`Test::Perl::Critic`) and `xt/tidy.t` (`Test::PerlTidy`) and they fail the build on violations — see commit `0a3297c` which had to ship a follow-up fix for exactly these checks. Run `make tidy` and `prove -lr xt` before every commit; delete the `.bak` files perltidy leaves behind (already excluded via `MANIFEST.SKIP`, but never stage them).
+
 **Branch naming:** `fix/vendor-segment-parser-cleanup`. Branch from current `devel`.
 
 **Pre-flight (run before Task 1):**
@@ -19,9 +21,13 @@ git fetch origin
 git checkout -b fix/vendor-segment-parser-cleanup origin/devel
 perl Makefile.PL && make
 prove -lr t          # baseline: must be green before any change
+prove -lr xt         # baseline for author tests too
 ```
 
 If baseline is not green, stop and investigate — no point fixing cleanup issues on top of a broken tree.
+
+**Existing coverage to be aware of (do NOT duplicate):**
+- `t/09-predicates.t` already has a `"Robustness: Truncated segments"` subtest that exercises the *new* `_parse_vendor_bitfield_or_range` helper's slice-aligned size guard (added in `460aaa9` and tightened in `7926ebc`). Task 1 below targets the **core** helpers (`_parse_bitfield` / `_parse_range_section`), which still pass the un-aligned `data_size`; its test must use a TC string with no auxiliary segments so the truncation lands on the core bitfield, not the disclosure segment.
 
 ---
 
@@ -30,46 +36,47 @@ If baseline is not green, stop and investigate — no point fixing cleanup issue
 **Issue addressed:** Residual #1 from the review — `_parse_bitfield` and `_parse_range_section` pass `data_size => length($self->{core_data})` (full core, in bits) alongside a sliced `$data`. The new `_parse_vendor_bitfield_or_range` already does the right thing (`length($slice)`); this task ports the pattern back so `data_size` faithfully describes what the callee receives. For typical valid TC strings this is purely cosmetic; for truncated cores with very small `max_id` it tightens the existing `data_size < $max_id` guard in `BitField->Parse`.
 
 **Files:**
-- Modify: `lib/GDPR/IAB/TCFv2.pm:921-936` (`_parse_range_section`)
-- Modify: `lib/GDPR/IAB/TCFv2.pm:942-954` (`_parse_bitfield`)
+- Modify: `lib/GDPR/IAB/TCFv2.pm:925-944` (`_parse_range_section`)
+- Modify: `lib/GDPR/IAB/TCFv2.pm:946-962` (`_parse_bitfield`)
 - Test: `t/05-tcf-v23.t` (append a new subtest)
 
 - [ ] **Step 1: Inspect both helpers and confirm current line ranges**
 
 ```bash
 grep -n "^sub _parse_bitfield\b\|^sub _parse_range_section" lib/GDPR/IAB/TCFv2.pm
-sed -n '921,955p' lib/GDPR/IAB/TCFv2.pm
+sed -n '925,965p' lib/GDPR/IAB/TCFv2.pm
 ```
 
 Expected output: two helpers, each computing `my $data_size = length( $self->{core_data} );` then passing it through to `BitField->Parse` / `RangeSection->Parse`.
 
+If the line numbers have shifted, update the `Files:` references above before continuing — the surrounding code on this branch evolves quickly (`7926ebc` and `0a3297c` already moved things since this plan was written).
+
 - [ ] **Step 2: Write the failing test**
 
-Append the following subtest to `t/05-tcf-v23.t` (just before `done_testing` if present, otherwise at the end of the file):
+Append the following subtest to `t/05-tcf-v23.t` (just before `done_testing` if present, otherwise at the end of the file). The test deliberately uses a **single-segment core-only** TC string so the truncation lands on the *core* bitfield (which goes through `_parse_bitfield`), not on a Disclosed Vendors segment (which is already covered by `t/09-predicates.t :: "Robustness: Truncated segments"` via the new helper).
 
 ```perl
-subtest "BitField data_size reflects slice length, not full core" => sub {
-    # Construct a malformed Core that claims max_id_consent = 24 (the
-    # purpose-allowed field width happens to leave 24 bits) but truncates
-    # the bitfield payload. With the OLD code, data_size = length(core)
-    # could exceed max_id and let the truncation slip past Parse;
-    # with the NEW code, data_size == slice length and the croak fires.
+subtest "Core BitField data_size reflects slice length, not full core" => sub {
+    # The fixture below is the same single-segment v2.0 string used
+    # elsewhere in the suite.  It has NO disclosure/allowed/publisher_tc
+    # segments, so a truncation falls squarely on the core bitfield and
+    # exercises _parse_bitfield (NOT _parse_vendor_bitfield_or_range).
     #
-    # We build the smallest reproducible case: take a known-good v2.0
-    # consent string and chop bytes off the END, leaving the bitfield
-    # claim intact but the payload short.
-    my $good =
-      'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+    # OLD behavior: data_size = length(core_data) which is larger than
+    # max_id, so the BitField size guard never fires; downstream
+    # contains() calls silently under-read.
+    # NEW behavior: data_size = length(slice), guard fires and the
+    # parser croaks with the standard "requires N bits" message.
+    my $good = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
 
-    # Sanity: the unmodified string parses cleanly.
-    lives_ok { GDPR::IAB::TCFv2->Parse($good) } 'baseline parses';
+    lives_ok { GDPR::IAB::TCFv2->Parse($good) } 'baseline parses cleanly';
 
-    # Truncate by removing the trailing 4 base64 chars (~24 bits payload).
+    # Trim 4 base64 chars (~24 bits of payload) off the end.
     my $truncated = substr( $good, 0, length($good) - 4 );
 
     throws_ok { GDPR::IAB::TCFv2->Parse($truncated) }
-      qr/BitField for \d+ bits requires a consent string of at least \d+ bits/,
-      'truncated bitfield is rejected with slice-aware size in error message';
+      qr/a BitField for \d+ bits requires a consent string of at least \d+ bits/,
+      'truncated core bitfield is rejected with slice-aware size guard';
 };
 ```
 
@@ -77,11 +84,11 @@ subtest "BitField data_size reflects slice length, not full core" => sub {
 
 Run: `prove -lv t/05-tcf-v23.t`
 
-Expected: the new subtest may pass *or* fail today depending on whether the truncation is large enough to fall under either size. Note the actual outcome — if it already passes, that proves the existing code happens to catch this case via a different bound; the data_size alignment is then pure cleanup. If it fails, the alignment fix in Step 4 will make it pass.
+Expected: the new subtest **fails** — the unmodified `_parse_bitfield` passes the full-core bit-length as `data_size`, the BitField guard does not fire, and `Parse` returns silently instead of croaking. If the test unexpectedly passes, the truncation may have happened to fall into a different bounds check (e.g., the range section's `_parse_range`); inspect the actual exception (or absence) before proceeding to Step 4.
 
 - [ ] **Step 4: Update `_parse_range_section` to pass slice length**
 
-Edit `lib/GDPR/IAB/TCFv2.pm:921-936`. Replace:
+Edit `lib/GDPR/IAB/TCFv2.pm:925-944`. Replace:
 
 ```perl
 sub _parse_range_section {
@@ -132,7 +139,7 @@ sub _parse_range_section {
 
 - [ ] **Step 5: Update `_parse_bitfield` to pass slice length**
 
-Edit `lib/GDPR/IAB/TCFv2.pm:942-954`. Replace:
+Edit `lib/GDPR/IAB/TCFv2.pm:946-962`. Replace:
 
 ```perl
 sub _parse_bitfield {
@@ -207,7 +214,7 @@ already used in _parse_vendor_bitfield_or_range."
 **Issue addressed:** Residual #2 — the helper trusts `_decode_tc_string_segments` to have routed the segment correctly, but never validates that bits 0-2 of the slice actually equal the expected segment type. `PublisherTC->Parse` does this defensively; this task brings the new helper to parity.
 
 **Files:**
-- Modify: `lib/GDPR/IAB/TCFv2.pm:837-883` (`_parse_disclosed_vendors`, `_parse_allowed_vendors`, `_parse_vendor_bitfield_or_range`)
+- Modify: `lib/GDPR/IAB/TCFv2.pm:841-891` (`_parse_disclosed_vendors`, `_parse_allowed_vendors`, `_parse_vendor_bitfield_or_range`)
 - Test: `t/05-tcf-v23.t` (extend the existing "TCF v2.3 segments" subtest or add a new one)
 
 - [ ] **Step 1: Write the failing test**
@@ -250,7 +257,7 @@ Expected: FAIL — current helper signature does not accept an expected-type arg
 
 - [ ] **Step 3: Add expected-type parameter and assertion**
 
-Edit `lib/GDPR/IAB/TCFv2.pm:856-883`. Replace the signature line and add a header check immediately after reading `$max_id`:
+Edit `lib/GDPR/IAB/TCFv2.pm:860-891`. Replace the signature line and add a header check immediately after reading `$max_id`:
 
 ```perl
 sub _parse_vendor_bitfield_or_range {
@@ -300,7 +307,7 @@ Note: `get_uint3` must already be in the import list at the top of the module (i
 
 - [ ] **Step 4: Update both callers to pass the expected type**
 
-Edit `lib/GDPR/IAB/TCFv2.pm:837-850`. Replace:
+Edit `lib/GDPR/IAB/TCFv2.pm:841-858`. Replace:
 
 ```perl
 sub _parse_disclosed_vendors {
@@ -380,7 +387,7 @@ might bypass _decode_tc_string_segments routing."
 **Issue addressed:** Residual #3 — the new helper returns `$vendors_section` only, while the older `_parse_bitfield_or_range` returns `($vendors_section, $next_offset)`. The asymmetry is correct (each Disclosed/Allowed segment is its own decode unit, with no trailing payload to chain into), but a future maintainer might be confused. A short comment locks in the rationale.
 
 **Files:**
-- Modify: `lib/GDPR/IAB/TCFv2.pm:856` (just above the `_parse_vendor_bitfield_or_range` signature, after Task 2 lands)
+- Modify: `lib/GDPR/IAB/TCFv2.pm:860` (just above the `_parse_vendor_bitfield_or_range` signature, after Task 2 lands)
 
 **No test required:** comment-only change.
 
@@ -415,7 +422,7 @@ git commit -m "docs: explain single-return shape of vendor-segment helper"
 **Issue addressed:** Residual #4 — the spec allows `MaxVendorId = 0` ("field unused"). The bitfield branch already handles it gracefully (empty slice, `contains` early-exits on `$id > max_id`). The range branch does NOT: `RangeSection->Parse` would happily try to read `num_entries` and any trailing range tuples even though, per spec, none should be present. This task short-circuits both branches to a uniform empty result before the sub-parsers run.
 
 **Files:**
-- Modify: `lib/GDPR/IAB/TCFv2.pm:856-...` (`_parse_vendor_bitfield_or_range`, post-Task-2 shape)
+- Modify: `lib/GDPR/IAB/TCFv2.pm:860-...` (`_parse_vendor_bitfield_or_range`, post-Task-2 shape)
 - Test: `t/05-tcf-v23.t`
 
 - [ ] **Step 1: Write the failing test**
@@ -565,6 +572,13 @@ new error messages and the new test cases in `t/05-tcf-v23.t`.
 
 **3. Type/symbol consistency:**
 - `_parse_vendor_bitfield_or_range` signature evolves across Tasks 2 and 4: Task 2 introduces `$expected_segment_type` as the second positional arg; Task 4 inserts the `max_id == 0` short-circuit *after* the `get_uint16` line introduced in Task 2. Step 3 of Task 4 references this post-Task-2 shape explicitly. ✓
-- `SEGMENT_TYPES->{DISCLOSED_VENDORS}` / `->{ALLOWED_VENDORS}` are the literal constants defined in `lib/GDPR/IAB/TCFv2.pm:39-44`. ✓
+- `SEGMENT_TYPES->{DISCLOSED_VENDORS}` / `->{ALLOWED_VENDORS}` are the literal constants defined in `lib/GDPR/IAB/TCFv2.pm` (use `grep -n 'SEGMENT_TYPES' lib/GDPR/IAB/TCFv2.pm` to find current line — was 39-44 at plan-write time, may have shifted). ✓
 - The test cases in Task 2 and Task 4 call the private helper directly via `$consent->_parse_vendor_bitfield_or_range(...)`. The package fully-qualified constant access `GDPR::IAB::TCFv2::SEGMENT_TYPES->{...}` works because `SEGMENT_TYPES` is defined as a `use constant` and is accessible via fully-qualified name. ✓
 - Variable rename in Task 2 (`$next_offset` → `$next_offset_after_max`) is preserved in Task 4's short-circuit insertion point. ✓
+
+**4. Rebase status (re-review on 2026-05-06 after `7926ebc`/`dd427da`/`0a3297c`):**
+- Line numbers shifted ~+4 lines for all targeted helpers; updated throughout the plan above.
+- `_parse_vendor_bitfield_or_range` body is **unchanged** since `460aaa9` — Task 2's diff still applies cleanly.
+- `t/09-predicates.t` already exercises the *new helper's* slice-aligned size guard (`"Robustness: Truncated segments"` subtest); Task 1's test is therefore scoped to a **core-only** TC string that hits `_parse_bitfield`, avoiding overlap.
+- `TO_JSON` was rewritten in `7926ebc` to introduce `$purpose_consents` / `$purpose_li` lexicals when `vendor_id` is set; this changes the *meaning* of `purpose.consents[$id]` under the filter (now reflects vendor allowance) but does not affect any code path touched by this plan.
+- CI is now strict on perlcritic + perltidy after `0a3297c`. Every task's last-but-one step (`prove -lr xt`) gates this; if violations appear, run `make tidy` and re-stage.

--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -843,9 +843,10 @@ sub _parse_disclosed_vendors {
 
     return unless defined $self->{disclosed_vendors_data};
 
-    $self->{disclosed_vendors} =
-      $self->_parse_vendor_bitfield_or_range(
-        $self->{disclosed_vendors_data} );
+    $self->{disclosed_vendors} = $self->_parse_vendor_bitfield_or_range(
+        $self->{disclosed_vendors_data},
+        SEGMENT_TYPES->{DISCLOSED_VENDORS},
+    );
 }
 
 sub _parse_allowed_vendors {
@@ -853,14 +854,21 @@ sub _parse_allowed_vendors {
 
     return unless defined $self->{allowed_vendors_data};
 
-    $self->{allowed_vendors} =
-      $self->_parse_vendor_bitfield_or_range( $self->{allowed_vendors_data} );
+    $self->{allowed_vendors} = $self->_parse_vendor_bitfield_or_range(
+        $self->{allowed_vendors_data},
+        SEGMENT_TYPES->{ALLOWED_VENDORS},
+    );
 }
 
 sub _parse_vendor_bitfield_or_range {
-    my ( $self, $data ) = @_;
+    my ( $self, $data, $expected_segment_type ) = @_;
 
-    my $offset = 3;    # segment type
+    my ( $segment_type, $offset ) = get_uint3( $data, 0 );
+
+    croak
+      "invalid segment type $segment_type: expected $expected_segment_type"
+      if defined $expected_segment_type
+      && $segment_type != $expected_segment_type;
 
     my ( $max_id, $next_offset ) = get_uint16( $data, $offset );
 

--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -925,13 +925,12 @@ sub _parse_bitfield_or_range {
 sub _parse_range_section {
     my ( $self, $max_id, $range_section_start_offset ) = @_;
 
-    my $data      = substr( $self->{core_data}, $range_section_start_offset );
-    my $data_size = length( $self->{core_data} );
+    my $data = substr( $self->{core_data}, $range_section_start_offset );
 
     my ( $range_section, $next_offset ) =
       GDPR::IAB::TCFv2::RangeSection->Parse(
         data      => $data,
-        data_size => $data_size,
+        data_size => length($data),
         offset    => 0,
         max_id    => $max_id,
         options   => $self->{options},
@@ -947,11 +946,10 @@ sub _parse_bitfield {
     my ( $self, $max_id, $bitfield_start_offset ) = @_;
 
     my $data = substr( $self->{core_data}, $bitfield_start_offset, $max_id );
-    my $data_size = length( $self->{core_data} );
 
     my ( $bitfield, $next_offset ) = GDPR::IAB::TCFv2::BitField->Parse(
         data      => $data,
-        data_size => $data_size,
+        data_size => length($data),
         max_id    => $max_id,
         options   => $self->{options},
     );

--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -876,6 +876,20 @@ sub _parse_vendor_bitfield_or_range {
 
     my ( $max_id, $next_offset ) = get_uint16( $data, $offset );
 
+    # Spec: MaxVendorId == 0 means "field unused".  Skip the IsRange flag
+    # and any trailing payload entirely; return an empty BitField so that
+    # has_vendor_disclosure() still reports the segment as present while
+    # contains() always returns false for any vendor id.
+    if ( $max_id == 0 ) {
+        my ($empty_section) = GDPR::IAB::TCFv2::BitField->Parse(
+            data      => '',
+            data_size => 0,
+            max_id    => 0,
+            options   => $self->{options},
+        );
+        return $empty_section;
+    }
+
     my ( $is_range, $bf_offset ) = is_set( $data, $next_offset );
 
     my $vendors_section;

--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -860,6 +860,10 @@ sub _parse_allowed_vendors {
     );
 }
 
+# Returns only $vendors_section -- unlike _parse_bitfield_or_range, which
+# yields ($section, $next_offset) so the caller can keep parsing the core
+# segment.  Disclosed/Allowed Vendors live in their own base64 segment
+# with nothing trailing the bitfield/range, so there is no offset to chain.
 sub _parse_vendor_bitfield_or_range {
     my ( $self, $data, $expected_segment_type ) = @_;
 

--- a/t/05-tcf-v23.t
+++ b/t/05-tcf-v23.t
@@ -94,6 +94,37 @@ subtest "TCF v2.2/v2.3 Legitimate Interest Restrictions" => sub {
     );
 };
 
+subtest "MaxVendorId == 0 yields an empty vendor section" => sub {
+    my $consent = GDPR::IAB::TCFv2->Parse(
+        'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA');
+
+    # Hand-built Disclosed Vendors segment:
+    #   segment_type      = 001 (=1)
+    #   max_vendor_id     = 16 zero bits
+    #   is_range_encoding = 1
+    #   num_entries       = 12 zero bits
+    # With IsRange=1 and max_id=0, RangeSection->Parse would parse the
+    # 12-bit num_entries from the trailing zeros (NumEntries=0, harmless
+    # here, but a malicious payload could declare NumEntries>0).  The
+    # short-circuit must skip RangeSection entirely and return an empty
+    # BitField regardless of the IsRange flag.
+    my $segment = '001' . ( '0' x 16 ) . '1' . ( '0' x 12 );
+
+    my $section;
+    lives_ok {
+        $section = $consent->_parse_vendor_bitfield_or_range(
+            $segment,
+            GDPR::IAB::TCFv2::SEGMENT_TYPES->{DISCLOSED_VENDORS},
+        );
+    }
+    'max_id=0 segment parses without error';
+
+    ok defined $section, 'returns a defined section';
+    is $section->max_id, 0, 'max_id is 0';
+    ok !$section->contains(1),
+      'contains(1) returns falsey (early-exit on id > max_id)';
+};
+
 subtest "Disclosed Vendors helper rejects mis-typed payload" => sub {
 
     # Hand-craft a "Disclosed Vendors" segment whose first 3 bits claim

--- a/t/05-tcf-v23.t
+++ b/t/05-tcf-v23.t
@@ -94,4 +94,29 @@ subtest "TCF v2.2/v2.3 Legitimate Interest Restrictions" => sub {
     );
 };
 
+subtest "Core BitField data_size reflects slice length, not full core" => sub {
+
+    # Single-segment v2.0 string with a sizeable core bitfield
+    # (max_vendor_id_consent = 115).  Truncating 4 base64 chars chops
+    # ~24 bits off the bitfield tail.
+    #
+    # OLD behavior: data_size = length(core_data) > max_id, so the
+    # BitField guard never fires; the parser stumbles forward and
+    # eventually croaks deep in _parse_publisher_section with a
+    # misleading "missing 'core_data'" error.
+    # NEW behavior: data_size = length(slice) < max_id, the guard
+    # fires immediately with a clear "requires N bits" message that
+    # points at the actual problem.
+    my $good =
+      'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA';
+
+    lives_ok { GDPR::IAB::TCFv2->Parse($good) } 'baseline parses cleanly';
+
+    my $truncated = substr( $good, 0, length($good) - 4 );
+
+    throws_ok { GDPR::IAB::TCFv2->Parse($truncated) }
+    qr/a BitField for \d+ bits requires a consent string of at least \d+ bits/,
+      'truncated core bitfield is rejected with slice-aware size guard';
+};
+
 done_testing;

--- a/t/05-tcf-v23.t
+++ b/t/05-tcf-v23.t
@@ -94,6 +94,28 @@ subtest "TCF v2.2/v2.3 Legitimate Interest Restrictions" => sub {
     );
 };
 
+subtest "Disclosed Vendors helper rejects mis-typed payload" => sub {
+
+    # Hand-craft a "Disclosed Vendors" segment whose first 3 bits claim
+    # segment_type=2 (Allowed Vendors) instead of 1.  The router would
+    # never feed this through _parse_disclosed_vendors today, but the
+    # helper itself should still reject it as defense-in-depth.
+    my $consent = GDPR::IAB::TCFv2->Parse(
+        'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA');
+
+    # 3 bits = 010 (=2), then a benign MaxVendorId=0, IsRangeEncoding=0 tail.
+    my $bad = '010' . ( '0' x 16 ) . '0';
+
+    throws_ok {
+        $consent->_parse_vendor_bitfield_or_range(
+            $bad,
+            GDPR::IAB::TCFv2::SEGMENT_TYPES->{DISCLOSED_VENDORS},
+        );
+    }
+    qr/invalid segment type/,
+      'helper croaks when payload header does not match expected type';
+};
+
 subtest "Core BitField data_size reflects slice length, not full core" => sub {
 
     # Single-segment v2.0 string with a sizeable core bitfield


### PR DESCRIPTION
## Vendor segment parser cleanup

**Stacked on #44** (`feat/phase-1-v23-logic`). Will need a rebase onto `devel` once #44 merges.

Four small fixes from the deep-dive review of `_parse_vendor_bitfield_or_range`. No public API changes; behavior is observable only through new error messages on malformed input and the new test cases.

### Commits

| | |
|---|---|
| `41e504b` | `fix:` align core bitfield/range `data_size` to slice length |
| `53a1eb1` | `feat:` defensive segment-type check in vendor-segment helper |
| `d9cd813` | `docs:` explain single-return shape of vendor-segment helper |
| `3311029` | `fix:` short-circuit `MaxVendorId=0` in vendor-segment helper |
| `a6c5795` | `docs:` refresh implementation plan with current line numbers |

### What changed

1. **`_parse_bitfield` / `_parse_range_section`** now pass `data_size => length($slice)` instead of `length($self->{core_data})`. This matches the pattern already used in `_parse_vendor_bitfield_or_range` (introduced in #44 / `460aaa9`). For typical valid TC strings the change is cosmetic; for truncated cores it makes the BitField guard fire immediately with a clear "requires N bits" message instead of silently stumbling forward and croaking deep in `_parse_publisher_section` with a misleading "missing 'core_data'" error.

2. **`_parse_vendor_bitfield_or_range`** gains a second positional arg `$expected_segment_type` and croaks if the payload's first 3 bits disagree. Brings parity with `PublisherTC->Parse` and protects against future refactors that might bypass `_decode_tc_string_segments` routing. Both callers (`_parse_disclosed_vendors`, `_parse_allowed_vendors`) updated to pass the appropriate `SEGMENT_TYPES->{...}` constant.

3. **Comment** above `_parse_vendor_bitfield_or_range` explaining why it returns only `$vendors_section` (no `$next_offset`) — distinct from `_parse_bitfield_or_range` which returns the offset for chained core-segment parsing.

4. **`MaxVendorId == 0` short-circuit.** Per spec, `MaxVendorId=0` means "field unused". Without the short-circuit, a segment with `IsRangeEncoding=1` and `max_id=0` would call `RangeSection->Parse`, which then hits its 31-byte minimum-size guard and croaks with a misleading message. With the short-circuit, an empty `BitField` is returned immediately, preserving `has_vendor_disclosure()` semantics while keeping `contains()` falsey for any vendor id.

### Tests

Three new subtests in `t/05-tcf-v23.t`:

- `"Core BitField data_size reflects slice length, not full core"` — truncated v2.0 core (`CLcVDx...` chopped 4 base64 chars), expects the slice-aware `BitField requires N bits` message.
- `"Disclosed Vendors helper rejects mis-typed payload"` — calls the private helper with a hand-built segment whose header claims type 2, expects the `invalid segment type` croak.
- `"MaxVendorId == 0 yields an empty vendor section"` — calls the private helper with a hand-built `max_id=0` + `IsRange=1` segment, expects an empty `BitField` rather than a croak.

8271 tests pass (`prove -lr t`); critic + tidy clean (`prove -lr xt`).

### Implementation plan

The full plan that drove this work lives at `docs/superpowers/plans/2026-05-06-vendor-segment-parser-cleanup.md` and is included in this PR for traceability.
