### PR TITLE
feat(cli): integrate CMPValidator into iabtcfv2 validate (PR B)

### DIFF
--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -226,6 +226,10 @@ sub run_validate {
         'check-disclosed-vendors'      => 0,
         strict                         => 0,
         'min-policy-version'           => undef,
+        'cmp-list'                     => undef,
+        'cmp-list-network-ok'          => 0,
+        'cmp-list-verify-ssl'          => 1,
+        'cmp-list-timeout'             => 30,
         all                            => 0,
         text                           => 0,
     );
@@ -246,6 +250,10 @@ sub run_validate {
         'check-disclosed-vendors|d' => \$opts{'check-disclosed-vendors'},
         'strict|s'                  => \$opts{strict},
         'min-policy-version|m=i'    => \$opts{'min-policy-version'},
+        'cmp-list=s'                => \$opts{'cmp-list'},
+        'cmp-list-network-ok'       => \$opts{'cmp-list-network-ok'},
+        'cmp-list-verify-ssl!'      => \$opts{'cmp-list-verify-ssl'},
+        'cmp-list-timeout=i'        => \$opts{'cmp-list-timeout'},
         'all|a'                     => \$opts{all},
         'text|t'                    => \$opts{text},
         'help|h'                    => sub {
@@ -284,6 +292,49 @@ sub run_validate {
       if defined $opts{'flexible-purposes'};
     $vargs{min_policy_version} = $opts{'min-policy-version'}
       if defined $opts{'min-policy-version'};
+
+    if ( defined $opts{'cmp-list'} ) {
+        require GDPR::IAB::TCFv2::CMPValidator;
+
+        my $src      = $opts{'cmp-list'};
+        my %cmp_args = (
+            verify_ssl => $opts{'cmp-list-verify-ssl'},
+            timeout    => $opts{'cmp-list-timeout'},
+        );
+
+        if ( $src =~ m{^https?://}i ) {
+            $cmp_args{url}        = $src;
+            $cmp_args{network_ok} = 1 if $opts{'cmp-list-network-ok'};
+        }
+        else {
+            $cmp_args{file} = $src;
+        }
+
+        # The CMPValidator emits a `carp` when the registry is older
+        # than 28 days. Surface that warning only when the user has
+        # opted into warnings (--enable-warnings); otherwise filter it
+        # out so routine CLI use stays quiet. Other warnings flow
+        # through unchanged.
+        my $cmp_v;
+        {
+            local $SIG{__WARN__} = sub {
+                my $msg = $_[0] // '';
+                return if $msg =~ /CMP list is older than 28 days/;
+                warn @_;
+              }
+              if !$opts{'enable-warnings'};
+
+            $cmp_v = eval { GDPR::IAB::TCFv2::CMPValidator->new(%cmp_args) };
+        }
+
+        if ( my $err = $@ ) {
+            chomp $err;
+            warn "validate: $err\n";
+            exit 2;
+        }
+
+        $vargs{cmp_validator} = $cmp_v;
+    }
 
     my $validator = eval { GDPR::IAB::TCFv2::Validator->new(%vargs) };
     if ( my $err = $@ ) {
@@ -328,7 +379,7 @@ sub _validate_string {
     my ( $str, $state, $o, $j, $validator ) = @_;
 
     my $result = eval {
-        $o->{all}
+            $o->{all}
           ? $validator->validate_all($str)
           : $validator->validate($str);
     };
@@ -422,7 +473,7 @@ sub _emit_validate {
             else {
                 $line = join "\n",
                   "FAIL   $tc vendor $vid:",
-                  map { "  - $_" } @reasons;
+                  map {"  - $_"} @reasons;
             }
         }
         print "$line\n";
@@ -670,6 +721,37 @@ Enable strict spec validation in the underlying parser (see C<dump --strict>).
 Reject TC strings whose Global Vendor List policy version is below I<N>.
 Checked first, before any vendor- or purpose-level rules.
 
+=item B<--cmp-list> I<PATH-OR-URL>
+
+Validate the C<cmp_id> embedded in each TC string against an IAB CMP
+registry snapshot. The argument is detected as a URL when it starts
+with C<http://> or C<https://>, otherwise it is treated as a local
+file path. Failures yield a C<reason> mentioning the unknown or
+deleted CMP id.
+
+When the argument is a URL, the standard HTTP-proxy environment
+variables (C<https_proxy>, C<http_proxy>, C<no_proxy>) are honored
+automatically.
+
+=item B<--cmp-list-network-ok>
+
+Required when B<--cmp-list> is a URL. Without this flag, URL fetching
+is refused (mirrors the library's C<network_ok =E<gt> 1> opt-in:
+fetching from an arbitrary URL is intentional, never accidental).
+Has no effect when B<--cmp-list> is a file path.
+
+=item B<--cmp-list-verify-ssl>, B<--no-cmp-list-verify-ssl>
+
+Verify TLS certificates when fetching from an HTTPS URL. On by default;
+disable with B<--no-cmp-list-verify-ssl> only when targeting a server
+with a self-signed or otherwise non-public-CA certificate. Has no
+effect when B<--cmp-list> is a file path.
+
+=item B<--cmp-list-timeout> I<SECONDS>
+
+Per-request timeout for the URL fetch, in seconds. Defaults to 30.
+Has no effect when B<--cmp-list> is a file path.
+
 =item B<--all>, B<-a>
 
 Accumulate every failing rule into a C<reasons> array instead of
@@ -714,7 +796,8 @@ Route parse-error records to B<STDERR> instead of B<STDOUT>.
 =item B<--enable-warnings>, B<-w>
 
 Emit human-readable warning messages on B<STDERR> when a TC string fails to
-parse. Off by default.
+parse, and when the B<--cmp-list> registry snapshot is older than 28 days.
+Off by default.
 
 =item B<--quiet>, B<-q>
 
@@ -738,7 +821,8 @@ B<1> — at least one TC string failed validation or could not be parsed.
 
 =item *
 
-B<2> — bad CLI usage (missing C<--vendor-id>, incoherent purpose lists).
+B<2> — bad CLI usage (missing C<--vendor-id>, incoherent purpose lists,
+unreachable C<--cmp-list> source).
 
 =back
 
@@ -757,6 +841,17 @@ B<2> — bad CLI usage (missing C<--vendor-id>, incoherent purpose lists).
     # `jq -s` if you need a single JSON array.
     iabtcfv2 validate -v 32 -C 1,3 CO...AAA CO...BBB
     iabtcfv2 validate -v 32 -C 1,3 CO...AAA CO...BBB | jq -s .
+
+    # Reject TC strings that name an unknown or deleted CMP, using a
+    # local snapshot of the IAB CMP registry.
+    iabtcfv2 validate -v 32 --cmp-list /etc/iab/cmp-list.json CO...AAA
+
+    # Same, but fetching the registry over HTTPS through whatever
+    # proxy `https_proxy` points at.
+    iabtcfv2 validate -v 32 \
+        --cmp-list https://cmplist.consensu.org/v2/cmp-list.json \
+        --cmp-list-network-ok \
+        CO...AAA
 
 =head1 DESCRIPTION
 

--- a/t/10-cli-iabtcfv2.t
+++ b/t/10-cli-iabtcfv2.t
@@ -343,4 +343,115 @@ subtest 'validate subcommand' => sub {
     is( $? >> 8,     1,  '--ignore-errors still exits 1' );
 };
 
+subtest '--cmp-list integration' => sub {
+    my $cmp_file   = File::Spec->catfile( 't', 'corpus', 'cmp-list.json' );
+    my $tc_known   = $tc_string;    # CMP 21, present in fixture
+    my $tc_unknown = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+
+    # Known CMP: should still validate.
+    my $ok_out =
+      `$perl -Ilib $bin validate -v 1 --cmp-list $cmp_file $tc_known 2>$devnull`;
+    my $ok_data = decode_helper($ok_out);
+    ok( $ok_data, "known-CMP validate emits JSON" );
+    is( $ok_data->{valid},
+        JSON->can('true') ? JSON->true() : JSON::PP::true(),
+        "known CMP passes the cmp_validator rule"
+    );
+
+    # Unknown CMP: should fail with an unknown-CMP reason.
+    my $bad_out =
+      `$perl -Ilib $bin validate -v 1 --cmp-list $cmp_file $tc_unknown 2>$devnull`;
+    my $bad_code = $? >> 8;
+    my $bad_data = decode_helper($bad_out);
+    ok( $bad_data, "unknown-CMP validate emits JSON" );
+    is( $bad_data->{valid}, $json_false, "unknown CMP fails validation" );
+    like(
+        $bad_data->{reason},
+        qr/CMP\s+\d+\s+is not valid/,
+        "reason names the bad CMP"
+    );
+    is( $bad_code, 1, "unknown CMP exits 1" );
+
+    # URL without --cmp-list-network-ok: refused (exit 2, message on stderr).
+    my $stderr_capture = File::Spec->catfile(
+        File::Spec->tmpdir(),
+        "tcf_cmp_url_stderr_$$"
+    );
+    my $url_out =
+      `$perl -Ilib $bin validate -v 1 --cmp-list https://example.invalid/x.json $tc_known 2>$stderr_capture`;
+    my $url_code = $? >> 8;
+    is( $url_code, 2,
+        "URL without --cmp-list-network-ok exits 2 (bad usage)"
+    );
+    is( $url_out, '', "URL refusal emits no stdout" );
+    open my $fh, '<', $stderr_capture
+      or die "Could not read $stderr_capture: $!";
+    my $stderr = do { local $/ = undef; <$fh> };
+    close $fh;
+    unlink $stderr_capture;
+    like(
+        $stderr, qr/network_ok was not set/,
+        "URL refusal mentions network_ok in the diagnostic"
+    );
+
+    # --no-cmp-list-verify-ssl is accepted as a flag (file path makes
+    # the SSL setting moot at runtime, but Getopt::Long must accept it).
+    my $no_verify_out =
+      `$perl -Ilib $bin validate -v 1 --cmp-list $cmp_file --no-cmp-list-verify-ssl $tc_known 2>$devnull`;
+    my $no_verify_data = decode_helper($no_verify_out);
+    ok( $no_verify_data, "--no-cmp-list-verify-ssl is accepted" );
+    is( $no_verify_data->{valid},
+        JSON->can('true') ? JSON->true() : JSON::PP::true(),
+        "--no-cmp-list-verify-ssl does not affect file-path use"
+    );
+
+    # --cmp-list-timeout takes an integer.
+    my $timeout_out =
+      `$perl -Ilib $bin validate -v 1 --cmp-list $cmp_file --cmp-list-timeout 5 $tc_known 2>$devnull`;
+    ok( decode_helper($timeout_out), "--cmp-list-timeout is accepted" );
+};
+
+subtest '--cmp-list staleness warning gate' => sub {
+    my $cmp_file = File::Spec->catfile( 't', 'corpus', 'cmp-list.json' );
+
+    # Fixture lastUpdated is 2026-04-01. The repo policy is that this
+    # gets older over time — we rely on that fact for this test. Skip
+    # if for any reason we are running before the fixture turned 28
+    # days old (would never happen on the maintained line, but keeps
+    # the test honest if someone backports it onto an older snapshot).
+    plan skip_all => "fixture not yet 28 days stale (future-dated run?)"
+      if time() < ( 1743465600 + 28 * 86400 );    # 2026-04-01 + 28d
+
+    my $stderr_quiet = File::Spec->catfile(
+        File::Spec->tmpdir(),
+        "tcf_cmp_stale_quiet_$$"
+    );
+    my $stderr_loud = File::Spec->catfile(
+        File::Spec->tmpdir(),
+        "tcf_cmp_stale_loud_$$"
+    );
+
+    # Without --enable-warnings: staleness carp is suppressed.
+    `$perl -Ilib $bin validate -v 1 --cmp-list $cmp_file $tc_string 2>$stderr_quiet`;
+    open my $qfh, '<', $stderr_quiet or die "open $stderr_quiet: $!";
+    my $quiet = do { local $/ = undef; <$qfh> };
+    close $qfh;
+    unlink $stderr_quiet;
+    unlike(
+        $quiet, qr/CMP list is older than 28 days/,
+        "no staleness warning without --enable-warnings"
+    );
+
+    # With --enable-warnings: staleness carp surfaces on stderr.
+    `$perl -Ilib $bin validate -wv 1 --cmp-list $cmp_file $tc_string 2>$stderr_loud`;
+    open my $lfh, '<', $stderr_loud or die "open $stderr_loud: $!";
+    my $loud = do { local $/ = undef; <$lfh> };
+    close $lfh;
+    unlink $stderr_loud;
+    like(
+        $loud, qr/CMP list is older than 28 days/,
+        "staleness warning surfaces with --enable-warnings"
+    );
+};
+
 done_testing();


### PR DESCRIPTION
## Summary

PR B of two for **v0.391**. Wires the CMPValidator (shipped in v0.390) into the CLI so end users can use it without writing Perl glue. Builds on PR A (#64), which landed the underlying \`http_client\` / \`verify_ssl\` / \`timeout\` / \`env_proxy\` options on the library.

Four new flags on \`iabtcfv2 validate\`:

| Flag | Default | Notes |
|---|---|---|
| \`--cmp-list <PATH-OR-URL>\` | — | URL detected by \`^https?://\` prefix; otherwise file path. |
| \`--cmp-list-network-ok\` | off | Required for URL sources (mirrors library's \`network_ok\`). |
| \`--cmp-list-verify-ssl!\` | on | Negatable: \`--no-cmp-list-verify-ssl\`. |
| \`--cmp-list-timeout=i\` | 30 | Seconds. |

CMP failures flow through the existing JSON \`reasons\`/\`reason\` path — no output-shape change. URL fetches automatically honor \`https_proxy\` / \`http_proxy\` / \`no_proxy\` env vars (the \`env_proxy => 1\` wiring landed in #64).

The 28-day staleness warning is gated on \`--enable-warnings\`: routine CLI use stays quiet, opted-in users see the carp on stderr.

## Test plan

- [x] \`prove -lv t/10-cli-iabtcfv2.t\` — 30 subtests, including 14 new assertions across two subtests:
    - Known/unknown CMP via \`--cmp-list <fixture>\` (passes / fails with reason).
    - URL without \`--cmp-list-network-ok\` → exit 2 + diagnostic on stderr.
    - \`--no-cmp-list-verify-ssl\` accepted as a flag (file-path use unaffected).
    - \`--cmp-list-timeout 5\` accepted.
    - Staleness warning gate: silent without \`-w\`, surfaced with \`-w\`.
- [x] \`prove -lr t/\` — 17535 tests pass.
- [x] \`prove -lr xt/\` — critic + tidy green.
- [x] Manual smoke: \`iabtcfv2 validate -v 1 --cmp-list t/corpus/cmp-list.json <known-tc>\` → \`{"valid":true,...}\`; URL without \`--cmp-list-network-ok\` → exit 2 with the network_ok message.

## Out of scope (intentionally)

- \`--cmp-list-now\` was discussed and dropped — pure test scaffolding, not a production-relevant flag.
- \`--cmp-list-data\` (raw JSON via flag) skipped — \`--cmp-list <(echo '...')\` covers it via shell.
- \`--cmp-list-http-client\` (Perl-only object) inherently can't cross a CLI boundary.
- No version bump in this PR; \`$VERSION\` bumps to 0.391 in a release-prep commit after this merges.

## Release sequence

After this merges:
1. Bump \`$VERSION\` in \`lib/GDPR/IAB/TCFv2.pm\` to \`0.391\`.
2. Update \`Changes\` with a single v0.391 entry covering #64 + this PR.
3. Tag \`v0.391\`, push tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)