### PR TITLE
fix: coerce Math::BigInt fallback to plain scalars (Perl 5.8 CPAN Testers FAIL)

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -22,5 +22,6 @@ t/01-parse.t
 t/02-json-bitfield.t
 t/03-json-range.t
 t/10-cli-iabtcfv2.t
+t/12-bigint-fallback.t
 t/90-bugs.t
 t/99-pod.t

--- a/lib/GDPR/IAB/TCFv2/BitUtils.pm
+++ b/lib/GDPR/IAB/TCFv2/BitUtils.pm
@@ -12,8 +12,8 @@ use base qw<Exporter>;
 
 use constant ASCII_OFFSET => ord('A');
 
-my $CAN_PACK_QUADS;
-my $CAN_FORCE_BIG_ENDIAN;
+our $CAN_PACK_QUADS;
+our $CAN_FORCE_BIG_ENDIAN;
 
 BEGIN {
     $CAN_PACK_QUADS       = !!eval { my $f = pack 'Q>'; 1 };
@@ -119,7 +119,9 @@ sub _get_big_endian_short_16bits {
     my ( $data_with_padding, $next_offset ) =
       _add_padding( $data, 16, $offset, $nbits );
 
-    my $r = Math::BigInt->new( "0b" . $data_with_padding );
+    # Coerce to a native scalar so downstream JSON serializers don't
+    # choke on a blessed Math::BigInt.  16 bits always fits in an IV.
+    my $r = Math::BigInt->new( "0b" . $data_with_padding )->numify;
 
     return wantarray ? ( $r, $next_offset ) : $r;
 }
@@ -139,7 +141,10 @@ sub get_uint36 {
     my ( $data_with_padding, $next_offset ) =
       _add_padding( $data, 64, $offset, 36 );
 
-    my $r = Math::BigInt->new( "0b" . $data_with_padding );
+    # Same coercion as _get_big_endian_short_16bits.  36 bits fits in
+    # an NV's 53-bit mantissa with no precision loss (covers all TCF
+    # v2 deciseconds-since-epoch through year ~2148).
+    my $r = Math::BigInt->new( "0b" . $data_with_padding )->numify;
 
     return wantarray ? ( $r, $next_offset ) : $r;
 }

--- a/t/12-bigint-fallback.t
+++ b/t/12-bigint-fallback.t
@@ -1,0 +1,73 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+
+use GDPR::IAB::TCFv2;
+use GDPR::IAB::TCFv2::BitUtils;
+
+# These flags decide whether the BitUtils helpers take the fast
+# pack 'S>' / 'Q>' path or the Math::BigInt fallback.  On modern
+# Perls both flags are true; on Perl < 5.10 (e.g. 5.8.9 on FreeBSD,
+# CPAN Testers report 281cd334-...) the fallback is the only path.
+#
+# Forcing both flags off here exercises the fallback unconditionally
+# so the regression is testable on any Perl.
+#
+# Regression: the fallback used to return raw Math::BigInt blessed
+# objects, which then propagated into TO_JSON output and made any
+# JSON encoder without `convert_blessed` croak with
+# "encountered object 'Math::BigInt=HASH(...)'...".
+
+my $tc_string =
+  'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA';
+
+subtest 'fallback path returns plain scalars (no blessed Math::BigInt)' =>
+  sub {
+    local $GDPR::IAB::TCFv2::BitUtils::CAN_PACK_QUADS       = 0;
+    local $GDPR::IAB::TCFv2::BitUtils::CAN_FORCE_BIG_ENDIAN = 0;
+
+    my $consent;
+    lives_ok { $consent = GDPR::IAB::TCFv2->Parse($tc_string) }
+    'Parse succeeds with both fast paths disabled';
+
+    for my $accessor (
+        qw< cmp_id cmp_version vendor_list_version policy_version
+        max_vendor_id_consent max_vendor_id_legitimate_interest
+        created last_updated >
+      )
+    {
+        my $value = $consent->$accessor;
+        is ref($value), '',
+          "$accessor returns a plain scalar (got "
+          . ( ref($value) || 'scalar' ) . ')';
+    }
+  };
+
+subtest 'fallback values JSON-encode without convert_blessed' => sub {
+    local $GDPR::IAB::TCFv2::BitUtils::CAN_PACK_QUADS       = 0;
+    local $GDPR::IAB::TCFv2::BitUtils::CAN_FORCE_BIG_ENDIAN = 0;
+
+    my $json_class =
+        eval { require JSON;     1 } ? 'JSON'
+      : eval { require JSON::PP; 1 } ? 'JSON::PP'
+      :                                undef;
+    plan skip_all => 'no JSON encoder available' unless $json_class;
+
+    my $consent = GDPR::IAB::TCFv2->Parse($tc_string);
+
+    # Deliberately do NOT enable convert_blessed.  A blessed Math::BigInt
+    # leaking through TO_JSON would croak here.
+    my $encoder = $json_class->new;
+    my $output;
+    lives_ok { $output = $encoder->encode( $consent->TO_JSON ) }
+    'TO_JSON encodes cleanly without convert_blessed';
+
+    like $output, qr/"cmp_id"\s*:\s*\d+/,
+      'cmp_id is encoded as a JSON number';
+    like $output, qr/"vendor_list_version"\s*:\s*\d+/,
+      'vendor_list_version is encoded as a JSON number';
+};
+
+done_testing;


### PR DESCRIPTION
## Fix Math::BigInt fallback leak into JSON output

### Background

CPAN Testers report [281cd334-...](https://matrix.perl-magpie.org/results/281cd334-4931-11f1-a8e2-4d036e8775ea) shows v0.340 failing on **Perl 5.8.9 / FreeBSD 9.2** with 7 of 8 subtests failing in `t/10-cli-iabtcfv2.t`. The failure mode is:

```
encountered object 'Math::BigInt=HASH(...)' but neither
allow_blessed, convert_blessed nor allow_tags settings are enabled
```

### Root cause

`lib/GDPR/IAB/TCFv2/BitUtils.pm` detects `pack 'Q>'` and `pack 'S>'` at `BEGIN`. On Perls without those format characters (added in 5.10), `_get_big_endian_short_16bits` (backing `get_uint12` / `get_uint16`) and `get_uint36` fall through to a `Math::BigInt` constructor and return blessed BigInt objects. Those objects flow unchanged through `cmp_id`, `cmp_version`, `vendor_list_version`, `policy_version`, `created`, `last_updated`, `max_vendor_id_consent`, `max_vendor_id_legitimate_interest`, into `TO_JSON`, into the CLI's `JSON->encode` — which croaks.

### Fix

Coerce at the BitUtils boundary by calling `->numify` on the BigInt result in both fallback paths.

- 16 bits: always fits in an IV.
- 36 bits: fits exactly in an NV's 53-bit mantissa (covers all TCF v2 deciseconds-since-epoch through year ~2148).

The pack-based fast paths are untouched. No public API change.

Also promotes `$CAN_PACK_QUADS` and `$CAN_FORCE_BIG_ENDIAN` from `my` lexicals to `our` package globals so the new regression test can `local`-override them and exercise the BigInt path on any Perl. The variables remain undocumented (no POD) and are intended only for internal/test use.

### New regression test (`t/12-bigint-fallback.t`)

Two subtests, both exercising the fallback path via `local` overrides:

1. **`fallback path returns plain scalars`** — parse a known TC string with both fast-path flags forced off; verify `cmp_id`, `cmp_version`, `vendor_list_version`, `policy_version`, `max_vendor_id_consent`, `max_vendor_id_legitimate_interest`, `created`, `last_updated` all return non-blessed scalars.
2. **`fallback values JSON-encode without convert_blessed`** — same setup; encode `$consent->TO_JSON` with a plain `JSON->new` (or `JSON::PP`) and verify the encoder doesn't croak. Asserts the actual numeric encoding of `cmp_id` and `vendor_list_version`.

I verified locally that the test fails with the exact regression pattern (`got Math::BigInt`) when the `numify` coercion is removed.

### Verification

```
prove -lr t   # 7237 tests pass (10 files; +1 from baseline)
prove -lr xt  # 34 tests pass (perlcritic + perltidy)
```

### Notes

- This patch targets `devel` directly — orthogonal to PR #44 (Phase 1) and PR #45 (segment-parser cleanup); none of those touch `BitUtils`.
- `Makefile.PL` declares `MIN_PERL_VERSION => 5.008`, so 5.8.9 is in the supported range; this fix restores correctness for that range.
- `MANIFEST` updated to include `t/12-bigint-fallback.t` so the new test ships in the dist.

### Out of scope (possible follow-ups)

- Belt-and-suspenders: enable `convert_blessed` on the CLI's JSON encoder so any *future* leaked blessed value (e.g. a date formatter) doesn't crash. Not done here because no other blessed values are reachable today.
- Adding a Perl 5.8 entry to the GitHub Actions matrix (currently only 5.12.2 + latest) so this regression class gets caught in CI.
