### PR TITLE
feat(validator): structured Failure objects + Result accessors (Phase 6.2)

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -15,6 +15,7 @@ lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm
 lib/GDPR/IAB/TCFv2/PublisherTC.pm
 lib/GDPR/IAB/TCFv2/RangeSection.pm
 lib/GDPR/IAB/TCFv2/Validator.pm
+lib/GDPR/IAB/TCFv2/Validator/Failure.pm
 lib/GDPR/IAB/TCFv2/Validator/Reason.pm
 lib/GDPR/IAB/TCFv2/Validator/Result.pm
 LICENSE
@@ -37,6 +38,7 @@ t/12-bigint-fallback.t
 t/13-constants-aliases.t
 t/14-cmp-validator.t
 t/15-validator-reason.t
+t/16-validator-failures.t
 t/90-bugs.t
 t/99-pod.t
 t/corpus/cmp-list.json

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -6,6 +6,8 @@ use warnings;
 use Carp         qw<croak>;
 use Scalar::Util qw<blessed>;
 use GDPR::IAB::TCFv2;
+use GDPR::IAB::TCFv2::Validator::Failure;
+use GDPR::IAB::TCFv2::Validator::Reason qw<:all>;
 use GDPR::IAB::TCFv2::Validator::Result;
 
 sub new {
@@ -122,74 +124,92 @@ sub _run_validation {
 
     croak "missing vendor_id" unless defined $vendor_id;
 
-    my @reasons;
+    my @failures;
 
-    $self->_check_min_policy_version( $tc, $min_policy_version, \@reasons );
-    return $self->_make_result( 0, \@reasons ) if $stop_on_first && @reasons;
+    $self->_check_min_policy_version( $tc, $min_policy_version, \@failures );
+    return $self->_make_result( 0, \@failures )
+      if $stop_on_first && @failures;
 
-    $self->_check_cmp_validator( $tc, $cmp_validator, \@reasons );
-    return $self->_make_result( 0, \@reasons ) if $stop_on_first && @reasons;
+    $self->_check_cmp_validator( $tc, $cmp_validator, \@failures );
+    return $self->_make_result( 0, \@failures )
+      if $stop_on_first && @failures;
 
-    $self->_check_disclosed( $tc, $vendor_id, $check_disclosed, \@reasons );
-    return $self->_make_result( 0, \@reasons ) if $stop_on_first && @reasons;
+    $self->_check_disclosed( $tc, $vendor_id, $check_disclosed, \@failures );
+    return $self->_make_result( 0, \@failures )
+      if $stop_on_first && @failures;
 
     $self->_check_consent_purposes(
-        $tc, $vendor_id, $strict, \@reasons,
+        $tc, $vendor_id, $strict, \@failures,
         $stop_on_first
     );
-    return $self->_make_result( 0, \@reasons ) if $stop_on_first && @reasons;
+    return $self->_make_result( 0, \@failures )
+      if $stop_on_first && @failures;
 
     $self->_check_li_purposes(
-        $tc, $vendor_id, $strict, \@reasons,
+        $tc, $vendor_id, $strict, \@failures,
         $stop_on_first
     );
 
-    if (@reasons) {
-        return $self->_make_result( 0, \@reasons );
+    if (@failures) {
+        return $self->_make_result( 0, \@failures );
     }
 
     return $self->_make_result( 1, [] );
 }
 
 sub _check_cmp_validator {
-    my ( $self, $tc, $cmp_validator, $reasons ) = @_;
+    my ( $self, $tc, $cmp_validator, $failures ) = @_;
 
     return unless defined $cmp_validator;
 
     my $cmp_id = $tc->cmp_id;
     unless ( $cmp_validator->is_valid($cmp_id) ) {
-        push @{$reasons}, "CMP $cmp_id is not valid/disclosed";
+        push @{$failures},
+          GDPR::IAB::TCFv2::Validator::Failure->new(
+            code    => ReasonInvalidCMP,
+            message => "CMP $cmp_id is not valid/disclosed",
+            cmp_id  => $cmp_id,
+          );
     }
     return;
 }
 
 sub _check_min_policy_version {
-    my ( $self, $tc, $min_policy_version, $reasons ) = @_;
+    my ( $self, $tc, $min_policy_version, $failures ) = @_;
 
     return unless defined $min_policy_version;
 
     my $actual = $tc->policy_version;
     if ( $actual < $min_policy_version ) {
-        push @{$reasons},
-          "TC string policy version $actual is below required minimum $min_policy_version";
+        push @{$failures},
+          GDPR::IAB::TCFv2::Validator::Failure->new(
+            code    => ReasonPolicyVersionTooLow,
+            message =>
+              "TC string policy version $actual is below required minimum $min_policy_version",
+          );
     }
     return;
 }
 
 sub _check_disclosed {
-    my ( $self, $tc, $vendor_id, $check_disclosed, $reasons ) = @_;
+    my ( $self, $tc, $vendor_id, $check_disclosed, $failures ) = @_;
 
     return unless $check_disclosed;
     return unless $tc->has_vendor_disclosure;
 
     unless ( $tc->disclosed_vendor($vendor_id) ) {
-        push @{$reasons}, "vendor $vendor_id not disclosed";
+        push @{$failures},
+          GDPR::IAB::TCFv2::Validator::Failure->new(
+            code      => ReasonVendorNotDisclosed,
+            message   => "vendor $vendor_id not disclosed",
+            vendor_id => $vendor_id,
+          );
     }
     return;
 }
 
 sub _check_consent_purposes {
-    my ( $self, $tc, $vendor_id, $strict, $reasons, $stop_on_first ) = @_;
+    my ( $self, $tc, $vendor_id, $strict, $failures, $stop_on_first ) = @_;
 
     foreach my $pid ( @{ $self->{consent_purpose_ids} } ) {
         my $allowed = $self->{_flexible_set}->{$pid}
@@ -203,8 +223,14 @@ sub _check_consent_purposes {
           );
 
         unless ($allowed) {
-            push @{$reasons},
-              "vendor $vendor_id not allowed for purpose $pid (consent)";
+            push @{$failures},
+              GDPR::IAB::TCFv2::Validator::Failure->new(
+                code    => ReasonVendorNotAllowedConsent,
+                message =>
+                  "vendor $vendor_id not allowed for purpose $pid (consent)",
+                purpose_id => $pid,
+                vendor_id  => $vendor_id,
+              );
             return if $stop_on_first;
         }
     }
@@ -212,7 +238,7 @@ sub _check_consent_purposes {
 }
 
 sub _check_li_purposes {
-    my ( $self, $tc, $vendor_id, $strict, $reasons, $stop_on_first ) = @_;
+    my ( $self, $tc, $vendor_id, $strict, $failures, $stop_on_first ) = @_;
 
     foreach my $pid ( @{ $self->{legitimate_interest_purpose_ids} } ) {
         my $allowed = $self->{_flexible_set}->{$pid}
@@ -226,8 +252,14 @@ sub _check_li_purposes {
           );
 
         unless ($allowed) {
-            push @{$reasons},
-              "vendor $vendor_id not allowed for purpose $pid (legitimate interest)";
+            push @{$failures},
+              GDPR::IAB::TCFv2::Validator::Failure->new(
+                code    => ReasonVendorNotAllowedLegitimateInterest,
+                message =>
+                  "vendor $vendor_id not allowed for purpose $pid (legitimate interest)",
+                purpose_id => $pid,
+                vendor_id  => $vendor_id,
+              );
             return if $stop_on_first;
         }
     }
@@ -236,11 +268,11 @@ sub _check_li_purposes {
 
 
 sub _make_result {
-    my ( $self, $ok, $reasons ) = @_;
+    my ( $self, $ok, $failures ) = @_;
 
     return GDPR::IAB::TCFv2::Validator::Result->new(
-        ok      => $ok,
-        reasons => $reasons,
+        ok       => $ok,
+        failures => $failures,
     );
 }
 

--- a/lib/GDPR/IAB/TCFv2/Validator/Failure.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Failure.pm
@@ -1,0 +1,148 @@
+package GDPR::IAB::TCFv2::Validator::Failure;
+
+use strict;
+use warnings;
+
+use overload
+  '""'     => sub { $_[0]->{message} },
+  fallback => 1;
+
+sub new {
+    my ( $klass, %args ) = @_;
+
+    my $self = {
+        code             => defined $args{code}    ? $args{code}    : 0,
+        message          => defined $args{message} ? $args{message} : '',
+        purpose_id       => $args{purpose_id},
+        vendor_id        => $args{vendor_id},
+        restriction_type => $args{restriction_type},
+        cmp_id           => $args{cmp_id},
+    };
+
+    return bless $self, $klass;
+}
+
+sub code             { $_[0]->{code} }
+sub message          { $_[0]->{message} }
+sub purpose_id       { $_[0]->{purpose_id} }
+sub vendor_id        { $_[0]->{vendor_id} }
+sub restriction_type { $_[0]->{restriction_type} }
+sub cmp_id           { $_[0]->{cmp_id} }
+
+1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+GDPR::IAB::TCFv2::Validator::Failure - structured failure record from the Validator
+
+=head1 SYNOPSIS
+
+    use GDPR::IAB::TCFv2::Validator::Reason qw<:all>;
+
+    my $result = $validator->validate($tc_string);
+
+    unless ($result) {
+        for my $f ( $result->failures ) {
+            warn sprintf "code=%d message=%s\n", $f->code, $f->message;
+
+            if ( $f->code == ReasonVendorNotAllowedConsent ) {
+                # machine-readable handling
+                ...
+            }
+        }
+    }
+
+=head1 DESCRIPTION
+
+A lightweight value object describing a single failure detected by
+L<GDPR::IAB::TCFv2::Validator>. Each failure carries a stable integer
+C<code> from L<GDPR::IAB::TCFv2::Validator::Reason> plus the
+human-readable C<message> the validator emitted, and any structured
+context that is relevant to the failure (purpose ID, vendor ID,
+publisher restriction type, CMP ID).
+
+This is the per-failure analogue of the Go C<lib-gdpr/validator>
+C<Result> struct: code-driven, machine-actionable, but with a
+ready-to-display string already attached.
+
+C<Validator::Failure> objects are created by
+L<GDPR::IAB::TCFv2::Validator> and surfaced via
+L<GDPR::IAB::TCFv2::Validator::Result/failures>; users normally do not
+construct them directly.
+
+=head1 OVERLOADS
+
+=head2 Stringification
+
+    print "$failure";
+
+Returns L</message>, so a Failure object drops into any context that
+expects a reason string.
+
+=head1 METHODS
+
+=head2 code
+
+    my $code = $failure->code;
+
+Integer reason code from L<GDPR::IAB::TCFv2::Validator::Reason>. Use
+this to switch on the failure type programmatically.
+
+=head2 message
+
+    my $msg = $failure->message;
+
+Human-readable description of the failure (the same string previously
+returned by L<GDPR::IAB::TCFv2::Validator::Result/reasons>).
+
+=head2 purpose_id
+
+    my $pid = $failure->purpose_id;
+
+The TCF purpose ID associated with the failure, or C<undef> when the
+failure is not purpose-specific (e.g. a missing-disclosed-vendors
+failure or a CMP failure).
+
+=head2 vendor_id
+
+    my $vid = $failure->vendor_id;
+
+The vendor ID under validation when the failure occurred, or
+C<undef> when the failure is not vendor-specific.
+
+=head2 restriction_type
+
+    my $rt = $failure->restriction_type;
+
+The publisher restriction type (0 = NotAllowed, 1 = RequireConsent,
+2 = RequireLegitimateInterest) when the failure was caused by a
+publisher restriction, or C<undef> otherwise. Currently always
+C<undef> -- distinct restriction-type reasons are introduced in a
+follow-up phase.
+
+=head2 cmp_id
+
+    my $cmp = $failure->cmp_id;
+
+The CMP ID from the consent string when the failure was caused by the
+CMP-validator rule, or C<undef> otherwise.
+
+=head1 CONSTRUCTOR
+
+=head2 new
+
+Internal -- C<Validator::Failure> objects are constructed by
+L<GDPR::IAB::TCFv2::Validator> as it walks its rules, then surfaced
+via L<GDPR::IAB::TCFv2::Validator::Result/failures>.
+
+=head1 SEE ALSO
+
+L<GDPR::IAB::TCFv2::Validator::Reason> for the reason-code vocabulary,
+L<GDPR::IAB::TCFv2::Validator::Result> for the container type returned
+by L<GDPR::IAB::TCFv2::Validator/validate>.
+
+=cut

--- a/lib/GDPR/IAB/TCFv2/Validator/Reason.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Reason.pm
@@ -56,6 +56,13 @@ use constant {
     # The consent string could not be decoded (malformed, empty, or
     # unsupported version). Only emitted when explicitly requested.
     ReasonDecodeError => 12,
+
+    # The consent string's CMP ID is not recognized as a valid (active,
+    # non-deleted) entry in the configured CMP registry. The CMPValidator
+    # rule today returns a single boolean; a future refinement may
+    # introduce ReasonCMPDeleted / ReasonCMPUnknown to distinguish the
+    # lifecycle states (codes reserved for that work).
+    ReasonInvalidCMP => 13,
 };
 
 use constant ReasonDescription => {
@@ -78,6 +85,7 @@ use constant ReasonDescription => {
       "legitimate interest not permitted for purpose",
     ReasonPolicyVersionTooLow => "tcf policy version too low",
     ReasonDecodeError         => "decode error",
+    ReasonInvalidCMP          => "invalid cmp id",
 };
 
 # Lazily built reverse map: integer code -> human-readable string.
@@ -113,6 +121,7 @@ our @EXPORT_OK = qw<
   ReasonLegitimateInterestNotPermittedForPurpose
   ReasonPolicyVersionTooLow
   ReasonDecodeError
+  ReasonInvalidCMP
   ReasonDescription
   reason_string
 >;
@@ -232,6 +241,14 @@ configured C<min_policy_version>.
 Code 12. The consent string could not be decoded (malformed, empty, or
 unsupported version). Only emitted when the validator is configured to
 report decode errors as structured failures rather than via C<croak>.
+
+=head2 ReasonInvalidCMP
+
+Code 13. The consent string's CMP ID is not recognized as a valid
+(active, non-deleted) entry in the configured CMP registry. The
+C<CMPValidator> rule today returns a single boolean; a future
+refinement may add C<ReasonCMPDeleted> / C<ReasonCMPUnknown> to
+distinguish lifecycle states (the codes are reserved for that work).
 
 =head2 ReasonDescription
 

--- a/lib/GDPR/IAB/TCFv2/Validator/Result.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Result.pm
@@ -11,15 +11,15 @@ use overload
 
     # Use $ORS (Output Record Separator) or newline as fallback
     my $sep = defined($\) ? $\ : "\n";
-    return join( $sep, @{ $self->{reasons} || [] } );
+    return join( $sep, map { $_->message } @{ $self->{failures} || [] } );
   };
 
 sub new {
     my ( $klass, %args ) = @_;
 
     my $self = {
-        ok      => $args{ok}      || 0,
-        reasons => $args{reasons} || [],
+        ok       => $args{ok}       || 0,
+        failures => $args{failures} || [],
     };
 
     return bless $self, $klass;
@@ -27,9 +27,19 @@ sub new {
 
 sub is_valid { $_[0]->{ok} }
 
+sub failures {
+    my $self = shift;
+    return @{ $self->{failures} || [] };
+}
+
+sub reason_codes {
+    my $self = shift;
+    return map { $_->code } @{ $self->{failures} || [] };
+}
+
 sub reasons {
     my $self = shift;
-    return @{ $self->{reasons} || [] };
+    return map { $_->message } @{ $self->{failures} || [] };
 }
 
 1;
@@ -107,8 +117,34 @@ prefer it.
 
     my @reasons = $result->reasons;
 
-Returns the list of human-readable failure reasons. Empty for a passing
-result.
+Returns the list of human-readable failure reason strings. Empty for
+a passing result. Equivalent to C<map { $_-E<gt>message } $result-E<gt>failures>.
+
+=head2 failures
+
+    my @failures = $result->failures;
+
+Returns the list of structured L<GDPR::IAB::TCFv2::Validator::Failure>
+objects. Each failure carries a stable integer C<code>, the
+human-readable C<message>, and any structured context (purpose,
+vendor, restriction type, CMP). Use this when you need to react
+programmatically to specific failure types.
+
+    use GDPR::IAB::TCFv2::Validator::Reason qw<:all>;
+
+    for my $f ( $result->failures ) {
+        if ( $f->code == ReasonVendorNotAllowedConsent ) {
+            handle_consent_gap( $f->purpose_id );
+        }
+    }
+
+=head2 reason_codes
+
+    my @codes = $result->reason_codes;
+
+Returns the list of integer reason codes. Equivalent to
+C<map { $_-E<gt>code } $result-E<gt>failures>; useful when only the
+codes are needed (e.g. for assertions or counters).
 
 =head1 CONSTRUCTOR
 
@@ -119,6 +155,8 @@ than directly.
 
 =head1 SEE ALSO
 
-L<GDPR::IAB::TCFv2::Validator>.
+L<GDPR::IAB::TCFv2::Validator>,
+L<GDPR::IAB::TCFv2::Validator::Failure>,
+L<GDPR::IAB::TCFv2::Validator::Reason>.
 
 =cut

--- a/t/15-validator-reason.t
+++ b/t/15-validator-reason.t
@@ -23,9 +23,10 @@ subtest 'all reason codes are distinct non-negative integers' => sub {
         ReasonLegitimateInterestNotPermittedForPurpose(),
         ReasonPolicyVersionTooLow(),
         ReasonDecodeError(),
+        ReasonInvalidCMP(),
     );
 
-    is( scalar(@codes), 13, 'all 13 reason codes accounted for' );
+    is( scalar(@codes), 14, 'all 14 reason codes accounted for' );
 
     is( ReasonNone, 0, 'ReasonNone is zero (sentinel for success)' );
 
@@ -68,6 +69,7 @@ subtest 'reason_string returns the canonical description for each code' =>
         ],
         [ ReasonPolicyVersionTooLow(), "tcf policy version too low" ],
         [ ReasonDecodeError(),         "decode error" ],
+        [ ReasonInvalidCMP(),          "invalid cmp id" ],
     );
 
     for my $case (@cases) {

--- a/t/16-validator-failures.t
+++ b/t/16-validator-failures.t
@@ -1,0 +1,175 @@
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use File::Spec;
+use lib 'lib';
+
+use GDPR::IAB::TCFv2::Validator;
+use GDPR::IAB::TCFv2::Validator::Failure;
+use GDPR::IAB::TCFv2::Validator::Reason qw<:all>;
+
+# A known-valid TC string from elsewhere in the test suite. CMP id 21,
+# vendor consents include 32. Used as the baseline for failure-injecting
+# variations below.
+my $tc_string =
+  'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA';
+
+subtest 'Validator::Failure: round-trip and stringification' => sub {
+    my $f = GDPR::IAB::TCFv2::Validator::Failure->new(
+        code             => ReasonPublisherRestrictionNotAllowed,
+        message          => "publisher restriction: not allowed (purpose 5)",
+        purpose_id       => 5,
+        vendor_id        => 284,
+        restriction_type => 0,
+    );
+
+    is( $f->code, ReasonPublisherRestrictionNotAllowed, 'code accessor' );
+    is( $f->message, "publisher restriction: not allowed (purpose 5)",
+        'message accessor'
+    );
+    is( $f->purpose_id,       5,     'purpose_id accessor' );
+    is( $f->vendor_id,        284,   'vendor_id accessor' );
+    is( $f->restriction_type, 0,     'restriction_type accessor' );
+    is( $f->cmp_id,           undef, 'cmp_id is undef when not set' );
+
+    is( "$f", "publisher restriction: not allowed (purpose 5)",
+        'stringification returns message'
+    );
+};
+
+subtest 'Validator::Failure: unset structured fields are undef' => sub {
+    my $f = GDPR::IAB::TCFv2::Validator::Failure->new(
+        code    => ReasonVendorNotAllowed,
+        message => "vendor not allowed",
+    );
+
+    is( $f->purpose_id,       undef, 'purpose_id defaults to undef' );
+    is( $f->vendor_id,        undef, 'vendor_id defaults to undef' );
+    is( $f->restriction_type, undef, 'restriction_type defaults to undef' );
+    is( $f->cmp_id,           undef, 'cmp_id defaults to undef' );
+};
+
+subtest 'Validator::Result: passing result has no failures' => sub {
+    my $validator = GDPR::IAB::TCFv2::Validator->new( vendor_id => 32 );
+    my $result    = $validator->validate($tc_string);
+
+    ok( $result,           'result is truthy when validation passes' );
+    ok( $result->is_valid, 'is_valid is true when validation passes' );
+
+    my @failures = $result->failures;
+    is( scalar @failures, 0, 'no failures on a passing result' );
+
+    my @codes = $result->reason_codes;
+    is( scalar @codes, 0, 'no reason codes on a passing result' );
+
+    my @reasons = $result->reasons;
+    is( scalar @reasons, 0, 'no reason strings on a passing result' );
+
+    is( "$result", '', 'stringifies to empty on success' );
+};
+
+subtest
+  'Validator::Result: failing result exposes failures + codes + reasons' =>
+  sub {
+
+    # Vendor 99999 is well above any vendor in the fixture, so
+    # consent for any required purpose will fail. Forces predictable
+    # ReasonVendorNotAllowedConsent failures.
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id           => 99999,
+        consent_purpose_ids => [ 1, 3 ],
+    );
+    my $result = $validator->validate_all($tc_string);
+
+    ok( !$result,           'result is falsy on failure' );
+    ok( !$result->is_valid, 'is_valid is false on failure' );
+
+    my @failures = $result->failures;
+    cmp_ok( scalar @failures, '>=', 1, 'at least one failure recorded' );
+
+    isa_ok $failures[0], 'GDPR::IAB::TCFv2::Validator::Failure',
+      'each entry is a Failure object';
+
+    my @codes   = $result->reason_codes;
+    my @reasons = $result->reasons;
+    is( scalar @codes,   scalar @failures, 'reason_codes count matches' );
+    is( scalar @reasons, scalar @failures, 'reasons count matches' );
+
+    # All consent-purpose failures should carry the consent code and
+    # the offending vendor + purpose ids.
+    for my $f (@failures) {
+        is( $f->code, ReasonVendorNotAllowedConsent,
+            'consent-path failures use ReasonVendorNotAllowedConsent'
+        );
+        is( $f->vendor_id, 99999, 'vendor_id is set on the failure' );
+        ok( defined $f->purpose_id, 'purpose_id is set on the failure' );
+    }
+
+    # Stringified result is the failure messages joined per the
+    # output-record-separator overload (legacy contract).
+    like(
+        "$result", qr/vendor 99999 not allowed for purpose/,
+        'stringification includes failure messages'
+    );
+  };
+
+subtest
+  'Validator::Result: min_policy_version failure carries correct code' => sub {
+
+    # The fixture TC string uses TCF policy version 2 (pre v2.3).
+    # A floor of 5 forces a ReasonPolicyVersionTooLow failure on the
+    # first rule, before any vendor/purpose check.
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id          => 32,
+        min_policy_version => 5,
+    );
+    my $result = $validator->validate($tc_string);
+
+    ok( !$result, 'result is falsy when policy version is too low' );
+
+    my @failures = $result->failures;
+    is( scalar @failures, 1, 'fail-fast yields exactly one failure' );
+
+    is( $failures[0]->code, ReasonPolicyVersionTooLow,
+        'code is ReasonPolicyVersionTooLow'
+    );
+    like(
+        $failures[0]->message,
+        qr/policy version \d+ is below required minimum 5/,
+        'message describes the policy-version mismatch'
+    );
+  };
+
+subtest 'Validator::Result: invalid CMP carries ReasonInvalidCMP' => sub {
+    require GDPR::IAB::TCFv2::CMPValidator;
+
+    my $cmp_file = File::Spec->catfile(
+        $FindBin::Bin, 'corpus',
+        'cmp-list.json'
+    );
+
+    # CMP 888 is not in the fixture; this TC string carries it.
+    my $tc_unknown_cmp =
+      'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id     => 1,
+        cmp_validator => { file => $cmp_file, now => 1776254400 },
+    );
+    my $result = $validator->validate($tc_unknown_cmp);
+
+    ok( !$result, 'unknown CMP fails validation' );
+
+    my @failures = $result->failures;
+    is( scalar @failures, 1, 'fail-fast yields exactly one failure' );
+
+    is( $failures[0]->code, ReasonInvalidCMP,
+        'code is ReasonInvalidCMP'
+    );
+    is( $failures[0]->cmp_id, 888,
+        'cmp_id is set to the CMP from the consent string'
+    );
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

First substantive PR of Phase 6 (Structured Failure Reporting). Adds the data model that the rest of Phase 6 will build on.

**New module** \`GDPR::IAB::TCFv2::Validator::Failure\` — a lightweight value object representing a single validation failure:
- \`code\` — stable integer reason code (from \`Validator::Reason\`).
- \`message\` — human-readable string (the same string previously returned by \`reasons()\`).
- Optional structured context: \`purpose_id\`, \`vendor_id\`, \`restriction_type\`, \`cmp_id\`.
- Stringifies to \`message\` so it drops into existing display code without ceremony.

**Extended** \`GDPR::IAB::TCFv2::Validator::Result\` with two new accessors:
| Accessor | Returns |
|---|---|
| \`failures()\` | list of \`Validator::Failure\` objects (machine-actionable) |
| \`reason_codes()\` | list of integer codes (when codes are all you need) |

The bool/stringify overloads, \`is_valid()\`, and \`reasons()\` are **unchanged** — \`reasons()\` now derives from \`Failure->message\`, but the strings it returns are byte-identical.

**Validator.pm** internals migrated to push Failure objects with the appropriate \`Reason*\` code + structured fields:
- \`ReasonPolicyVersionTooLow\` — \`min_policy_version\` mismatch
- \`ReasonVendorNotDisclosed\` — \`check_disclosed_vendors\` miss
- \`ReasonVendorNotAllowedConsent\` / \`...LegitimateInterest\` — per-purpose flag missing
- \`ReasonInvalidCMP\` — \`cmp_validator\` rejection (carries \`cmp_id\`)

**\`Validator::Reason\`** gains \`ReasonInvalidCMP\` (code 13). \`ReasonCMPDeleted\` / \`ReasonCMPUnknown\` are reserved for a future refinement that lets \`CMPValidator\` distinguish lifecycle states (slot documented in the comment).

## Out of scope (Phase 6.3-6.5)

- TCF spec carve-out reason (\`ReasonLegitimateInterestNotPermittedForPurpose\` for P1 / P3-6 LI).
- Distinct publisher-restriction reasons (validator inspecting restrictions before delegating).
- Per-call list overrides for purpose IDs.

## Test plan

- [x] \`t/16-validator-failures.t\` — 6 subtests / 32+ assertions:
    - Failure round-trip and stringification.
    - Unset structured fields are \`undef\`.
    - Passing result has empty failures/codes/reasons + empty stringification.
    - Failing result exposes failures + codes + reasons; codes match expected reason; structured fields populated.
    - \`min_policy_version\` failure has \`ReasonPolicyVersionTooLow\`.
    - Invalid-CMP failure has \`ReasonInvalidCMP\` and the \`cmp_id\` from the consent string.
- [x] \`t/15-validator-reason.t\` updated for the new \`ReasonInvalidCMP\` constant (14 codes total).
- [x] \`prove -lr t/\` — 17542 tests pass (including unchanged \`t/06-validator.t\` and \`t/14-cmp-validator.t\`).
- [x] \`prove -lr xt/\` — critic + tidy green (54 tests).

## No version bump

Phase 6 ships as v0.400 once 6.2-6.5 (and the CMPValidator follow-up) are all merged. This PR is structurally additive on existing callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)