### PR TITLE
fix(ci): drop unused pod2markdown install and use latest Perl in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,11 @@ jobs:
       - name: Set up Perl
         uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: '5.38'
+          perl-version: 'latest'
 
       - name: Install Release Dependencies
         run: |
-          cpanm -n CPAN::Uploader pod2markdown
+          cpanm -n CPAN::Uploader
 
       - name: Build Distribution
         run: |


### PR DESCRIPTION
## Fix release workflow (CPAN upload + perl pin)

Follow-up to the failed release run [25433702175](https://github.com/peczenyj/GDPR-IAB-TCFv2/actions/runs/25433702175/job/74606082250).

### Bug

The `Install Release Dependencies` step ran `cpanm -n CPAN::Uploader pod2markdown` and failed:

```
! Finding pod2markdown on cpanmetadb failed.
! Finding pod2markdown () on metacpan failed.
! Finding pod2markdown () on mirror https://www.cpan.org failed.
! Couldn't find module or a distribution pod2markdown
##[error]Process completed with exit code 1.
```

Root cause: `pod2markdown` is the executable shipped with the **Pod::Markdown** distribution, not a distribution itself. `cpanm` looks for distributions/modules with that exact name and finds none.

### Fix

Two minimal changes:

1. **Drop `pod2markdown` from the install line entirely.** The workflow only does `perl Makefile.PL && make manifest && make dist` and never invokes `pod2markdown`. README regeneration is a local prep step (see `CONTRIBUTING.pod` step 5), so the runner doesn't need `Pod::Markdown` at all. Dropping the install rather than renaming it to `Pod::Markdown` keeps the workflow honest about what it actually uses.
2. **Switch `perl-version: '5.38'` → `'latest'`** to match every other workflow in the repo. There was no specific reason to pin 5.38 for the release step; release tooling (`CPAN::Uploader`, `make dist`) doesn't depend on Perl version.

### Verification

The workflow only fires on `v*` tag push, so the fix is effectively unverifiable until the next release tag. The change is small enough to review by inspection.

### Notes

- Doesn't change the `softprops/action-gh-release@v2` step or its hard-coded `draft: false` (left as-is per the design tradeoff documented in `CONTRIBUTING.pod` § "Pre-release review").
- Doesn't touch the PAUSE upload step.
