### PR TITLE
test: assert CLI dump JSON structurally instead of by regex

### DIFF
--- a/t/09-predicates.t
+++ b/t/09-predicates.t
@@ -4,6 +4,17 @@ use Test::More;
 use GDPR::IAB::TCFv2;
 use File::Spec;
 
+eval { require JSON; 1 }
+  or eval { require JSON::PP; 1 }
+  or plan skip_all => 'JSON or JSON::PP required for this test';
+
+my $json_pkg = JSON->can('new') ? 'JSON' : 'JSON::PP';
+
+sub decode_json_str {
+    my $s = shift;
+    return eval { $json_pkg->new->utf8->decode($s) };
+}
+
 # Test TC strings
 my $tc_with_res = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA'
   ;    # Core + Restrictions
@@ -79,19 +90,23 @@ subtest 'CLI --vendor-id option' => sub {
     my $bin  = File::Spec->catfile( 'bin', 'iabtcfv2' );
     my $perl = $^X;
 
-    # Filter for vendor 1
-    # Vendor section should have "1":true
-    # Vendor section should NOT have "23":true (it was in original disclosed)
-    my $out = `$perl -Ilib $bin dump --vendor-id 1 $tc_full`;
+    # Filter for vendor 1.  Decoded structurally so the assertions don't
+    # depend on JSON key order, which varies by encoder, Perl version,
+    # and hash randomization (CPAN Testers report 4f448578-4978-... saw
+    # JSON::XS on Perl 5.32.1 emit a different key order than the
+    # previous regex assumed).
+    my $data = decode_json_str(`$perl -Ilib $bin dump --vendor-id 1 $tc_full`);
+    ok( $data, 'CLI emits valid JSON' )
+      or BAIL_OUT('--vendor-id output was not parseable JSON');
 
-    # Use a more flexible regex that doesn't choke on nested braces
-    like(
-        $out, qr/"vendor":\{.*"consents":\{"1":true\}/s,
-        'CLI isolated vendor consents'
+    is_deeply(
+        [ sort { $a <=> $b } keys %{ $data->{vendor}{consents} || {} } ],
+        [1],
+        'CLI isolated vendor consents to vendor 1 only'
     );
-    unlike(
-        $out, qr/"disclosed":\{[^}]*"23":true/,
-        'CLI removed other disclosed vendors'
+    ok( $data->{vendor}{consents}{1}, 'vendor 1 consent is true' );
+    ok( !exists $data->{vendor}{disclosed}{23},
+        'CLI removed other disclosed vendors (vendor 23 not in disclosed)'
     );
 
     # Regression: lowercase short -v must be parsed as --vendor-id by the
@@ -104,8 +119,12 @@ subtest 'CLI --vendor-id option' => sub {
         $out_short, qr/^iabtcfv2 version/,
         'short -v is not shadowed by the global -V/--version'
     );
-    like(
-        $out_short, qr/"vendor":\{.*"consents":\{"1":true\}/s,
+    my $data_short = decode_json_str($out_short);
+    ok( $data_short, 'short -v emits valid JSON' )
+      or BAIL_OUT('-v output was not parseable JSON');
+    is_deeply(
+        $data_short->{vendor}{consents},
+        $data->{vendor}{consents},
         'short -v isolates the same vendor as --vendor-id'
     );
 };


### PR DESCRIPTION
## Summary

CPAN Testers report [4f448578-4978-...](https://www.cpantesters.org/cpan/report/4f448578-4978-11f1-9737-f43e6e8775ea) (x86_64-linux-thread-multi, Perl 5.32.1, Amazon Linux 2) flagged `t/09-predicates.t` ▸ `CLI --vendor-id option` ▸ test 4 (`CLI isolated vendor consents`).

The assertion was a regex over the encoded JSON:

```perl
like( $out, qr/"vendor":\{.*"consents":\{"1":true\}/s, ... );
```

That implicitly required the encoder to emit `vendor` before any other top-level key carrying a `consents` block, AND vendor `1` to be the first key inside `vendor.consents`. Both are key-order assumptions, and JSON object key order is non-deterministic — it varies across:

- JSON encoder (`JSON::XS` vs `JSON::PP`)
- Perl version (hash randomization differs)
- Hash size and bucket-split history

Slaven Rezic's smoker on Perl 5.32.1 happened to emit a different order and the regex didn't match.

## Fix

Replace every regex-on-JSON assertion in the `CLI --vendor-id option` subtest with a structural check after decoding the output:

| Before | After |
|---|---|
| `like(qr/"vendor":\{.*"consents":\{"1":true\}/s)` | `is_deeply([keys vendor.consents], [1])` + `ok($data->{vendor}{consents}{1})` |
| `unlike(qr/"disclosed":\{[^}]*"23":true/)` | `ok( !exists $data->{vendor}{disclosed}{23} )` |
| Same regex for short `-v` | `is_deeply` between the long- and short-form invocations |

The remaining `unlike(qr/^iabtcfv2 version/, ...)` line stays as a regex — it's checking plain-text output (the CLI's version banner), not JSON.

JSON loading uses the same pattern as `t/10-cli-iabtcfv2.t`: try `JSON`, fall back to `JSON::PP`, `plan skip_all` if neither is available.

## Audit

I swept `t/` for any other `qr/"…":/`-style patterns. The remaining hits are all order-independent (just looking for `"key":value` somewhere in the output, no positional assumptions about siblings) and don't need changes:

- `t/09-predicates.t:122` — `qr/"tc_string":/i`
- `t/10-cli-iabtcfv2.t:37` — `qr/"version"\s*:\s*2/`
- `t/12-bigint-fallback.t:67,69` — `qr/"cmp_id"\s*:\s*\d+/` etc.

## Test plan

- [x] `prove -lv t/09-predicates.t` — 5 subtests pass, the `CLI --vendor-id option` subtest now has 7 ok lines (up from 4) and asserts the same things more precisely.
- [x] Full local suite passes (8274 tests, 12 files).
- [ ] Confirm on the next CPAN Testers cycle on the same smoker that the failure is resolved.