### PR TITLE
chore(cli): remove --json-array; JSONL is enough

### DIFF
--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -70,7 +70,6 @@ sub run_dump {
     my @args = @_;
     my %opts = (
         pretty             => 0,
-        'json-array'       => 0,
         compact            => 0,
         'ignore-errors'    => 0,
         'fail-fast'        => 0,
@@ -84,7 +83,6 @@ sub run_dump {
     GetOptionsFromArray(
         \@args,
         'pretty|p'           => \$opts{pretty},
-        'json-array'         => \$opts{'json-array'},
         'compact|c'          => \$opts{compact},
         'ignore-errors|i'    => \$opts{'ignore-errors'},
         'fail-fast|f'        => \$opts{'fail-fast'},
@@ -111,9 +109,6 @@ sub run_dump {
         $json->pretty(1);
         $json->indent_length(4) if $json->isa('JSON::PP');
     }
-    if ( $opts{'json-array'} && !$opts{'quiet'} ) {
-        print "[\n";
-    }
 
     my $state = {
         count    => 0,
@@ -134,11 +129,6 @@ sub run_dump {
             next unless $line =~ /\S/;
             _process_string( $line, $state, \%opts, $json );
         }
-    }
-
-
-    if ( $opts{'json-array'} && !$opts{'quiet'} ) {
-        print "\n]\n";
     }
 
     exit EXIT_SUCCESS;
@@ -188,23 +178,9 @@ sub _process_string {
 
     return if $o->{'quiet'};
 
-    my $out = $j->encode($output_data);
-
-    if ( $o->{'json-array'} ) {
-        print ",\n" if $state->{count} > 0;
-        print $o->{pretty} ? _indent($out) : $out;
-    }
-    else {
-        print "$out\n";
-    }
+    print $j->encode($output_data) . "\n";
 
     $state->{count}++;
-}
-
-sub _indent {
-    my $text = shift;
-    $text =~ s/^/    /mg;
-    return $text;
 }
 
 sub _show_help {
@@ -238,7 +214,6 @@ sub run_validate {
     my @args = @_;
     my %opts = (
         pretty                         => 0,
-        'json-array'                   => 0,
         'ignore-errors'                => 0,
         'fail-fast'                    => 0,
         'errors-to-stderr'             => 0,
@@ -258,7 +233,6 @@ sub run_validate {
     GetOptionsFromArray(
         \@args,
         'pretty|p'                         => \$opts{pretty},
-        'json-array'                       => \$opts{'json-array'},
         'ignore-errors|i'                  => \$opts{'ignore-errors'},
         'fail-fast|f'                      => \$opts{'fail-fast'},
         'errors-to-stderr|e'               => \$opts{'errors-to-stderr'},
@@ -288,14 +262,6 @@ sub run_validate {
 
     unless ( defined $opts{'vendor-id'} ) {
         warn "validate: --vendor-id|-v is required\n";
-        pod2usage(
-            -input    => $script_path, -exitval => 2, -verbose => 99,
-            -sections => "VALIDATE|BUGS"
-        );
-    }
-
-    if ( $opts{'json-array'} && $opts{text} ) {
-        warn "validate: --text and --json-array are mutually exclusive\n";
         pod2usage(
             -input    => $script_path, -exitval => 2, -verbose => 99,
             -sections => "VALIDATE|BUGS"
@@ -333,11 +299,6 @@ sub run_validate {
         $json->indent_length(4) if $json->isa('JSON::PP');
     }
 
-    my $array_brackets =
-      $opts{'json-array'} && !$opts{quiet} && !$opts{text};
-
-    print "[\n" if $array_brackets;
-
     my $state = {
         count    => 0,
         line_num => 0,
@@ -359,8 +320,6 @@ sub run_validate {
             _validate_string( $line, $state, \%opts, $json, $validator );
         }
     }
-
-    print "\n]\n" if $array_brackets;
 
     exit( $state->{any_fail} ? EXIT_PARSE_ERROR : EXIT_SUCCESS );
 }
@@ -434,10 +393,7 @@ sub _validate_string {
 
     _emit_validate( $output_data, $state, $o, $j );
 
-    if ( !$result->is_valid && $o->{'fail-fast'} ) {
-        print "\n]\n" if $o->{'json-array'} && !$o->{text};
-        exit EXIT_PARSE_ERROR;
-    }
+    exit EXIT_PARSE_ERROR if !$result->is_valid && $o->{'fail-fast'};
 
     return;
 }
@@ -474,15 +430,7 @@ sub _emit_validate {
         return;
     }
 
-    my $out = $j->encode($output_data);
-
-    if ( $o->{'json-array'} ) {
-        print ",\n" if $state->{count} > 0;
-        print $o->{pretty} ? _indent($out) : $out;
-    }
-    else {
-        print "$out\n";
-    }
+    print $j->encode($output_data) . "\n";
     $state->{count}++;
 
     return;
@@ -545,10 +493,6 @@ Parses TC strings and outputs them as JSON.
 
 Output human-readable, indented JSON.
 
-=item B<--json-array>
-
-Output a single JSON array containing all parsed objects.
-
 =item B<--compact>, B<-c>
 
 Output a compact JSON representation (lists of IDs instead of boolean maps).
@@ -593,11 +537,14 @@ checks. Combine with C<--enable-warnings> if you want diagnostics on B<STDERR>.
     # Dump a string to JSON line
     iabtcfv2 dump CPi...AAA
 
-    # Dump multiple strings to a pretty-printed JSON array
-    iabtcfv2 dump --pretty --json-array CPi...AAA CPj...BBB
+    # Dump multiple strings (one JSON object per line)
+    iabtcfv2 dump CPi...AAA CPj...BBB
 
     # Read from STDIN
-    cat strings.txt | iabtcfv2 dump --json-array
+    cat strings.txt | iabtcfv2 dump
+
+    # Pipe through `jq -s` if you need a single JSON array
+    cat strings.txt | iabtcfv2 dump | jq -s .
 
 =head2 Short option bundling
 
@@ -739,10 +686,6 @@ C<reasons> (array) instead of singular C<reason> (string).
 
 Output human-readable, indented JSON.
 
-=item B<--json-array>
-
-Output a single JSON array containing all validation records.
-
 =item B<--text>, B<-t>
 
 Output one human-readable line per TC string instead of JSON. Format:
@@ -752,7 +695,6 @@ Output one human-readable line per TC string instead of JSON. Format:
     ERROR  <tc>: <parse error>
 
 In B<--all> mode, multi-reason failures span multiple indented lines.
-Mutually exclusive with C<--json-array>.
 
 =item B<--ignore-errors>, B<-i>
 
@@ -796,8 +738,7 @@ B<1> — at least one TC string failed validation or could not be parsed.
 
 =item *
 
-B<2> — bad CLI usage (missing C<--vendor-id>, incoherent purpose lists,
-mutually exclusive flags).
+B<2> — bad CLI usage (missing C<--vendor-id>, incoherent purpose lists).
 
 =back
 
@@ -812,8 +753,10 @@ mutually exclusive flags).
     # Pipeline-friendly: just the exit code
     if iabtcfv2 validate -q -v 32 -C 1,3 "$tc"; then ...
 
-    # Many strings as a single JSON array
-    iabtcfv2 validate -v 32 -C 1,3 --json-array CO...AAA CO...BBB
+    # Many strings as JSON Lines (one record per line); pipe through
+    # `jq -s` if you need a single JSON array.
+    iabtcfv2 validate -v 32 -C 1,3 CO...AAA CO...BBB
+    iabtcfv2 validate -v 32 -C 1,3 CO...AAA CO...BBB | jq -s .
 
 =head1 DESCRIPTION
 

--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -1145,8 +1145,11 @@ Parses TC strings and output them as JSON.
     # Pretty printed JSON
     iabtcfv2 dump --pretty "CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA"
 
-    # Stream multiple strings from STDIN to a JSON array
-    cat strings.txt | iabtcfv2 dump --json-array
+    # Stream multiple strings from STDIN as JSON Lines
+    cat strings.txt | iabtcfv2 dump
+
+    # Pipe through `jq -s` if you need a single JSON array
+    cat strings.txt | iabtcfv2 dump | jq -s .
 
     # Short flags can be bundled (the last bundled short may take a value)
     iabtcfv2 dump -pi "CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA"
@@ -1187,8 +1190,9 @@ valid, C<1> on any parse or validation failure, C<2> on bad CLI usage.
         echo "ok"
     fi
 
-    # Stream multiple strings from STDIN as a JSON array
-    cat strings.txt | iabtcfv2 validate -v 284 -C 1,3 --json-array
+    # Stream multiple strings from STDIN as JSON Lines (pipe through
+    # `jq -s` if you need a single JSON array)
+    cat strings.txt | iabtcfv2 validate -v 284 -C 1,3
 
 See C<iabtcfv2 --help> or C<perldoc iabtcfv2> for more details.
 

--- a/t/10-cli-iabtcfv2.t
+++ b/t/10-cli-iabtcfv2.t
@@ -49,12 +49,18 @@ is_deeply(
     "Short -p alias produces logically same output as --pretty"
 );
 
-# Test array output
-my $array_output = `$perl -Ilib $bin dump --json-array $tc_string $tc_string`;
-my $array_json   = decode_helper($array_output);
-ok( $array_json, "Output is valid JSON array" );
-is( ref($array_json),     'ARRAY', "Root is an array" );
-is( scalar(@$array_json), 2,       "Array contains two elements" );
+# Test JSON Lines output: dumping multiple strings emits one JSON object
+# per line (the `--json-array` flag was removed; `jq -s .` does the wrap).
+my $multi_output = `$perl -Ilib $bin dump $tc_string $tc_string`;
+my @multi_lines  = grep {/\S/} split /\n/, $multi_output;
+is( scalar @multi_lines, 2, "Two TC strings yield two output lines" );
+for my $i ( 0 .. $#multi_lines ) {
+    my $obj = decode_helper( $multi_lines[$i] );
+    ok( $obj && ref($obj) eq 'HASH',
+        "Line " . ( $i + 1 ) . " is a JSON object"
+    );
+    is( $obj->{version}, 2, "Line " . ( $i + 1 ) . " parsed as version 2" );
+}
 
 # Test STDIN (using Perl to avoid shell-specific echo/heredoc issues)
 my $stdin_output = `$perl -e "print '$tc_string'" | $perl -Ilib $bin dump`;
@@ -126,11 +132,8 @@ subtest 'Help System' => sub {
     my $dump_help = `$perl -Ilib $bin dump --help`;
     like( $dump_help, qr/DUMP/i,      "Subcommand help header found" );
     like( $dump_help, qr/--compact/i, "Subcommand help lists --compact" );
-    like(
-        $dump_help, qr/--json-array/i,
-        "Subcommand help lists --json-array"
-    );
-    like( $dump_help, qr/Examples/i, "Subcommand help shows examples" );
+    like( $dump_help, qr/--pretty/i,  "Subcommand help lists --pretty" );
+    like( $dump_help, qr/Examples/i,  "Subcommand help shows examples" );
 
     # 3. Help Subcommand
     my $help_cmd = `$perl -Ilib $bin help dump`;


### PR DESCRIPTION
## Summary

Removes the `--json-array` flag from both `iabtcfv2 dump` and `iabtcfv2 validate`. The default JSON Lines output (one JSON object per line) is the universal interchange format — every text-processing tool reads it directly, and `jq -s .` wraps it into a single JSON array when callers actually need that shape.

## Why

Carrying `--json-array` meant carrying state-tracking code in both subcommands:

- opening / closing brackets gated on `--quiet` / `--text` / `--fail-fast` combinations,
- comma injection between records,
- a dead `_indent` helper (only used inside the array-pretty branch),
- a mutual-exclusion check between `--text` and `--json-array` in validate.

All of that goes. The per-record print now reduces to one line:

```perl
print $j->encode($output_data) . "\n";
```

Net diff: **+36 / -86** across 3 files.

## Migration

```diff
- iabtcfv2 dump --json-array tc1 tc2 tc3
+ iabtcfv2 dump tc1 tc2 tc3 | jq -s .
```

POD examples updated to show the `jq -s .` pipeline.

## Breaking change disclosure

This is a CLI-level breaking change three commits after v0.370 shipped. Mitigated by:
- the migration is a single shell pipe (`| jq -s .`),
- JSON Lines is *more* useful in practice for streaming pipelines (you can react to records as they arrive instead of waiting for the closing `]`),
- `--json-array`'s comma-tracking + bracket emission was a recurring source of edge cases (e.g. needing the `if !$o->{quiet} && !$o->{text}` guard everywhere).

Worth a CHANGELOG / release-notes line: "BREAKING: `iabtcfv2 dump --json-array` and `iabtcfv2 validate --json-array` removed. Use `... | jq -s .` instead."

## Test plan

- [x] Removed the `--json-array` functional test in `t/10-cli-iabtcfv2.t`; replaced with a JSONL-shape assertion (multi-string invocation → multiple newline-separated JSON objects, each parseable).
- [x] Help-text assertion for `--json-array` swapped for `--pretty`.
- [x] Full suite passes: 16536 tests across 17 files in `t/`, plus `xt/critic.t` and `xt/tidy.t`.
- [x] Smoke-tested locally: `dump`, `dump | jq -s .`, `validate`, all behave as expected.