### PR TITLE
fix: avoid 32-bit IV overflow when decoding 36-bit timestamps

### DIFF
--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -163,12 +163,22 @@ sub last_updated {
 sub _get_epoch {
     my ( $self, $offset ) = @_;
 
+    # Drop the file-level `use integer` for this scope. TCF v2 stores
+    # Created and LastUpdated as a 36-bit deciseconds-since-epoch field,
+    # which exceeds a 32-bit signed IV. On a Perl built without 64-bit
+    # ints (e.g. the armv6l smokers), `get_uint36` returns the value as
+    # an NV via Math::BigInt->numify; the C-integer `/` and `%` of
+    # `use integer` would then coerce that NV back into an overflowing
+    # 32-bit IV. NV float math keeps full precision (36 bits fits in
+    # the 53-bit mantissa) and lands a correct integer result via int().
+    no integer;
+
     my $deciseconds = scalar( get_uint36( $self->{core_data}, $offset ) );
 
-    return (
-        ( $deciseconds / 10 ),
-        ( ( $deciseconds % 10 ) * 100_000_000 ),
-    );
+    my $seconds     = int( $deciseconds / 10 );
+    my $nanoseconds = int( ( $deciseconds - $seconds * 10 ) * 100_000_000 );
+
+    return ( $seconds, $nanoseconds );
 }
 
 sub cmp_id {

--- a/t/12-bigint-fallback.t
+++ b/t/12-bigint-fallback.t
@@ -45,6 +45,44 @@ subtest 'fallback path returns plain scalars (no blessed Math::BigInt)' =>
     }
   };
 
+subtest 'fallback path returns correct 36-bit timestamp values' => sub {
+
+    # Regression for CPAN Testers report 3e3e8fca-4988-11f1-843a-...
+    # on armv6l-linux (Perl 5.42.2 with use64bitint=undef, ivsize=4).
+    #
+    # TCF v2 stores Created/LastUpdated as a 36-bit deciseconds-since-epoch
+    # field, which doesn't fit in a 32-bit signed IV.  When the BigInt
+    # fallback is in use, get_uint36 returns the value as an NV via
+    # Math::BigInt->numify -- but the file-level `use integer` in
+    # GDPR::IAB::TCFv2 was forcing the subsequent `/ 10` and `% 10` to
+    # coerce that NV back to a 32-bit IV, overflowing and producing
+    # `created => 0` and `nanoseconds => -100000000` on armv6l.
+    #
+    # This subtest forces the fallback path on every Perl so the bug is
+    # caught on 64-bit smokers too.
+
+    local $GDPR::IAB::TCFv2::BitUtils::CAN_PACK_QUADS       = 0;
+    local $GDPR::IAB::TCFv2::BitUtils::CAN_FORCE_BIG_ENDIAN = 0;
+
+    my $consent = GDPR::IAB::TCFv2->Parse($tc_string);
+
+    is $consent->created, 1228644257,
+      'created returns the correct epoch in scalar context';
+    is $consent->last_updated, 1326215413,
+      'last_updated returns the correct epoch in scalar context';
+
+    {
+        my ( $sec, $nsec ) = $consent->created;
+        is $sec,  1228644257, 'created seconds in list context';
+        is $nsec, 700000000,  'created nanoseconds in list context';
+    }
+    {
+        my ( $sec, $nsec ) = $consent->last_updated;
+        is $sec,  1326215413, 'last_updated seconds in list context';
+        is $nsec, 400000000,  'last_updated nanoseconds in list context';
+    }
+};
+
 subtest 'fallback values JSON-encode without convert_blessed' => sub {
     local $GDPR::IAB::TCFv2::BitUtils::CAN_PACK_QUADS       = 0;
     local $GDPR::IAB::TCFv2::BitUtils::CAN_FORCE_BIG_ENDIAN = 0;


### PR DESCRIPTION
## Summary

CPAN Testers report [3e3e8fca-4988-...](https://matrix.perl-magpie.org/results/3e3e8fca-4988-11f1-843a-a5841c8b931a) flagged failures across `t/01-parse.t`, `t/02-json-bitfield.t`, `t/03-json-range.t`, and `t/07-golden.t` on an `armv6l-linux` smoker (Raspberry Pi class hardware, Perl 5.42.2 built with `use64bitint=undef, ivsize=4`).

The failures all centered on `created` / `last_updated` timestamps:

| Field | Got | Expected |
|---|---|---|
| `created` | `0` | `1228644257` |
| `(last_updated)[1]` (nanoseconds) | `-100000000` | `700000000` |

## Root cause

TCF v2 stores `Created` and `LastUpdated` as a **36-bit** field of deciseconds since epoch. A 2024 timestamp is ~1.7 × 10^10 deciseconds — 34 bits, well past the 31-bit ceiling of a signed 32-bit IV.

`BitUtils::get_uint36` already falls back to `Math::BigInt->new(...)->numify` when `pack 'Q>'` isn't available (which is the case on this build), and that returns the value as an NV (double) — fine, since 36 bits fits losslessly in NV's 53-bit mantissa.

The bug is in `_get_epoch`. The file-level `use integer` in `lib/GDPR/IAB/TCFv2.pm` makes `/` and `%` use C-integer semantics, which coerces the NV operand back to a 32-bit IV before the operation. That's where the overflow happens. The `-100000000` nanoseconds value is the smoking gun: it can only come from `(-1) * 100_000_000`, which means `% 10` was evaluated under C-integer semantics on a clamped float-to-int conversion.

## Fix

`no integer;` for the scope of `_get_epoch`, and reformulate the modulo as `($deciseconds - $seconds * 10) * 1e8` so the math stays in NV-land. `int()` lands the correct integer at the end without ever converting an out-of-range NV to a 32-bit IV.

## Test plan

- [x] New regression subtest in `t/12-bigint-fallback.t` forces `$CAN_PACK_QUADS = 0` and asserts spec-correct `created` / `last_updated` values in both scalar and list context. Catches the bug on 64-bit smokers too.
- [x] Full local suite passes (8275 tests, all 13 files green) on x86_64 Perl.
- [ ] Verify on a 32-bit smoker once a CPAN Testers report comes in for the next release.