### PR TITLE
feat(constants): TCF v2.3 spec-aligned long-form aliases

### DIFF
--- a/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
@@ -84,6 +84,9 @@ our %EXPORT_TAGS = ( all => \@EXPORT_OK );
 1;
 
 __END__
+
+=encoding utf8
+
 =head1 NAME
 
 GDPR::IAB::TCFv2::Constants::Purpose - TCF v2.3 purposes

--- a/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
@@ -6,6 +6,9 @@ require Exporter;
 use base qw<Exporter>;
 
 use constant {
+
+    # Short, established names -- supported indefinitely.  Used by examples
+    # and tests across the distribution.
     InfoStorageAccess        => 1,
     BasicAdserving           => 2,
     PersonalizationProfile   => 3,
@@ -17,6 +20,22 @@ use constant {
     MarketResearch           => 9,
     DevelopImprove           => 10,
     SelectContent            => 11,
+
+    # TCF v2.3 spec-aligned long-form aliases (Phase 3).  Each name tracks
+    # the canonical wording from the IAB Global Vendor List JSON for the
+    # corresponding purpose.id.  Both names resolve to the same integer and
+    # are interchangeable everywhere a Purpose constant is accepted.
+    StoreAndOrAccessInformationOnDevice        => 1,
+    UseLimitedDataToSelectAdvertising          => 2,
+    CreateProfilesForPersonalisedAdvertising   => 3,
+    UseProfilesToSelectPersonalisedAdvertising => 4,
+    CreateProfilesToPersonaliseContent         => 5,
+    UseProfilesToSelectPersonalisedContent     => 6,
+    MeasureAdvertisingPerformance              => 7,
+    MeasureContentPerformance                  => 8,
+    UnderstandAudiences                        => 9,
+    DevelopAndImproveServices                  => 10,
+    UseLimitedDataToSelectContent              => 11,
 };
 
 use constant PurposeDescription => {
@@ -47,6 +66,17 @@ our @EXPORT_OK = qw<
   MarketResearch
   DevelopImprove
   SelectContent
+  StoreAndOrAccessInformationOnDevice
+  UseLimitedDataToSelectAdvertising
+  CreateProfilesForPersonalisedAdvertising
+  UseProfilesToSelectPersonalisedAdvertising
+  CreateProfilesToPersonaliseContent
+  UseProfilesToSelectPersonalisedContent
+  MeasureAdvertisingPerformance
+  MeasureContentPerformance
+  UnderstandAudiences
+  DevelopAndImproveServices
+  UseLimitedDataToSelectContent
   PurposeDescription
 >;
 our %EXPORT_TAGS = ( all => \@EXPORT_OK );
@@ -302,3 +332,72 @@ A sports news mobile app has started a new section of articles covering the most
 =head2 PurposeDescription
 
 Returns a hashref with a mapping between all purpose ids and their description.
+
+=head1 NAME ALIASES
+
+In addition to the short names documented above, every purpose is also
+exported under a long-form alias that tracks the canonical wording of the
+IAB Global Vendor List for TCF v2.3. Both names resolve to the same integer
+and may be used interchangeably anywhere a Purpose constant is accepted
+(C<is_purpose_consent_allowed>, C<is_vendor_consent_allowed>, etc.).
+
+    use GDPR::IAB::TCFv2::Constants::Purpose qw<:all>;
+
+    # Equivalent:
+    $consent->is_purpose_consent_allowed( InfoStorageAccess );
+    $consent->is_purpose_consent_allowed( StoreAndOrAccessInformationOnDevice );
+
+The full mapping:
+
+=over 4
+
+=item *
+
+C<InfoStorageAccess> — C<StoreAndOrAccessInformationOnDevice> (id 1)
+
+=item *
+
+C<BasicAdserving> — C<UseLimitedDataToSelectAdvertising> (id 2)
+
+=item *
+
+C<PersonalizationProfile> — C<CreateProfilesForPersonalisedAdvertising> (id 3)
+
+=item *
+
+C<PersonalizationSelection> — C<UseProfilesToSelectPersonalisedAdvertising> (id 4)
+
+=item *
+
+C<ContentProfile> — C<CreateProfilesToPersonaliseContent> (id 5)
+
+=item *
+
+C<ContentSelection> — C<UseProfilesToSelectPersonalisedContent> (id 6)
+
+=item *
+
+C<AdPerformance> — C<MeasureAdvertisingPerformance> (id 7)
+
+=item *
+
+C<ContentPerformance> — C<MeasureContentPerformance> (id 8)
+
+=item *
+
+C<MarketResearch> — C<UnderstandAudiences> (id 9)
+
+=item *
+
+C<DevelopImprove> — C<DevelopAndImproveServices> (id 10)
+
+=item *
+
+C<SelectContent> — C<UseLimitedDataToSelectContent> (id 11)
+
+=back
+
+The short names are the historical established forms and are supported
+indefinitely. The long-form aliases are provided for callers who prefer
+to mirror the IAB spec wording verbatim (e.g. when generating policy
+documents or audit logs).

--- a/lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
@@ -6,8 +6,14 @@ require Exporter;
 use base qw<Exporter>;
 
 use constant {
+
+    # Short, established names -- supported indefinitely.
     Geolocation => 1,
-    DeviceScan  => 2
+    DeviceScan  => 2,
+
+    # TCF v2.3 spec-aligned long-form aliases (Phase 3).
+    UsePreciseGeolocationData                          => 1,
+    ActivelyScanDeviceCharacteristicsForIdentification => 2,
 };
 
 use constant SpecialFeatureDescription => {
@@ -18,6 +24,8 @@ use constant SpecialFeatureDescription => {
 our @EXPORT_OK = qw<
   Geolocation
   DeviceScan
+  UsePreciseGeolocationData
+  ActivelyScanDeviceCharacteristicsForIdentification
   SpecialFeatureDescription
 >;
 
@@ -66,3 +74,22 @@ With your acceptance, certain characteristics specific to your device might be r
 =head2 SpecialFeatureDescription
 
 Returns a hashref with a mapping between all restriction types and their description.
+
+=head1 NAME ALIASES
+
+Both special features are also exported under long-form aliases that mirror
+the IAB Global Vendor List wording for TCF v2.3:
+
+=over 4
+
+=item *
+
+C<Geolocation> — C<UsePreciseGeolocationData> (id 1)
+
+=item *
+
+C<DeviceScan> — C<ActivelyScanDeviceCharacteristicsForIdentification> (id 2)
+
+=back
+
+Both names resolve to the same integer and are interchangeable.

--- a/lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
@@ -35,6 +35,8 @@ our %EXPORT_TAGS = ( all => \@EXPORT_OK );
 
 __END__
 
+=encoding utf8
+
 =head1 NAME
 
 GDPR::IAB::TCFv2::Constants::SpecialFeature - TCF v2.3 special features

--- a/t/13-constants-aliases.t
+++ b/t/13-constants-aliases.t
@@ -1,0 +1,70 @@
+use strict;
+use warnings;
+use Test::More;
+
+# Phase 3: TCF v2.3 spec-aligned long-form aliases for the established
+# short-form Purpose and SpecialFeature constants.  Both names must
+# resolve to the same integer and must be exported via :all.
+
+use GDPR::IAB::TCFv2::Constants::Purpose        qw<:all>;
+use GDPR::IAB::TCFv2::Constants::SpecialFeature qw<:all>;
+
+subtest 'Purpose aliases resolve to the canonical integers' => sub {
+
+    # Use parens on the LHS to force constant-call interpretation; the fat
+    # comma `=>` would otherwise auto-quote the bareword to a string.
+    my @pairs = (
+        [ InfoStorageAccess(), StoreAndOrAccessInformationOnDevice() ],
+        [ BasicAdserving(),    UseLimitedDataToSelectAdvertising() ],
+        [   PersonalizationProfile(),
+            CreateProfilesForPersonalisedAdvertising()
+        ],
+        [   PersonalizationSelection(),
+            UseProfilesToSelectPersonalisedAdvertising()
+        ],
+        [ ContentProfile(),     CreateProfilesToPersonaliseContent() ],
+        [ ContentSelection(),   UseProfilesToSelectPersonalisedContent() ],
+        [ AdPerformance(),      MeasureAdvertisingPerformance() ],
+        [ ContentPerformance(), MeasureContentPerformance() ],
+        [ MarketResearch(),     UnderstandAudiences() ],
+        [ DevelopImprove(),     DevelopAndImproveServices() ],
+        [ SelectContent(),      UseLimitedDataToSelectContent() ],
+    );
+
+    for my $pair (@pairs) {
+        is( $pair->[0], $pair->[1],
+            "Purpose alias resolves to id $pair->[0]"
+        );
+    }
+    is( scalar @pairs, 11, 'all 11 purposes have an alias' );
+};
+
+subtest 'SpecialFeature aliases resolve to the canonical integers' => sub {
+    is( Geolocation, UsePreciseGeolocationData(),
+        'SpecialFeature 1 alias resolves to id 1'
+    );
+    is( DeviceScan, ActivelyScanDeviceCharacteristicsForIdentification(),
+        'SpecialFeature 2 alias resolves to id 2'
+    );
+};
+
+subtest 'aliases work as drop-in replacements in the parser API' => sub {
+    require GDPR::IAB::TCFv2;
+
+    my $tc_string =
+      'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA';
+    my $consent = GDPR::IAB::TCFv2->Parse($tc_string);
+
+    # Whatever the consent says about purpose 1, both names must agree.
+    is( !!$consent->is_purpose_consent_allowed(InfoStorageAccess),
+        !!$consent->is_purpose_consent_allowed(
+            StoreAndOrAccessInformationOnDevice),
+        'is_purpose_consent_allowed accepts the alias for purpose 1'
+    );
+    is( !!$consent->is_special_feature_opt_in(Geolocation),
+        !!$consent->is_special_feature_opt_in(UsePreciseGeolocationData),
+        'is_special_feature_opt_in accepts the alias for special feature 1'
+    );
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

**Phase 3** of the TODO roadmap — "Alignment & Cleanup". Adds long-form aliases for every `Purpose` and `SpecialFeature` constant that mirror the canonical IAB Global Vendor List wording for TCF v2.3. Existing short names remain the established working forms and are supported indefinitely.

## Why this PR (and not #36)

The original Phase 3 PR (#36) was authored 38 commits behind current `devel`, predates the v0.370 Validator release, and would silently revert recent production work in \`Validator.pm\` and the corpus. Of its claimed v2.3 alignment changes, only **one constant rename** (purpose 11) was substantive — the other changes were either noise or actual *regressions* from v2.3 spec wording back to v2.0 wording.

This PR cherry-picks the legitimate intent (spec alignment) and broadens it: every purpose and special feature gets a long-form alias, no rename, no breaking change. Recommend closing #36 in favor of this.

## Mapping

| ID | Short (existing) | Long (new alias) |
|---|---|---|
| 1 | InfoStorageAccess | StoreAndOrAccessInformationOnDevice |
| 2 | BasicAdserving | UseLimitedDataToSelectAdvertising |
| 3 | PersonalizationProfile | CreateProfilesForPersonalisedAdvertising |
| 4 | PersonalizationSelection | UseProfilesToSelectPersonalisedAdvertising |
| 5 | ContentProfile | CreateProfilesToPersonaliseContent |
| 6 | ContentSelection | UseProfilesToSelectPersonalisedContent |
| 7 | AdPerformance | MeasureAdvertisingPerformance |
| 8 | ContentPerformance | MeasureContentPerformance |
| 9 | MarketResearch | UnderstandAudiences |
| 10 | DevelopImprove | DevelopAndImproveServices |
| 11 | SelectContent | UseLimitedDataToSelectContent |

| ID | Short | Long |
|---|---|---|
| 1 | Geolocation | UsePreciseGeolocationData |
| 2 | DeviceScan | ActivelyScanDeviceCharacteristicsForIdentification |

`RestrictionType` is unchanged — its existing names (`NotAllowed`, `RequireConsent`, `RequireLegitimateInterest`) already match the spec verbatim.

## Backward compatibility

Zero impact on existing callers. Every previously-exported name is still exported and still resolves to the same integer. The new aliases are additive.

## Test plan

- [x] New `t/13-constants-aliases.t` exercises every alias against its canonical counterpart, plus a drop-in equivalence check via the parser API (`is_purpose_consent_allowed`, `is_special_feature_opt_in`).
- [x] Full suite passes (16533 tests across 17 files in `t/`, plus `xt/critic.t` and `xt/tidy.t`).

## Followups

PR #36 should be closed with a comment pointing to this one.