### PR TITLE
docs/test: Test::Warn refactor, bug-tracker footer, Docker image name fix

### DIFF
--- a/CONTRIBUTING.pod
+++ b/CONTRIBUTING.pod
@@ -318,7 +318,7 @@ the workflow.
         | jq .version
     # Should report "0.360"
 
-The docker image (C<peczenyj/iabtcfv2:0.360> and C<:latest>) is published
+The docker image (C<peczenyj/gdpr-iab-tcfv2:0.360> and C<:latest>) is published
 by F<.github/workflows/docker.yml> on the same C<v*> tag push.
 
 =back

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,6 +13,7 @@ WriteMakefile(
         'Test::Exception' => 0.43,
         'Test::More'      => 0.94,
         'Test::Pod'       => 0,
+        'Test::Warn'      => 0.30,
     },
     (   eval { ExtUtils::MakeMaker->VERSION(6.46) }
         ? ( META_MERGE => {

--- a/README.md
+++ b/README.md
@@ -107,17 +107,17 @@ This tool is also available as a Docker image on Docker Hub.
 
 ## Basic Usage
 
-    docker run --rm peczenyj/iabtcfv2 dump "CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA"
+    docker run --rm peczenyj/gdpr-iab-tcfv2 dump "CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA"
 
 ## Processing Streams (STDIN)
 
 To process a stream of strings via pipe:
 
-    cat strings.txt | docker run -i --rm peczenyj/iabtcfv2 dump
+    cat strings.txt | docker run -i --rm peczenyj/gdpr-iab-tcfv2 dump
 
 To type strings manually:
 
-    docker run -it --rm peczenyj/iabtcfv2 dump
+    docker run -it --rm peczenyj/gdpr-iab-tcfv2 dump
 
 # ACRONYMS
 

--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -314,17 +314,17 @@ This tool is also available as a Docker image on Docker Hub.
 
 =head2 Basic Usage
 
-    docker run --rm peczenyj/iabtcfv2 dump "CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA"
+    docker run --rm peczenyj/gdpr-iab-tcfv2 dump "CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA"
 
 =head2 Processing Streams (STDIN)
 
 To process a stream of strings via pipe:
 
-    cat strings.txt | docker run -i --rm peczenyj/iabtcfv2 dump
+    cat strings.txt | docker run -i --rm peczenyj/gdpr-iab-tcfv2 dump
 
 To type strings manually:
 
-    docker run -it --rm peczenyj/iabtcfv2 dump
+    docker run -it --rm peczenyj/gdpr-iab-tcfv2 dump
 
 =head1 VALIDATE
 

--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -27,7 +27,7 @@ GetOptions(
   )
   or pod2usage(
     -input    => $script_path, -exitval => 2, -verbose => 99,
-    -sections => "SYNOPSIS|OPTIONS|SUBCOMMANDS"
+    -sections => "SYNOPSIS|OPTIONS|SUBCOMMANDS|BUGS"
   );
 
 if ( $global_opts{help} ) {
@@ -35,12 +35,12 @@ if ( $global_opts{help} ) {
     if ( $topic && $topic eq 'dump' ) {
         pod2usage(
             -input    => $script_path, -exitval => 1, -verbose => 99,
-            -sections => "DUMP"
+            -sections => "DUMP|BUGS"
         );
     }
     pod2usage(
         -input    => $script_path, -exitval => 1, -verbose => 99,
-        -sections => "SYNOPSIS|OPTIONS|SUBCOMMANDS"
+        -sections => "SYNOPSIS|OPTIONS|SUBCOMMANDS|BUGS"
     );
 }
 pod2usage( -input => $script_path, -exitval => 1, -verbose => 2 )
@@ -60,19 +60,19 @@ elsif ( $subcommand eq 'help' ) {
     if ( $topic && $topic eq 'dump' ) {
         pod2usage(
             -input    => $script_path, -exitval => 1, -verbose => 99,
-            -sections => "DUMP"
+            -sections => "DUMP|BUGS"
         );
     }
     pod2usage(
         -input    => $script_path, -exitval => 1, -verbose => 99,
-        -sections => "SYNOPSIS|OPTIONS|SUBCOMMANDS"
+        -sections => "SYNOPSIS|OPTIONS|SUBCOMMANDS|BUGS"
     );
 }
 else {
     warn "Unknown subcommand: $subcommand\n";
     pod2usage(
         -input    => $script_path, -exitval => 1, -verbose => 99,
-        -sections => "SYNOPSIS|OPTIONS|SUBCOMMANDS"
+        -sections => "SYNOPSIS|OPTIONS|SUBCOMMANDS|BUGS"
     );
 }
 
@@ -104,13 +104,13 @@ sub run_dump {
         'help|h'             => sub {
             pod2usage(
                 -input    => $script_path, -exitval => 1, -verbose => 99,
-                -sections => "DUMP"
+                -sections => "DUMP|BUGS"
             );
         },
       )
       or pod2usage(
         -input    => $script_path, -exitval => 2, -verbose => 99,
-        -sections => "DUMP"
+        -sections => "DUMP|BUGS"
       );
 
     my $json_pkg = JSON->can('new') ? 'JSON' : 'JSON::PP';
@@ -339,5 +339,9 @@ B<iabtcfv2> is a command-line interface for the GDPR::IAB::TCFv2 library.
 Previous versions of this distribution (v0.300) included a standalone utility
 named B<iabtcf-dump>. This has been unified into the B<iabtcfv2> tool using
 the B<dump> subcommand.
+
+=head1 BUGS
+
+Report bugs and feature requests at L<https://github.com/peczenyj/GDPR-IAB-TCFv2/issues>.
 
 =cut

--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -1122,17 +1122,17 @@ This tool is also available as a Docker image on Docker Hub.
 
 =head2 Basic Usage
 
-    docker run --rm peczenyj/iabtcfv2 dump "CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA"
+    docker run --rm peczenyj/gdpr-iab-tcfv2 dump "CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA"
 
 =head2 Processing Streams (STDIN)
 
 To process a stream of strings via pipe:
 
-    cat strings.txt | docker run -i --rm peczenyj/iabtcfv2 dump
+    cat strings.txt | docker run -i --rm peczenyj/gdpr-iab-tcfv2 dump
 
 To type strings manually:
 
-    docker run -it --rm peczenyj/iabtcfv2 dump
+    docker run -it --rm peczenyj/gdpr-iab-tcfv2 dump
 
 =head1 ACRONYMS
 

--- a/t/04-legal-basis.t
+++ b/t/04-legal-basis.t
@@ -3,18 +3,10 @@ use warnings;
 
 use Test::More;
 use Test::Exception;
+use Test::Warn;
 
 use GDPR::IAB::TCFv2;
 use GDPR::IAB::TCFv2::Constants::RestrictionType qw<:all>;
-
-# Helper for testing warnings
-sub warning_like (&$;$) {
-    my ( $code, $pattern, $message ) = @_;
-    my @warnings;
-    local $SIG{__WARN__} = sub { push @warnings, @_ };
-    $code->();
-    like( join( '', @warnings ), $pattern, $message );
-}
 
 subtest "is_vendor_consent_allowed" => sub {
     my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';


### PR DESCRIPTION
## CLI / docs polish: Test::Warn, bug-tracker footer, Docker image name fix

Three small docs/test-infra changes that grew together. None of them touch library behavior; the public CLI gains one footer line.

### Commits

| | |
|---|---|
| `0e6bc98` | `test:` replace custom `warning_like` helper with `Test::Warn` |
| `9b004f7` | `docs(cli):` add bug-tracker footer to `--help` and `dump --help` |
| `694def4` | `docs:` fix wrong Docker image name (`peczenyj/iabtcfv2` → `peczenyj/gdpr-iab-tcfv2`) |

### 1. Drop the homegrown `warning_like` for `Test::Warn`

`t/04-legal-basis.t` carried a 7-line `sub warning_like` that captured warns via `local $SIG{__WARN__}` and ran `like()` on the joined output. `Test::Warn` provides the same calling convention (block + `qr//` + description) as a battle-tested CPAN module — no reason to keep the helper in-tree.

- `t/04-legal-basis.t`: `use Test::Warn;` added, custom helper removed.
- `Makefile.PL`: `'Test::Warn' => 0.30` added to `TEST_REQUIRES`.

Existing call sites (`warning_like { ... } qr/.../, '...'`) work unchanged because `Test::Warn`'s API matches the helper's signature exactly.

### 2. Bug-tracker footer in `--help` / `dump --help`

`bin/iabtcfv2` now ends its POD with a `=head1 BUGS` section pointing at <https://github.com/peczenyj/GDPR-IAB-TCFv2/issues>. Every `pod2usage -sections => ...` regex used by the help paths includes `BUGS`, so the footer renders below the existing SYNOPSIS/OPTIONS/SUBCOMMANDS (or DUMP) blocks.

Visible in: `iabtcfv2 --help`, `-h`, `help`, `help dump`, `dump --help`, and `--man` (which already shows the entire POD).

```
Bugs:
    Report bugs and feature requests at
    <https://github.com/peczenyj/GDPR-IAB-TCFv2/issues>.
```

### 3. Fix the wrong Docker image name in docs

The published Docker Hub image is **`peczenyj/gdpr-iab-tcfv2`** (active, 108+ pulls per the Hub API). `peczenyj/iabtcfv2` does not exist (`object not found`).

Root cause: `.github/workflows/docker.yml` uses `IMAGE_NAME: ${{ github.repository }}`, which expands to `peczenyj/GDPR-IAB-TCFv2` and is then lowercased by Docker Hub to `peczenyj/gdpr-iab-tcfv2`. The docs were written with a guessed short name.

- `bin/iabtcfv2`: 3 occurrences in `=head1 DOCKER USAGE`
- `lib/GDPR/IAB/TCFv2.pm`: 3 occurrences in `=head1 DOCKER USAGE`
- `CONTRIBUTING.pod`: 1 occurrence in the release-flow note
- `README.md`: regenerated via `pod2markdown lib/GDPR/IAB/TCFv2.pm > README.md`

Verified with `grep -rn 'peczenyj/iabtcfv2' . --exclude-dir=.git` — zero remaining hits.

### Verification

- `prove -lr t` — 8271 tests pass (same count as before; net code change is removal)
- `prove -lr xt` — perlcritic + perltidy clean
- `iabtcfv2 --help` and `iabtcfv2 dump --help` smoke-tested locally; footer renders at the bottom

### Notes

- Independent of PR #48 (already merged) — no overlapping files.
- Test deps now include `Test::Warn`, which is a 25-year-old core-grade testing module; install friction is effectively zero.
- The library's public API surface is unchanged. The CLI gains the footer text in help output but no new flags.
