### PR TITLE
feat(cmp-validator): http_client injection + verify_ssl/timeout/env_proxy (PR A)

### DIFF
--- a/lib/GDPR/IAB/TCFv2/CMPValidator.pm
+++ b/lib/GDPR/IAB/TCFv2/CMPValidator.pm
@@ -3,8 +3,9 @@ package GDPR::IAB::TCFv2::CMPValidator;
 use strict;
 use warnings;
 
-use Carp     qw<croak carp>;
-use JSON::PP ();
+use Carp         qw<croak carp>;
+use JSON::PP     ();
+use Scalar::Util qw<blessed>;
 use Time::Piece;
 
 our $VERSION = '0.001';
@@ -12,10 +13,15 @@ our $VERSION = '0.001';
 sub new {
     my ( $klass, %args ) = @_;
 
+    _validate_http_options( \%args );
+
     my $self = {
         cmps         => {},
         last_updated => undef,
         now          => $args{now},
+        verify_ssl   => exists $args{verify_ssl} ? $args{verify_ssl} : 1,
+        timeout      => exists $args{timeout}    ? $args{timeout}    : 30,
+        http_client  => $args{http_client},
     };
     bless $self, $klass;
 
@@ -43,6 +49,24 @@ sub new {
     return $self;
 }
 
+sub _validate_http_options {
+    my ($args) = @_;
+
+    return unless exists $args->{http_client};
+
+    my $client = $args->{http_client};
+    croak
+      "http_client must be a blessed object responding to ->get(\$url); got "
+      . ( ref($client) || ( defined $client ? "a non-reference" : "undef" ) )
+      unless blessed($client) && $client->can('get');
+
+    croak
+      "http_client and verify_ssl/timeout are mutually exclusive: configure SSL/timeout on the http_client itself"
+      if exists $args->{verify_ssl} || exists $args->{timeout};
+
+    return;
+}
+
 sub load_from_file {
     my ( $self, $path ) = @_;
 
@@ -57,11 +81,23 @@ sub load_from_file {
 sub load_from_url {
     my ( $self, $url ) = @_;
 
-    eval { require HTTP::Tiny; 1 }
-      or croak "HTTP::Tiny is required to load CMP list from URL. "
-      . "Please install it or use a local file instead.";
+    my $client = $self->{http_client} // do {
+        eval { require HTTP::Tiny; 1 }
+          or croak "HTTP::Tiny is required to load CMP list from URL. "
+          . "Please install it or use a local file instead.";
 
-    my $response = HTTP::Tiny->new->get($url);
+        # env_proxy => 1: honor https_proxy / http_proxy / no_proxy.
+        # verify_SSL => 1 (default): pin the secure default regardless
+        # of the installed HTTP::Tiny version (older versions defaulted
+        # to 0).
+        HTTP::Tiny->new(
+            env_proxy  => 1,
+            verify_SSL => $self->{verify_ssl},
+            timeout    => $self->{timeout},
+        );
+    };
+
+    my $response = $client->get($url);
     croak "Failed to fetch CMP list from '$url': $response->{reason}"
       unless $response->{success};
 
@@ -235,8 +271,34 @@ than dialing out.
 
 =item *
 
-C<now> -- override the wall clock.  Useful for deterministic tests
+C<verify_ssl> -- boolean, default C<1>.  Convenience option for the
+default L<HTTP::Tiny> client: when true, server certificates are
+verified.  Disable only when targeting a CMP server with a self-signed
+or otherwise non-public-CA certificate.  Mutually exclusive with
+C<http_client> (configure SSL on the injected client itself).
+
+=item *
+
+C<timeout> -- integer seconds, default C<30>.  Convenience option for
+the default L<HTTP::Tiny> client.  Mutually exclusive with
+C<http_client>.
+
+=item *
+
+C<http_client> -- a pre-built object that responds to
+C<-E<gt>get($url)> in the L<HTTP::Tiny>-compatible shape (see
+L</INJECTING AN HTTP CLIENT>).  When provided, the validator uses this
+object verbatim and does not construct its own L<HTTP::Tiny>; the
+C<verify_ssl> and C<timeout> options are not accepted in this case
+(passing either alongside C<http_client> croaks).
+
+=item *
+
+C<now> -- B<test only.>  Override the wall clock used for
+C<deletedDate> comparisons and the 28-day staleness check
 (e.g. C<now =E<gt> 1776254400> pins comparisons to 2026-04-15).
+Production code should leave this unset; the validator reads the real
+wall clock by default.
 
 =back
 
@@ -268,7 +330,72 @@ Re-load from a raw JSON string.
 
 Fetch and load from C<$url>.  Bypasses the C<network_ok> gate -- the
 intent is that the caller has already validated they want to make a
-network call.  Requires L<HTTP::Tiny>.
+network call.  Uses the C<http_client> passed to the constructor when
+present; otherwise constructs a default L<HTTP::Tiny> with
+C<env_proxy =E<gt> 1>, C<verify_SSL> from C<verify_ssl>, and C<timeout>
+from C<timeout>.
+
+=head1 NETWORK PROXIES
+
+When C<load_from_url> uses the default L<HTTP::Tiny> client (i.e. no
+C<http_client> was injected), the standard HTTP-proxy environment
+variables are honored automatically:
+
+=over 4
+
+=item *
+
+C<https_proxy> -- proxy for C<https://> URLs.
+
+=item *
+
+C<http_proxy> -- proxy for C<http://> URLs.
+
+=item *
+
+C<all_proxy> -- fallback for both.
+
+=item *
+
+C<no_proxy> -- comma-separated host/domain patterns to bypass
+(e.g. C<localhost,*.internal>).
+
+=back
+
+Lowercase names are the canonical form.  HTTP::Tiny accepts uppercase
+as well, but the lowercase variants are preferred (some hardened
+environments treat the uppercase form as a security risk because of
+historical CGI injection bugs).
+
+When an injected C<http_client> is used, this module does no proxy
+configuration of its own: configure the client however you need before
+handing it in.
+
+=head1 INJECTING AN HTTP CLIENT
+
+For test fakes, custom CA bundles, signed-request middleware, or any
+other case the convenience options do not cover, hand the validator a
+pre-built object via C<http_client>:
+
+    package FakeHttp;
+    sub new { bless { responses => $_[1] }, $_[0] }
+    sub get { my $self = shift; shift @{ $self->{responses} } }
+
+    my $cmp_v = GDPR::IAB::TCFv2::CMPValidator->new(
+        url         => 'https://does-not-matter.example/',
+        network_ok  => 1,
+        http_client => FakeHttp->new( [
+            { success => 1, content => '{"cmps": {"7": {"id": 7}}}' },
+        ] ),
+    );
+
+The injected object must be a blessed reference that responds to a
+C<-E<gt>get($url)> method returning a hashref in the L<HTTP::Tiny>
+shape: at minimum, C<success> (boolean), C<content> (response body on
+success), and C<reason> (error text on failure).  The constructor
+verifies the object is blessed and L<UNIVERSAL/can> a C<get> method,
+so AUTOLOAD-using classes must override C<can> to advertise their
+methods (the standard Perl convention).
 
 =head1 STALE DATA WARNING
 

--- a/t/14-cmp-validator.t
+++ b/t/14-cmp-validator.t
@@ -200,4 +200,174 @@ subtest "Validator integration: bad cmp_validator value croaks" => sub {
       "non-object, non-hashref cmp_validator croaks";
 };
 
+# A minimal HTTP::Tiny-compatible fake. One method (get); returns a
+# pre-canned response. Used to test the http_client injection path
+# without doing real network IO.
+{
+
+    package FakeHttp;
+
+    sub new {
+        my ( $klass, $response ) = @_;
+        bless { response => $response, calls => [] }, $klass;
+    }
+
+    sub get {
+        my ( $self, $url ) = @_;
+        push @{ $self->{calls} }, $url;
+        return $self->{response};
+    }
+}
+
+# A blessed object that does NOT respond to ->get. Used to assert the
+# constructor's can('get') validation.
+{
+
+    package NoGetMethod;
+    sub new { bless {}, shift }
+}
+
+subtest "CMPValidator: HTTP options round-trip" => sub {
+    my $v = GDPR::IAB::TCFv2::CMPValidator->new(
+        file => $cmp_file,
+        now  => $now_fresh,
+    );
+    is( $v->{verify_ssl}, 1,  "verify_ssl defaults to 1" );
+    is( $v->{timeout},    30, "timeout defaults to 30" );
+
+    my $v2 = GDPR::IAB::TCFv2::CMPValidator->new(
+        file       => $cmp_file,
+        now        => $now_fresh,
+        verify_ssl => 0,
+        timeout    => 60,
+    );
+    is( $v2->{verify_ssl}, 0,  "verify_ssl override accepted" );
+    is( $v2->{timeout},    60, "timeout override accepted" );
+};
+
+subtest "CMPValidator: http_client must be a blessed object with ->get" =>
+  sub {
+    throws_ok {
+        GDPR::IAB::TCFv2::CMPValidator->new(
+            url         => 'https://example.invalid/',
+            network_ok  => 1,
+            http_client => { not_blessed => 1 },
+        );
+    }
+    qr/http_client must be a blessed object responding to ->get.*got HASH/,
+      "unblessed hashref croaks";
+
+    throws_ok {
+        GDPR::IAB::TCFv2::CMPValidator->new(
+            url         => 'https://example.invalid/',
+            network_ok  => 1,
+            http_client => "a string",
+        );
+    }
+    qr/http_client must be a blessed object responding to ->get.*got a non-reference/,
+      "non-reference scalar croaks";
+
+    throws_ok {
+        GDPR::IAB::TCFv2::CMPValidator->new(
+            url         => 'https://example.invalid/',
+            network_ok  => 1,
+            http_client => NoGetMethod->new,
+        );
+    }
+    qr/http_client must be a blessed object responding to ->get.*got NoGetMethod/,
+      "blessed object without a get method croaks";
+  };
+
+subtest "CMPValidator: http_client and verify_ssl/timeout are exclusive" =>
+  sub {
+    my $fake = FakeHttp->new( { success => 1, content => '{"cmps":{}}' } );
+
+    throws_ok {
+        GDPR::IAB::TCFv2::CMPValidator->new(
+            url         => 'https://example.invalid/',
+            network_ok  => 1,
+            http_client => $fake,
+            verify_ssl  => 0,
+        );
+    }
+    qr/http_client and verify_ssl\/timeout are mutually exclusive/,
+      "http_client + verify_ssl croaks";
+
+    throws_ok {
+        GDPR::IAB::TCFv2::CMPValidator->new(
+            url         => 'https://example.invalid/',
+            network_ok  => 1,
+            http_client => $fake,
+            timeout     => 60,
+        );
+    }
+    qr/http_client and verify_ssl\/timeout are mutually exclusive/,
+      "http_client + timeout croaks";
+  };
+
+subtest "CMPValidator: http_client injection drives load_from_url" => sub {
+
+    # Stable raw JSON for two known CMPs; lastUpdated kept fresh so no
+    # staleness warning leaks into the test output.
+    my $json = '{"lastUpdated":"2026-04-01T00:00:00Z",'
+      . '"cmps":{"7":{"id":7},"42":{"id":42}}}';
+
+    my $fake = FakeHttp->new( { success => 1, content => $json } );
+
+    my $v = GDPR::IAB::TCFv2::CMPValidator->new(
+        url         => 'https://does-not-matter.example/cmp.json',
+        network_ok  => 1,
+        http_client => $fake,
+        now         => $now_fresh,
+    );
+
+    is_deeply $fake->{calls},
+      ['https://does-not-matter.example/cmp.json'],
+      "the URL passed to ->get was the URL given to the constructor";
+
+    ok $v->is_valid(7),   "CMP 7 from injected response is valid";
+    ok $v->is_valid(42),  "CMP 42 from injected response is valid";
+    ok !$v->is_valid(99), "CMP 99 is unknown (proves the response was used)";
+};
+
+subtest "CMPValidator: failed http_client response croaks with the reason" =>
+  sub {
+    my $fake = FakeHttp->new(
+        { success => 0, status => 599, reason => "Connection refused" } );
+
+    throws_ok {
+        GDPR::IAB::TCFv2::CMPValidator->new(
+            url         => 'https://example.invalid/cmp.json',
+            network_ok  => 1,
+            http_client => $fake,
+        );
+    }
+    qr/Failed to fetch CMP list.*Connection refused/,
+      "failed response surfaces the reason text";
+  };
+
+subtest "CMPValidator: env_proxy is honored on the default client" => sub {
+
+    # Proves the default HTTP::Tiny is constructed with env_proxy => 1
+    # by setting an unreachable proxy and asserting the failure mentions
+    # it. Skip if the surrounding environment already has a real proxy
+    # configured -- we don't want to disturb the user's shell.
+    plan skip_all => "http_proxy already set in env"
+      if $ENV{http_proxy} || $ENV{HTTP_PROXY};
+    plan skip_all => "HTTP::Tiny not installed"
+      unless eval { require HTTP::Tiny; 1 };
+
+    local $ENV{http_proxy} = 'http://127.0.0.1:1';
+
+    throws_ok {
+        GDPR::IAB::TCFv2::CMPValidator->new(
+            url        => 'http://example.invalid/cmp.json',
+            network_ok => 1,
+            timeout    => 2,
+        );
+    }
+    qr/Failed to fetch CMP list/,
+      "fetch fails with the unreachable proxy in env (env_proxy was applied)";
+};
+
 done_testing;


### PR DESCRIPTION
## Summary

PR A of two for **v0.391**. Brings the `CMPValidator` HTTP layer in line with what callers actually need in production:

- **`verify_ssl`** (default `1`) — pin the secure default independent of installed HTTP::Tiny version (older versions silently defaulted to `0`).
- **`timeout`** (default `30`) — sane CLI-friendly default; HTTP::Tiny's own default of 60s is too long.
- **`http_client`** — inject any blessed object responding to `->get(\$url)` in the HTTP::Tiny shape. Power-user / test-fake escape hatch. Mutually exclusive with `verify_ssl`/`timeout` (configure those on the injected client itself); validated at construction time via \`blessed && ->can('get')\`.
- **`env_proxy => 1`** — always-on for the default HTTP::Tiny client, so \`https_proxy\` / \`http_proxy\` / \`no_proxy\` are honored automatically. This was previously silently ignored.
- POD additions: \`NETWORK PROXIES\` section, \`INJECTING AN HTTP CLIENT\` section, tightened \"test only\" wording on \`now\`.

PR B (CLI integration) follows after this merges; tags **v0.391** once both land.

## Test plan

- [x] \`prove -lv t/14-cmp-validator.t\` — 14 subtests, including six new ones:
    - HTTP options round-trip (defaults + overrides).
    - \`http_client\` validation (unblessed / non-ref / no-\`get\` all croak with actionable messages).
    - \`http_client\` mutually-exclusive croaks (with \`verify_ssl\`, with \`timeout\`).
    - End-to-end fake-client URL fetch (proves the injected object is used verbatim).
    - Failed-response surfacing.
    - \`env_proxy\` smoke test (sets unreachable proxy, asserts failure path; skipped if env already has http_proxy).
- [x] \`prove -lr t/\` — 17533 tests pass.
- [x] \`prove -lr xt/\` — critic + tidy green.

## Out of scope (intentionally)

- No CLI changes; that's PR B.
- \`now\` stays scalar-only — no coderef support added (decision: keep API simple).
- No version bump in this PR; \`$VERSION\` bumps to 0.391 in the release commit after PR B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)