### PR TITLE
feat(cli): bundling + short aliases (-c for --compact, -s for --strict)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ Parses TC strings and output them as JSON.
     # Stream multiple strings from STDIN to a JSON array
     cat strings.txt | iabtcfv2 dump --json-array
 
+    # Short flags can be bundled (the last bundled short may take a value)
+    iabtcfv2 dump -pq "CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA"
+    iabtcfv2 dump -pv 284 "CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA"
+
+    # Long options accept the GNU `--opt=value` form
+    iabtcfv2 dump --vendor-id=284 "CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA"
+
 See `iabtcfv2 --help` or `perldoc iabtcfv2` for more details.
 
 # DOCKER USAGE

--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -101,13 +101,13 @@ sub run_dump {
         \@args,
         'pretty|p'           => \$opts{pretty},
         'json-array'         => \$opts{'json-array'},
-        'compact'            => \$opts{compact},
+        'compact|c'          => \$opts{compact},
         'ignore-errors|i'    => \$opts{'ignore-errors'},
         'fail-fast|f'        => \$opts{'fail-fast'},
         'errors-to-stderr|e' => \$opts{'errors-to-stderr'},
         'quiet|q'            => \$opts{'quiet'},
         'vendor-id|v=i'      => \$opts{'vendor-id'},
-        'strict'             => \$opts{strict},
+        'strict|s'           => \$opts{strict},
         'help|h'             => sub {
             pod2usage(
                 -input    => $script_path, -exitval => 1, -verbose => 99,
@@ -277,7 +277,7 @@ Output human-readable, indented JSON.
 
 Output a single JSON array containing all parsed objects.
 
-=item B<--compact>
+=item B<--compact>, B<-c>
 
 Output a compact JSON representation (lists of IDs instead of boolean maps).
 
@@ -285,7 +285,7 @@ Output a compact JSON representation (lists of IDs instead of boolean maps).
 
 Filter the output to only show data for a specific vendor ID.
 
-=item B<--strict>
+=item B<--strict>, B<-s>
 
 Enable strict specification validation. In this mode, the tool will fail if
 mandatory segments are missing (e.g., Disclosed Vendors in TCF v2.3).

--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -3,7 +3,8 @@
 use strict;
 use warnings;
 
-use Getopt::Long qw(GetOptionsFromArray :config pass_through require_order);
+use Getopt::Long
+  qw(GetOptionsFromArray :config pass_through require_order bundling);
 use Pod::Usage;
 use File::Spec;
 eval { require JSON; 1 } or require JSON::PP;
@@ -317,6 +318,27 @@ Suppress human-readable warning messages on B<STDERR>.
 
     # Read from STDIN
     cat strings.txt | iabtcfv2 dump --json-array
+
+=head2 Short option bundling
+
+Single-character flags can be bundled together after a single dash. The last
+option in the bundle may take a value as the next argument.
+
+    # Equivalent of `--pretty --quiet`
+    iabtcfv2 dump -pq CPi...AAA
+
+    # Equivalent of `--pretty --ignore-errors --quiet`
+    iabtcfv2 dump -piq CPi...AAA
+
+    # Last bundled short can take a value: -p (pretty) + -v <id> (vendor-id)
+    iabtcfv2 dump -pv 284 CPi...AAA
+
+    # Long options accept the GNU `=value` form too
+    iabtcfv2 dump --vendor-id=284 CPi...AAA
+
+Bundling does NOT support abbreviating long options (`--ver` is not accepted
+as a shortcut for `--version`); always use the full long-option name or its
+single-character short alias.
 
 =head1 DOCKER USAGE
 

--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -1114,6 +1114,13 @@ Parses TC strings and output them as JSON.
     # Stream multiple strings from STDIN to a JSON array
     cat strings.txt | iabtcfv2 dump --json-array
 
+    # Short flags can be bundled (the last bundled short may take a value)
+    iabtcfv2 dump -pq "CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA"
+    iabtcfv2 dump -pv 284 "CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA"
+
+    # Long options accept the GNU `--opt=value` form
+    iabtcfv2 dump --vendor-id=284 "CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA"
+
 See C<iabtcfv2 --help> or C<perldoc iabtcfv2> for more details.
 
 =head1 DOCKER USAGE

--- a/t/10-cli-iabtcfv2.t
+++ b/t/10-cli-iabtcfv2.t
@@ -189,4 +189,39 @@ subtest 'Short option bundling and = value syntax' => sub {
     );
 };
 
+# Test short aliases -c (compact) and -s (strict)
+subtest 'Short aliases -c (compact) and -s (strict)' => sub {
+
+    # -c == --compact: assert by comparing decoded data against the long form.
+    my $c_data = decode_helper(`$perl -Ilib $bin dump -c $tc_string`);
+    my $long_data =
+      decode_helper(`$perl -Ilib $bin dump --compact $tc_string`);
+    is_deeply( $c_data, $long_data, '-c produces the same data as --compact' );
+    is( ref( $c_data->{purpose}{consents} ), 'ARRAY',
+        '-c enables compact form (purpose consents as array)'
+    );
+
+    # -s == --strict: a TCF v2.3 string without Disclosed Vendors segment
+    # must be rejected with the standard "Disclosed Vendors segment is
+    # mandatory" message.  --quiet keeps the warn off CI.
+    my $tc_v23_no_dv =
+      'CP188cAQKFpAAAHABBENBSFsAP_gAEPgAAiQKqNX_H__bW9r8X73aft0eY1P9_j77uQxBhfJE-4FzLvW_JwXx2ExNA36tqIKmRIEu3bBIQNlHJHUTVigaogVryHMak2cpTNKJ6BkiFMRM2dYCF5vm4tj-QKY5_r993dx2D-t_dv83dzyz81Hn3f5_2e0eLCdQ5-tDfv9bROb-9IPd_78v4v8_l_rk2_eT1n_tevr7D_-ft8__XW_9_fff_9Pn_-uB_-_3_vf_EFUwCTDQqIA-wJCQg0DCKBACoKwgIoFAQAAJA0QEAJgwKdgYALrCRACAFAAMEAIAAQZAAgAAAgAQiACQAoEAAEAgUAAYAEAwEABAwAAgAsBAIAAQHQMUwIIFAsIEjMioUwIQoEggJbKhBICgQVwhCLPAIgERMFAAgAAAVgACAsFgcSSAlQkECXUG0AABAAgFEIFQgk9MAAwJmy1B4MG0ZWmAYPmCRDTAMgCIIyEAAAA';
+
+    my $s_out = `$perl -Ilib $bin dump -s --quiet $tc_v23_no_dv`;
+    like(
+        $s_out, qr/Disclosed Vendors segment is mandatory/,
+        '-s enables --strict (rejects v2.3 without Disclosed Vendors)'
+    );
+
+    # Bundled new shorts: -cp must produce the same data as --compact --pretty.
+    my $bundled_cp_data =
+      decode_helper(`$perl -Ilib $bin dump -cp $tc_string`);
+    my $longform_cp_data =
+      decode_helper(`$perl -Ilib $bin dump --compact --pretty $tc_string`);
+    is_deeply(
+        $bundled_cp_data, $longform_cp_data,
+        '-cp produces the same data as --compact --pretty'
+    );
+};
+
 done_testing();

--- a/t/10-cli-iabtcfv2.t
+++ b/t/10-cli-iabtcfv2.t
@@ -150,4 +150,43 @@ subtest 'Version Option' => sub {
     );
 };
 
+# Test Short Option Bundling and = syntax
+subtest 'Short option bundling and = value syntax' => sub {
+
+    # Bundled boolean flags: -pq is parsed as --pretty --quiet.
+    # `--pretty` produces multi-line indented JSON, which is the easiest
+    # observable side effect to assert on.
+    my $bundled_flags_out  = `$perl -Ilib $bin dump -pq $tc_string`;
+    my $bundled_flags_data = decode_helper($bundled_flags_out);
+    ok( $bundled_flags_data, '-pq produces valid JSON' );
+    like(
+        $bundled_flags_out, qr/\n\s+"/,
+        '-pq enables --pretty (multi-line output)'
+    );
+
+    # Bundled flag + value-taking short: -pv 1 is --pretty --vendor-id 1.
+    # Compare logically against the canonical long-form invocation so the
+    # assertion doesn't depend on which fields are populated for the chosen
+    # vendor in the fixture.
+    my $bundled_value_data =
+      decode_helper(`$perl -Ilib $bin dump -pv 1 $tc_string`);
+    my $longform_data =
+      decode_helper(`$perl -Ilib $bin dump --pretty --vendor-id 1 $tc_string`);
+    is_deeply(
+        $bundled_value_data, $longform_data,
+        '-pv 1 produces the same data as --pretty --vendor-id 1'
+    );
+
+    # GNU-style --opt=value: --vendor-id=1 must behave identically to
+    # --vendor-id 1.
+    my $eq_data =
+      decode_helper(`$perl -Ilib $bin dump --vendor-id=1 $tc_string`);
+    my $space_data =
+      decode_helper(`$perl -Ilib $bin dump --vendor-id 1 $tc_string`);
+    is_deeply(
+        $eq_data, $space_data,
+        '--vendor-id=1 is parsed identically to --vendor-id 1'
+    );
+};
+
 done_testing();


### PR DESCRIPTION
## CLI: enable bundling + add short aliases `-c`/`-s`

Two related ergonomics improvements to the `iabtcfv2` CLI.

### 1. Enable Getopt::Long short-option bundling

Adds `bundling` to the global `Getopt::Long` config. Power users can combine short flags after a single dash:

| Invocation | Effect |
|---|---|
| `iabtcfv2 dump -pq <tc>` | `--pretty --quiet` |
| `iabtcfv2 dump -piq <tc>` | `--pretty --ignore-errors --quiet` |
| `iabtcfv2 dump -pv 284 <tc>` | `--pretty --vendor-id 284` (last bundled short takes a value) |
| `iabtcfv2 dump --vendor-id=284 <tc>` | GNU `--opt=value` syntax (works without bundling, doc-tested for completeness) |

#### Side effects of `bundling` (intentional)

| Effect | Verdict |
|---|---|
| Short options become case-sensitive (`no_ignore_case` forced ON) | **Good** — defense-in-depth on top of PR #51's `require_order` fix for the `-v` / `-V` shadowing bug |
| Long-option auto-abbreviation disabled | **Acceptable** — `--ver` no longer matches `--version`. POD now explicitly tells users to use the full name or the single-char short |
| Single-dash long form (`-help` instead of `--help`) no longer accepted | **Acceptable** — POSIX-correct; nobody should rely on this |

#### Why `gnu_compat` was considered but dropped

I initially added `gnu_compat` too. Investigation showed:

- `--opt=value` already works without `gnu_compat` (it's the default behavior for long options).
- `gnu_compat` only changes the behavior of `--opt=` with **empty** value (without it: error; with it: sets opt to ""). We don't care about empty-value semantics.
- The combination `pass_through + bundling + gnu_compat` actually **broke bundling** in my local tests — `-pq` was no longer split. Verified with a minimal repro:

  ```perl
  use Getopt::Long qw(GetOptionsFromArray :config pass_through bundling gnu_compat);
  my @args = ('-pq', 'tc');
  GetOptionsFromArray(\@args, 'pretty|p' => \$p, 'quiet|q' => \$q);
  # @args = ('-pq', 'tc')   <-- bundling didn't fire
  ```

  Without `gnu_compat`, the same combo correctly splits to `pretty=1, quiet=1, @args=('tc')`.

So the final config is just:
```perl
use Getopt::Long
  qw(GetOptionsFromArray :config pass_through require_order bundling);
```

### 2. New short aliases for `--compact` and `--strict`

Two of the dump subcommand's flags previously had no single-character short. Filling the gap:

| Long | Short | New? |
|---|---|---|
| `--pretty` | `-p` | existing |
| **`--compact`** | **`-c`** | **new** |
| `--ignore-errors` | `-i` | existing |
| `--fail-fast` | `-f` | existing |
| `--errors-to-stderr` | `-e` | existing |
| `--quiet` | `-q` | existing |
| `--vendor-id` | `-v` | existing |
| **`--strict`** | **`-s`** | **new** |

Both letters are previously unused in the dump-subcommand spec and in the global Getopt::Long spec; bundling makes the matching strictly case-sensitive so no clash is possible.

POD entries updated (`=item B<--compact>, B<-c>`; `=item B<--strict>, B<-s>`) — `iabtcfv2 dump --help` and `iabtcfv2 --man` show the new shorts automatically.

### Combined: power-user invocations enabled by both changes

```sh
iabtcfv2 dump -cpq  <tc>          # compact + pretty + quiet
iabtcfv2 dump -cs   <tc_v23>      # compact + strict
iabtcfv2 dump -cpv  284 <tc>      # compact + pretty + vendor-id 284
iabtcfv2 dump -ifq  <tc>          # ignore-errors + fail-fast + quiet
```

### Documentation updates

- **`bin/iabtcfv2`** — new `=head2 Short option bundling` subsection in the DUMP block, with copy-pasteable examples; POD `=item` entries for `--compact` and `--strict` now advertise their shorts.
- **`lib/GDPR/IAB/TCFv2.pm`** — three extra example lines in the `=head2 iabtcfv2` block.
- **`README.md`** — regenerated via `pod2markdown lib/GDPR/IAB/TCFv2.pm > README.md`.

### Tests (`t/10-cli-iabtcfv2.t`)

Two new subtests:

**`'Short option bundling and = value syntax'`** — 4 assertions:
- `-pq` produces valid JSON
- `-pq` enables `--pretty` (multi-line output is visible)
- `-pv 1` produces the same decoded data as `--pretty --vendor-id 1`
- `--vendor-id=1` is parsed identically to `--vendor-id 1`

**`'Short aliases -c (compact) and -s (strict)'`** — 4 assertions:
- `-c` decodes to the same data as `--compact`
- `-c` enables compact form (purpose consents as array)
- `-s` rejects a TCF v2.3 string that lacks the Disclosed Vendors segment (the existing strict-mode failure case, with `--quiet` to keep CI clean)
- `-cp` produces the same data as `--compact --pretty` (confirming the new shorts can be bundled)

`is_deeply` comparisons against the canonical long-form invocations sidestep fixture-specific concerns about which fields are populated.

### Verification

- `prove -lr t` — 8276 tests pass (+8 assertions across two new subtests)
- `prove -lr xt` — perlcritic + perltidy clean
- Smoke-tested locally: `-pq`, `-piq`, `-pv 1`, `-c`, `-s`, `-cs`, `-cp`, `-cpq`, `--vendor-id=1`, `--version`, `-V`, `-v 1`, `--help`, `dump --help` all behave as expected

### Sync with `devel`

This branch was originally cut before the v0.352 release. Merged `devel` (post-release) back into the branch (commit `10ad26d`) so the diff against current `devel` is clean: the bundling change, the two new shorts, the POD updates, the regenerated README, and the new test subtests.

### Notes on shipping

User-visible CLI behavior change. Per `CONTRIBUTING.pod`'s versioning convention (`+10` middle digit for features), this would warrant **v0.360**. Release prep (`$VERSION` bump + `git cliff`) is intentionally not in this PR — it can land in a separate `chore: prepare for v0.360 release` commit when you're ready.
