### PR TITLE
docs: track Phase 5 (CMP Validation) in TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -46,6 +46,18 @@
 *   **Tasks:**
     *   Investigate `vec()` for bitfields.
 
+## Phase 5: CMP Validation
+*   **Goal:** IAB Registry-based compliance and automatic CMP lifecycle checks.
+*   **Depends on:** Phase 2 (Validator Interface).
+*   **Tasks:**
+    *   Create `GDPR::IAB::TCFv2::CMPValidator` for querying the official IAB CMP list.
+    *   Support flexible registry loading: Local File path, Raw JSON string, or remote URL fetched via `HTTP::Tiny`.
+    *   **Compliance Checks:** verify CMP existence in the registry and respect `deletedDate` flags on retired CMPs.
+    *   **Stale Data Protection:** emit a warning when registry data is older than 28 days.
+    *   **Validator Integration:** expose a `cmp_validator` rule on the main `Validator` interface from Phase 2.
+    *   **Tests:** use fixed reference dates so the `deletedDate` / staleness checks are deterministic across execution environments.
+*   **Reference:** PR [#38](https://github.com/peczenyj/GDPR-IAB-TCFv2/pull/38) (`feat/phase-5-cmp-validator`, currently OPEN).
+
 ## Distribution
 *   [ ] Distribute CLI tool as Docker image via DockerHub.
     *   Create multi-stage `Dockerfile`.


### PR DESCRIPTION
## Track Phase 5 (CMP Validation) in TODO.md

Phase 5 is in flight on PR #38 (`feat/phase-5-cmp-validator`). Adding it to `TODO.md` so the planning doc stays a complete map of phases — future contributors and future-you can see the full roadmap from one file.

### Inserted between "Phase 4: Performance" and "Distribution"

```markdown
## Phase 5: CMP Validation
*   **Goal:** IAB Registry-based compliance and automatic CMP lifecycle checks.
*   **Depends on:** Phase 2 (Validator Interface).
*   **Tasks:**
    *   Create `GDPR::IAB::TCFv2::CMPValidator` for querying the official IAB CMP list.
    *   Support flexible registry loading: Local File path, Raw JSON string, or remote URL fetched via `HTTP::Tiny`.
    *   **Compliance Checks:** verify CMP existence in the registry and respect `deletedDate` flags on retired CMPs.
    *   **Stale Data Protection:** emit a warning when registry data is older than 28 days.
    *   **Validator Integration:** expose a `cmp_validator` rule on the main `Validator` interface from Phase 2.
    *   **Tests:** use fixed reference dates so the `deletedDate` / staleness checks are deterministic across execution environments.
*   **Reference:** PR #38 (`feat/phase-5-cmp-validator`, currently OPEN).
```

### Why a Phase-2 dependency note

The original PR #38 description mentions "Validator Integration: Added the `cmp_validator` rule to the main Validator interface." That interface (`GDPR::IAB::TCFv2::Validator` / `validate` / `validate_all`) is Phase 2 in `TODO.md` and not yet implemented. Calling out the dependency explicitly so reviewers/devs see Phase 2 has to land first (or together).

### Notes

- Doc-only change — no code touched.
- `TODO.md` is in `MANIFEST.SKIP`, so this does not affect the CPAN dist.
- Independent of every other open PR; safe to merge in any order.
