### PR TITLE
feat(validator): per-call list overrides (Phase 6.5)

### DIFF
--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -123,6 +123,26 @@ sub _run_validation {
       ? _coerce_cmp_validator( $overrides{cmp_validator} )
       : $self->{cmp_validator};
 
+    # Per-call list overrides. Coherence is not re-validated here:
+    # orphan flexible purposes (a pid in flexible_purpose_ids that
+    # isn't also in consent_purpose_ids or legitimate_interest_purpose_ids)
+    # are silently dropped because the rule loops only iterate over the
+    # consent/LI lists, so the flex flag for an orphan is unreachable.
+    # This keeps per-call overrides forgiving while the constructor
+    # remains strict for the static policy.
+    my $consent_ids =
+      exists $overrides{consent_purpose_ids}
+      ? $overrides{consent_purpose_ids}
+      : $self->{consent_purpose_ids};
+    my $li_ids =
+      exists $overrides{legitimate_interest_purpose_ids}
+      ? $overrides{legitimate_interest_purpose_ids}
+      : $self->{legitimate_interest_purpose_ids};
+    my $flexible_set =
+      exists $overrides{flexible_purpose_ids}
+      ? { map { $_ => 1 } @{ $overrides{flexible_purpose_ids} } }
+      : $self->{_flexible_set};
+
     croak "missing vendor_id" unless defined $vendor_id;
 
     my @failures;
@@ -140,15 +160,15 @@ sub _run_validation {
       if $stop_on_first && @failures;
 
     $self->_check_consent_purposes(
-        $tc, $vendor_id, $strict, \@failures,
-        $stop_on_first
+        $tc,            $vendor_id,   $strict, \@failures,
+        $stop_on_first, $consent_ids, $flexible_set,
     );
     return $self->_make_result( 0, \@failures )
       if $stop_on_first && @failures;
 
     $self->_check_li_purposes(
-        $tc, $vendor_id, $strict, \@failures,
-        $stop_on_first
+        $tc,            $vendor_id, $strict, \@failures,
+        $stop_on_first, $li_ids,    $flexible_set,
     );
 
     if (@failures) {
@@ -210,10 +230,12 @@ sub _check_disclosed {
 }
 
 sub _check_consent_purposes {
-    my ( $self, $tc, $vendor_id, $strict, $failures, $stop_on_first ) = @_;
+    my ($self,        $tc, $vendor_id, $strict, $failures, $stop_on_first,
+        $consent_ids, $flexible_set
+    ) = @_;
 
-    foreach my $pid ( @{ $self->{consent_purpose_ids} } ) {
-        my $is_flexible = $self->{_flexible_set}->{$pid};
+    foreach my $pid ( @{$consent_ids} ) {
+        my $is_flexible = $flexible_set->{$pid};
 
         # Publisher-restriction inspection runs before the parser
         # delegate so a restriction-driven failure carries the precise
@@ -259,12 +281,14 @@ sub _check_consent_purposes {
 }
 
 sub _check_li_purposes {
-    my ( $self, $tc, $vendor_id, $strict, $failures, $stop_on_first ) = @_;
+    my ($self,   $tc, $vendor_id, $strict, $failures, $stop_on_first,
+        $li_ids, $flexible_set
+    ) = @_;
 
     my $policy_version = $tc->policy_version;
 
-    foreach my $pid ( @{ $self->{legitimate_interest_purpose_ids} } ) {
-        my $is_flexible = $self->{_flexible_set}->{$pid};
+    foreach my $pid ( @{$li_ids} ) {
+        my $is_flexible = $flexible_set->{$pid};
 
         # TCF carve-out: legitimate interest is never permitted for
         # Purpose 1, and is forbidden for Purposes 3-6 in TCF v2.2+
@@ -538,9 +562,18 @@ the first failing rule (B<fail-fast> mode) and returns a
 L<GDPR::IAB::TCFv2::Validator::Result> carrying that one reason.
 
 C<%overrides> can replace the constructor values for C<vendor_id>,
-C<strict>, and C<check_disclosed_vendors> for this call only. The
-arrayref rules (C<consent_purpose_ids> etc.) are not currently
-overridable per call.
+C<strict>, C<check_disclosed_vendors>, C<min_policy_version>,
+C<cmp_validator>, C<consent_purpose_ids>,
+C<legitimate_interest_purpose_ids>, and C<flexible_purpose_ids> for
+this call only.
+
+The list overrides (C<consent_purpose_ids>,
+C<legitimate_interest_purpose_ids>, C<flexible_purpose_ids>) do B<not>
+re-validate coherence — orphan entries (a flexible pid that isn't also
+in one of the basis lists) are silently dropped at runtime rather than
+fatal. This makes per-call overrides forgiving for callers that
+generate their lists dynamically; the constructor remains strict for
+the static policy.
 
 C<$tc_string_or_object> may be either a raw consent string or a
 pre-parsed L<GDPR::IAB::TCFv2> object — handy when the same TC string

--- a/t/06-validator.t
+++ b/t/06-validator.t
@@ -325,4 +325,124 @@ subtest "Validator validate_all accumulates across rule families" => sub {
       'flexible P6 with default consent reports as a consent failure';
 };
 
+subtest "Validator per-call list overrides" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+
+    subtest "consent_purpose_ids per-call override" => sub {
+
+        # Constructor list [1] would fail (V1 P1 consent=0). Per-call
+        # override [6] passes (V1 P6 consent=1) -- proves the override
+        # replaces, not merges with, the constructor list.
+        my $validator = GDPR::IAB::TCFv2::Validator->new(
+            vendor_id           => 1,
+            consent_purpose_ids => [1],
+        );
+
+        ok !$validator->validate($tc_string),
+          'baseline fails with constructor consent=[1]';
+
+        ok $validator->validate( $tc_string, consent_purpose_ids => [6] ),
+          'per-call consent=[6] passes';
+
+        my $result =
+          $validator->validate( $tc_string, consent_purpose_ids => [ 1, 6 ] );
+        ok !$result, 'per-call [1,6] still fails on P1';
+        like "$result", qr/purpose 1/, 'reason mentions P1';
+
+        ok $validator->validate( $tc_string, consent_purpose_ids => [] ),
+          'per-call empty consent list passes vacuously';
+    };
+
+    subtest "legitimate_interest_purpose_ids per-call override" => sub {
+
+        # Constructor list [10] passes (V1 P10 LI=1, policy v2 -> no
+        # carve-out for P10). Per-call switches to [1] which always
+        # triggers the LI carve-out reason (P1 forbidden for LI).
+        my $validator = GDPR::IAB::TCFv2::Validator->new(
+            vendor_id                       => 1,
+            legitimate_interest_purpose_ids => [10],
+        );
+
+        ok $validator->validate($tc_string),
+          'baseline passes with constructor LI=[10]';
+
+        my $result = $validator->validate(
+            $tc_string,
+            legitimate_interest_purpose_ids => [1],
+        );
+        ok !$result, 'per-call LI=[1] fails (carve-out)';
+        like "$result", qr/legitimate interest not permitted for purpose 1/,
+          'failure is the LI carve-out reason';
+
+        ok $validator->validate(
+            $tc_string,
+            legitimate_interest_purpose_ids => [7],
+          ),
+          'per-call LI=[7] passes (V1 P7 LI=1, no carve-out at policy v2)';
+    };
+
+    subtest "flexible_purpose_ids per-call override -- orphan drop" => sub {
+
+        # Constructor's _check_coherence would croak on flex=[99] because
+        # 99 is not in consent or LI. The per-call path skips that check:
+        # the rule loops only iterate over the consent/LI lists, so an
+        # orphan flex pid is unreachable and silently ignored at runtime.
+        my $validator = GDPR::IAB::TCFv2::Validator->new(
+            vendor_id           => 1,
+            consent_purpose_ids => [6],
+        );
+
+        my $result;
+        lives_ok {
+            $result = $validator->validate(
+                $tc_string,
+                flexible_purpose_ids => [99],
+            );
+        }
+        'per-call orphan flexible pid does not croak';
+        ok $result, 'orphan flex pid does not affect validation outcome';
+    };
+
+    subtest "all three list overrides simultaneously" => sub {
+
+        # Constructor: a passing static policy.
+        my $validator = GDPR::IAB::TCFv2::Validator->new(
+            vendor_id           => 1,
+            consent_purpose_ids => [6],
+        );
+        ok $validator->validate($tc_string), 'baseline passes';
+
+        # Per-call: replace all three lists at once.
+        # consent=[6] (passes), LI=[10] (passes), flex=[6,10] (no PR so
+        # flex API mirrors basis-direct -- still passes).
+        my $result = $validator->validate(
+            $tc_string,
+            consent_purpose_ids             => [6],
+            legitimate_interest_purpose_ids => [10],
+            flexible_purpose_ids            => [ 6, 10 ],
+        );
+        ok $result, 'all-three override passes when each list is satisfiable';
+    };
+
+    subtest "validate_all with per-call list overrides" => sub {
+
+        # Vendor 99 fails uniformly (out of range). Override all three
+        # lists per call and confirm validate_all reports a reason for
+        # each rule that fails.
+        my $validator = GDPR::IAB::TCFv2::Validator->new(
+            vendor_id           => 99,
+            consent_purpose_ids => [6],
+        );
+
+        my $result = $validator->validate_all(
+            $tc_string,
+            consent_purpose_ids             => [ 7, 8 ],
+            legitimate_interest_purpose_ids => [9],
+        );
+        ok !$result, 'validate_all reports failure under overrides';
+        is scalar( $result->reasons ), 3,
+          'three reasons accumulated (two consent + one LI)';
+    };
+};
+
 done_testing;


### PR DESCRIPTION
## Summary

- `validate()` / `validate_all()` now accept `consent_purpose_ids`, `legitimate_interest_purpose_ids`, and `flexible_purpose_ids` in the `%overrides` hash, replacing the constructor lists for that call only.
- Coherence is enforced silently by orphan-drop at runtime: a flexible pid that is not in either basis list is unreachable by the rule loops and is silently dropped, instead of croaking like the constructor does. This keeps per-call overrides forgiving for callers that generate their lists dynamically while leaving the static-policy constructor strict.
- Refactors the consent/LI rule helpers to take the lists and the flex set as parameters; the rule semantics are unchanged when no override is supplied (existing tests cover the static path).

## Test plan

- [x] `prove -lr t` (17548 tests, all pass)
- [x] `AUTHOR_TESTING=1 prove -lr xt` (54 tests, perlcritic + perltidy clean)
- [x] New subtests in `t/06-validator.t` cover: per-call consent override, per-call LI override (incl. carve-out trigger), orphan-flex drop without croak, simultaneous three-list override, `validate_all` with overrides
- [x] CI green on devel target

🤖 Generated with [Claude Code](https://claude.com/claude-code)