### PR TITLE
feat(validator): Validator::Reason module (Phase 6.1)

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -15,6 +15,7 @@ lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm
 lib/GDPR/IAB/TCFv2/PublisherTC.pm
 lib/GDPR/IAB/TCFv2/RangeSection.pm
 lib/GDPR/IAB/TCFv2/Validator.pm
+lib/GDPR/IAB/TCFv2/Validator/Reason.pm
 lib/GDPR/IAB/TCFv2/Validator/Result.pm
 LICENSE
 Makefile.PL
@@ -35,6 +36,7 @@ t/10-cli-iabtcfv2.t
 t/12-bigint-fallback.t
 t/13-constants-aliases.t
 t/14-cmp-validator.t
+t/15-validator-reason.t
 t/90-bugs.t
 t/99-pod.t
 t/corpus/cmp-list.json

--- a/TODO.md
+++ b/TODO.md
@@ -58,7 +58,20 @@
     *   **Tests:** use fixed reference dates so the `deletedDate` / staleness checks are deterministic across execution environments.
 *   **Reference:** PR [#38](https://github.com/peczenyj/GDPR-IAB-TCFv2/pull/38) (`feat/phase-5-cmp-validator`, currently OPEN).
 
-## Phase 6: GVL-Aware Validator
+## Phase 6: Structured Failure Reporting
+*   **Goal:** Bring the Validator's failure-reporting model to parity with the Go `lib-gdpr/validator` package: stable machine-readable codes, structured failure objects, and distinct reasons for each failure mode. Sets the data model for every later phase that introduces new validation rules.
+*   **Depends on:** Phase 2 (Validator Interface).
+*   **Tasks:**
+    *   **6.1 — `Validator::Reason` module:** Create `GDPR::IAB::TCFv2::Validator::Reason` with integer `REASON_*` constants (mirror Go's `code.go` enum: `REASON_NONE`, `REASON_VENDOR_NOT_ALLOWED`, `REASON_VENDOR_NOT_DISCLOSED`, `REASON_PURPOSE_NOT_ALLOWED`, `REASON_VENDOR_NOT_ALLOWED_CONSENT`, `REASON_VENDOR_NOT_ALLOWED_LEGITIMATE_INTEREST`, `REASON_PUBLISHER_RESTRICTION_NOT_ALLOWED`, `REASON_PUBLISHER_RESTRICTION_REQUIRE_CONSENT`, `REASON_PUBLISHER_RESTRICTION_REQUIRE_LEGITIMATE_INTEREST`, `REASON_LEGITIMATE_INTEREST_NOT_PERMITTED_FOR_PURPOSE`, `REASON_POLICY_VERSION_TOO_LOW`, `REASON_MISSING_DISCLOSED_VENDORS`, `REASON_DECODE_ERROR`). Export under `:all`. Provide `reason_string($code)` helper.
+    *   **6.2 — `Validator::Failure` value object + `Result` extension:** Lightweight object with `code`, `message`, `purpose_id`, `vendor_id`, `restriction_type`. Extend `Validator::Result` with `failures()` and `reason_codes()` accessors. `reasons()` and the `bool` / `""` overloads stay back-compatible.
+    *   **6.3 — TCF carve-out reason:** Detect Purpose 1 LI (always) and Purposes 3-6 LI on policy ≥ 4 in the Validator and emit `REASON_LEGITIMATE_INTEREST_NOT_PERMITTED_FOR_PURPOSE` directly instead of the generic "not allowed (legitimate interest)".
+    *   **6.4 — Distinct publisher-restriction reasons:** Have the Validator inspect publisher restrictions itself before delegating to `is_vendor_*_allowed`, so each restriction-type failure surfaces its own reason. Refines the human-readable strings on `reasons()` output (note in `Changes`).
+    *   **6.5 — Per-call list overrides:** Allow `validate(..., consent_purpose_ids => [...], legitimate_interest_purpose_ids => [...], flexible_purpose_ids => [...])`. Coherence enforced silently by orphan-drop at runtime (constructor-time still croaks). Empty `[]` distinct from omitted key.
+    *   **(Follow-up, non-blocking):** Migrate `CMPValidator` (Phase 5) to emit `Validator::Failure` objects with a `REASON_CMP_*` family (`REASON_INVALID_CMP`, `REASON_CMP_DELETED`, `REASON_CMP_UNKNOWN`).
+    *   **Tests:** `t/15-validator-reason.t` (round-trip codes), `t/16-validator-failures.t` (table-driven matrix mirroring the Go `validator_strict_internal_test.go`: list membership × flex flag × restriction type × policy version), per-call-override tests.
+*   **Versioning:** ships as **v0.400**.
+
+## Phase 7: GVL-Aware Validator
 *   **Goal:** Bridge the IAB Global Vendor List schema to the Phase 2 validator so callers do not have to translate vendor entries by hand.
 *   **Depends on:** Phase 2 (Validator Interface).
 *   **Tasks:**
@@ -68,17 +81,17 @@
     *   CLI integration: `iabtcfv2 validate --gvl path/to/gvl.json -v 32 ...` derives the purpose lists from the GVL entry instead of requiring `-C` / `-L` / `-F` on the command line.
     *   **Tests:** golden GVL fixture covering vendors with and without flexible purposes; round-trip `from_gvl_vendor_entry` against a hand-crafted entry.
 
-## Phase 7: Features, Special Features, and Special Purposes
+## Phase 8: Features, Special Features, and Special Purposes
 *   **Goal:** Extend the validator beyond standard purposes to cover the rest of the TCF taxonomy.
-*   **Depends on:** Phase 2 (Validator Interface).
+*   **Depends on:** Phase 2 (Validator Interface), Phase 6 (Structured Failure Reporting — new rules emit `REASON_*` codes from day one).
 *   **Tasks:**
     *   Validator support for **Special Features** (opt-in, e.g. precise geolocation): require the bit to be set in the TC string when listed.
-    *   Validator support for **Features** (vendor-declared): no consent required, but cross-check that the vendor declares the feature in the GVL once Phase 6 lands.
+    *   Validator support for **Features** (vendor-declared): no consent required, but cross-check that the vendor declares the feature in the GVL once Phase 7 lands.
     *   Validator support for **Special Purposes**: legitimate-interest-only by spec; check vendor declaration without requiring a consent bit.
     *   Surface these on the CLI as `--special-features`, `--features`, `--special-purposes` (comma-separated, same shape as `-C` / `-L`).
     *   **Tests:** extend `t/06-validator.t` with subtests per category; add CLI subtests in `t/10-cli-iabtcfv2.t`.
 
-## Phase 8: CLI Configuration Loading
+## Phase 9: CLI Configuration Loading
 *   **Goal:** Reduce boilerplate on the command line by letting common flags come from the environment or a config file.
 *   **Tasks:**
     *   Map a curated set of environment variables to CLI flags (e.g. `IABTCFV2_VENDOR_ID`, `IABTCFV2_CONSENT_PURPOSES`, `IABTCFV2_LEGITIMATE_INTEREST_PURPOSES`, `IABTCFV2_FLEXIBLE_PURPOSES`, `IABTCFV2_MIN_POLICY_VERSION`). Explicit CLI flags always win.

--- a/lib/GDPR/IAB/TCFv2/Validator/Reason.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Reason.pm
@@ -1,0 +1,257 @@
+package GDPR::IAB::TCFv2::Validator::Reason;
+use strict;
+use warnings;
+
+require Exporter;
+use base qw<Exporter>;
+
+use constant {
+
+    # Successful validation: no failure to report.
+    ReasonNone => 0,
+
+    # The TCF string is missing the mandatory disclosed vendors segment
+    # (TCF v2.2+ requirement).
+    ReasonMissingDisclosedVendors => 1,
+
+    # The configured vendor ID is not present in the disclosed vendors
+    # segment.
+    ReasonVendorNotDisclosed => 2,
+
+    # The vendor is not allowed globally (neither consent nor legitimate
+    # interest is granted for any purpose).
+    ReasonVendorNotAllowed => 3,
+
+    # A required purpose is not allowed for the vendor.
+    ReasonPurposeNotAllowed => 4,
+
+    # A publisher restriction of type 0 (Not Allowed) is present for a
+    # required purpose.
+    ReasonPublisherRestrictionNotAllowed => 5,
+
+    # A publisher restriction of type 1 (Requires Consent) is present
+    # for a purpose configured under the legitimate-interest legal basis.
+    ReasonPublisherRestrictionRequireConsent => 6,
+
+    # A publisher restriction of type 2 (Requires Legitimate Interest) is
+    # present for a purpose configured under the consent legal basis.
+    ReasonPublisherRestrictionRequireLegitimateInterest => 7,
+
+    # The vendor is not allowed for a specific purpose under the consent
+    # legal basis (vendor consent flag and/or purpose consent flag missing).
+    ReasonVendorNotAllowedConsent => 8,
+
+    # The vendor is not allowed for a specific purpose under the legitimate
+    # interest legal basis (vendor LI flag and/or purpose LI flag missing).
+    ReasonVendorNotAllowedLegitimateInterest => 9,
+
+    # The TCF spec forbids the legitimate-interest legal basis for this
+    # purpose: Purpose 1 always; Purposes 3-6 on TcfPolicyVersion >= 4.
+    ReasonLegitimateInterestNotPermittedForPurpose => 10,
+
+    # The consent string's TcfPolicyVersion is below the validator's
+    # configured minimum.
+    ReasonPolicyVersionTooLow => 11,
+
+    # The consent string could not be decoded (malformed, empty, or
+    # unsupported version). Only emitted when explicitly requested.
+    ReasonDecodeError => 12,
+};
+
+use constant ReasonDescription => {
+    ReasonNone                           => "no failure",
+    ReasonMissingDisclosedVendors        => "missing disclosed vendors",
+    ReasonVendorNotDisclosed             => "vendor not disclosed",
+    ReasonVendorNotAllowed               => "vendor not allowed",
+    ReasonPurposeNotAllowed              => "purpose not allowed",
+    ReasonPublisherRestrictionNotAllowed =>
+      "publisher restriction: not allowed",
+    ReasonPublisherRestrictionRequireConsent =>
+      "publisher restriction: requires consent",
+    ReasonPublisherRestrictionRequireLegitimateInterest =>
+      "publisher restriction: requires legitimate interest",
+    ReasonVendorNotAllowedConsent =>
+      "vendor not allowed for purpose (consent)",
+    ReasonVendorNotAllowedLegitimateInterest =>
+      "vendor not allowed for purpose (legitimate interest)",
+    ReasonLegitimateInterestNotPermittedForPurpose =>
+      "legitimate interest not permitted for purpose",
+    ReasonPolicyVersionTooLow => "tcf policy version too low",
+    ReasonDecodeError         => "decode error",
+};
+
+# Lazily built reverse map: integer code -> human-readable string.
+my %_CODE_TO_STRING;
+
+sub reason_string {
+    my ($code) = @_;
+
+    return "unknown validation failure" unless defined $code;
+
+    unless (%_CODE_TO_STRING) {
+        my $desc = ReasonDescription;
+        for my $name ( keys %{$desc} ) {
+            my $value = __PACKAGE__->can($name)->();
+            $_CODE_TO_STRING{$value} = $desc->{$name};
+        }
+    }
+
+    return $_CODE_TO_STRING{$code} // "unknown validation failure";
+}
+
+our @EXPORT_OK = qw<
+  ReasonNone
+  ReasonMissingDisclosedVendors
+  ReasonVendorNotDisclosed
+  ReasonVendorNotAllowed
+  ReasonPurposeNotAllowed
+  ReasonPublisherRestrictionNotAllowed
+  ReasonPublisherRestrictionRequireConsent
+  ReasonPublisherRestrictionRequireLegitimateInterest
+  ReasonVendorNotAllowedConsent
+  ReasonVendorNotAllowedLegitimateInterest
+  ReasonLegitimateInterestNotPermittedForPurpose
+  ReasonPolicyVersionTooLow
+  ReasonDecodeError
+  ReasonDescription
+  reason_string
+>;
+
+our %EXPORT_TAGS = ( all => \@EXPORT_OK );
+
+1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+GDPR::IAB::TCFv2::Validator::Reason - machine-readable validation-failure codes
+
+=head1 SYNOPSIS
+
+    use strict;
+    use warnings;
+
+    use GDPR::IAB::TCFv2::Validator::Reason qw<:all>;
+
+    use feature 'say';
+
+    say "Code is ", ReasonVendorNotDisclosed,
+        ", and it means ", reason_string(ReasonVendorNotDisclosed);
+    # Output:
+    # Code is 2, and it means vendor not disclosed
+
+    # Lookup by name via the description hashref (auto-quoted bareword).
+    say ReasonDescription->{ReasonPublisherRestrictionNotAllowed};
+    # Output:
+    # publisher restriction: not allowed
+
+=head1 DESCRIPTION
+
+Stable, integer-valued reason codes that describe why
+L<GDPR::IAB::TCFv2::Validator/validate> or L</validate_all> rejected a
+TCF consent string. The set mirrors the C<Reason> enum from the Go
+C<lib-gdpr/validator> package so cross-language tooling can share a
+single vocabulary.
+
+Each code is also accompanied by a short human-readable string available
+via L</reason_string> (lookup by integer) or L</ReasonDescription>
+(lookup by constant name).
+
+=head1 CONSTANTS
+
+All constants are non-negative integers. The values are stable: new codes
+are appended; existing codes never change.
+
+=head2 ReasonNone
+
+Code 0. Successful validation; no failure to report.
+
+=head2 ReasonMissingDisclosedVendors
+
+Code 1. The TC string is missing the mandatory disclosed vendors segment
+(TCF v2.2+ requirement under policy version >= 5).
+
+=head2 ReasonVendorNotDisclosed
+
+Code 2. The configured vendor ID is not present in the disclosed vendors
+segment.
+
+=head2 ReasonVendorNotAllowed
+
+Code 3. The vendor is not allowed globally: neither vendor consent nor
+vendor legitimate interest is granted for any purpose.
+
+=head2 ReasonPurposeNotAllowed
+
+Code 4. A required purpose has neither its consent flag nor its
+legitimate-interest flag set.
+
+=head2 ReasonPublisherRestrictionNotAllowed
+
+Code 5. A publisher restriction of type 0 (Not Allowed) is present for
+a required purpose. Always rejects.
+
+=head2 ReasonPublisherRestrictionRequireConsent
+
+Code 6. A publisher restriction of type 1 (Requires Consent) is present
+for a purpose configured under the legitimate-interest legal basis.
+
+=head2 ReasonPublisherRestrictionRequireLegitimateInterest
+
+Code 7. A publisher restriction of type 2 (Requires Legitimate Interest)
+is present for a purpose configured under the consent legal basis.
+
+=head2 ReasonVendorNotAllowedConsent
+
+Code 8. The vendor is not allowed for a specific purpose under the
+consent legal basis (vendor consent flag and/or purpose consent flag is
+missing).
+
+=head2 ReasonVendorNotAllowedLegitimateInterest
+
+Code 9. The vendor is not allowed for a specific purpose under the
+legitimate-interest legal basis (vendor LI flag and/or purpose LI flag
+is missing).
+
+=head2 ReasonLegitimateInterestNotPermittedForPurpose
+
+Code 10. The TCF spec forbids the legitimate-interest legal basis for
+this purpose, regardless of the vendor's signal: Purpose 1 always, and
+Purposes 3-6 on TcfPolicyVersion >= 4 (TCF v2.2+).
+
+=head2 ReasonPolicyVersionTooLow
+
+Code 11. The consent string's TcfPolicyVersion is below the validator's
+configured C<min_policy_version>.
+
+=head2 ReasonDecodeError
+
+Code 12. The consent string could not be decoded (malformed, empty, or
+unsupported version). Only emitted when the validator is configured to
+report decode errors as structured failures rather than via C<croak>.
+
+=head2 ReasonDescription
+
+Hashref mapping each constant name (C<"ReasonNone">, C<"ReasonVendorNotAllowed">,
+...) to its human-readable string. Useful with auto-quoted bareword
+subscripts:
+
+    my $msg = ReasonDescription->{ReasonVendorNotAllowed};
+
+=head1 FUNCTIONS
+
+=head2 reason_string
+
+    my $msg = reason_string($code);
+
+Returns the human-readable description for an integer reason code.
+Returns C<"unknown validation failure"> for unknown or undefined codes.
+
+=head1 SEE ALSO
+
+L<GDPR::IAB::TCFv2::Validator>, L<GDPR::IAB::TCFv2::Validator::Result>.
+
+=cut

--- a/t/15-validator-reason.t
+++ b/t/15-validator-reason.t
@@ -1,0 +1,115 @@
+use strict;
+use warnings;
+use Test::More;
+
+# Phase 6.1: machine-readable reason codes for the Validator. These
+# constants and the reason_string() helper are the public vocabulary
+# every later structured-failure consumer will speak.
+
+use GDPR::IAB::TCFv2::Validator::Reason qw<:all>;
+
+subtest 'all reason codes are distinct non-negative integers' => sub {
+    my @codes = (
+        ReasonNone(),
+        ReasonMissingDisclosedVendors(),
+        ReasonVendorNotDisclosed(),
+        ReasonVendorNotAllowed(),
+        ReasonPurposeNotAllowed(),
+        ReasonPublisherRestrictionNotAllowed(),
+        ReasonPublisherRestrictionRequireConsent(),
+        ReasonPublisherRestrictionRequireLegitimateInterest(),
+        ReasonVendorNotAllowedConsent(),
+        ReasonVendorNotAllowedLegitimateInterest(),
+        ReasonLegitimateInterestNotPermittedForPurpose(),
+        ReasonPolicyVersionTooLow(),
+        ReasonDecodeError(),
+    );
+
+    is( scalar(@codes), 13, 'all 13 reason codes accounted for' );
+
+    is( ReasonNone, 0, 'ReasonNone is zero (sentinel for success)' );
+
+    my %seen;
+    for my $code (@codes) {
+        like( $code, qr/^\d+$/, "code $code is a non-negative integer" );
+        ok( !$seen{$code}++, "code $code is unique" );
+    }
+};
+
+subtest 'reason_string returns the canonical description for each code' =>
+  sub {
+
+    # Each pair is [ code, expected description ]. The descriptions are
+    # the strings reason_string() returns for known codes; they mirror
+    # the Go validator's Reason.String() output.
+    my @cases = (
+        [ ReasonNone(),                    "no failure" ],
+        [ ReasonMissingDisclosedVendors(), "missing disclosed vendors" ],
+        [ ReasonVendorNotDisclosed(),      "vendor not disclosed" ],
+        [ ReasonVendorNotAllowed(),        "vendor not allowed" ],
+        [ ReasonPurposeNotAllowed(),       "purpose not allowed" ],
+        [   ReasonPublisherRestrictionNotAllowed(),
+            "publisher restriction: not allowed"
+        ],
+        [   ReasonPublisherRestrictionRequireConsent(),
+            "publisher restriction: requires consent"
+        ],
+        [   ReasonPublisherRestrictionRequireLegitimateInterest(),
+            "publisher restriction: requires legitimate interest"
+        ],
+        [   ReasonVendorNotAllowedConsent(),
+            "vendor not allowed for purpose (consent)"
+        ],
+        [   ReasonVendorNotAllowedLegitimateInterest(),
+            "vendor not allowed for purpose (legitimate interest)"
+        ],
+        [   ReasonLegitimateInterestNotPermittedForPurpose(),
+            "legitimate interest not permitted for purpose"
+        ],
+        [ ReasonPolicyVersionTooLow(), "tcf policy version too low" ],
+        [ ReasonDecodeError(),         "decode error" ],
+    );
+
+    for my $case (@cases) {
+        my ( $code, $expected ) = @{$case};
+        is( reason_string($code), $expected,
+            "reason_string($code) -> $expected"
+        );
+    }
+  };
+
+subtest 'reason_string falls back for unknown or undefined codes' => sub {
+    is( reason_string(255), "unknown validation failure",
+        'unknown integer code falls back to a generic message'
+    );
+    is( reason_string(undef), "unknown validation failure",
+        'undef code falls back to a generic message'
+    );
+    is( reason_string(-1), "unknown validation failure",
+        'negative code falls back to a generic message'
+    );
+};
+
+subtest 'ReasonDescription hashref is keyed by constant name' => sub {
+
+    # Auto-quoted bareword keys: ReasonDescription->{ReasonNone} reads as
+    # the string "ReasonNone", matching the Perl convention used by
+    # RestrictionTypeDescription / SpecialFeatureDescription elsewhere
+    # in this distribution.
+    is( ReasonDescription->{ReasonNone}, "no failure",
+        'ReasonDescription->{ReasonNone}'
+    );
+    is( ReasonDescription->{ReasonVendorNotAllowed}, "vendor not allowed",
+        'ReasonDescription->{ReasonVendorNotAllowed}'
+    );
+    is( ReasonDescription->{ReasonLegitimateInterestNotPermittedForPurpose},
+        "legitimate interest not permitted for purpose",
+        'ReasonDescription->{ReasonLegitimateInterestNotPermittedForPurpose}'
+    );
+
+    is( ReasonDescription->{NotAReason}, undef,
+        'unknown name returns undef'
+    );
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

First sub-task of the new **Phase 6: Structured Failure Reporting** in TODO.md. Introduces \`GDPR::IAB::TCFv2::Validator::Reason\`: 13 stable, integer-valued reason codes mirroring the Go \`lib-gdpr/validator\` \`Reason\` enum. No behavior change to any existing module — this is the data-model foundation that Stages 6.2-6.5 will build on.

- \`ReasonNone\` ... \`ReasonDecodeError\` (13 codes; values are stable, new codes will be appended).
- \`ReasonDescription\` hashref (Perl convention, name-keyed via auto-quoted bareword).
- \`reason_string(\$code)\` helper (Go-parity, integer-keyed; falls back to \`"unknown validation failure"\` for unknown/undef/negative).

Also reorders TODO.md: new Phase 6 (this work) inserted; old 6 → 7 (GVL-Aware), 7 → 8 (Features/Special), 8 → 9 (CLI Config). Cross-language parity rationale included in the new Phase 6 description.

## Test plan

- [x] \`t/15-validator-reason.t\` — 4 subtests, 48 assertions: uniqueness, every code↔string round-trip, fallback paths, name-keyed hashref.
- [x] Full \`prove -lr t/\`: 17578 tests pass.
- [x] Full \`prove -lr xt/\`: critic + tidy green.
- [x] MANIFEST updated.

## Follow-ups (not in this PR)

- Phase 6.2: \`Validator::Failure\` value object + \`Validator::Result\` extension (additive: new \`failures()\` / \`reason_codes()\` accessors alongside existing \`reasons()\`).
- Phase 6.3-6.5 per TODO.md.
- Post-Phase 6 follow-up: migrate \`CMPValidator\` to emit \`Validator::Failure\` objects with a \`REASON_CMP_*\` family (drop-in, no caller breakage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)