### PR TITLE
fix: Perl 5.8 compat -- replace // with defined()

### DIFF
--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -318,7 +318,7 @@ sub run_validate {
         my $cmp_v;
         {
             local $SIG{__WARN__} = sub {
-                my $msg = $_[0] // '';
+                my $msg = defined( $_[0] ) ? $_[0] : '';
                 return if $msg =~ /CMP list is older than 28 days/;
                 warn @_;
               }

--- a/lib/GDPR/IAB/TCFv2/CMPValidator.pm
+++ b/lib/GDPR/IAB/TCFv2/CMPValidator.pm
@@ -81,7 +81,8 @@ sub load_from_file {
 sub load_from_url {
     my ( $self, $url ) = @_;
 
-    my $client = $self->{http_client} // do {
+    my $client = $self->{http_client};
+    unless ( defined $client ) {
         eval { require HTTP::Tiny; 1 }
           or croak "HTTP::Tiny is required to load CMP list from URL. "
           . "Please install it or use a local file instead.";
@@ -90,12 +91,12 @@ sub load_from_url {
         # verify_SSL => 1 (default): pin the secure default regardless
         # of the installed HTTP::Tiny version (older versions defaulted
         # to 0).
-        HTTP::Tiny->new(
+        $client = HTTP::Tiny->new(
             env_proxy  => 1,
             verify_SSL => $self->{verify_ssl},
             timeout    => $self->{timeout},
         );
-    };
+    }
 
     my $response = $client->get($url);
     croak "Failed to fetch CMP list from '$url': $response->{reason}"

--- a/lib/GDPR/IAB/TCFv2/Validator/Reason.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Reason.pm
@@ -104,7 +104,8 @@ sub reason_string {
         }
     }
 
-    return $_CODE_TO_STRING{$code} // "unknown validation failure";
+    my $string = $_CODE_TO_STRING{$code};
+    return defined($string) ? $string : "unknown validation failure";
 }
 
 our @EXPORT_OK = qw<


### PR DESCRIPTION
## Summary

Fixes the CPAN testers FAIL on Perl 5.8.9 (report: [365d9728-4aa1-11f1-9fd8-a2d66d8775ea](https://www.cpantesters.org/cpan/report/365d9728-4aa1-11f1-9fd8-a2d66d8775ea)).

The dist's \`MIN_PERL_VERSION\` is 5.008, but three sites used the defined-or operator \`//\`, a Perl 5.10 feature. On Perl 5.8 the parser treats \`//\` as the empty regex match and consumes tokens until it finds a closing \`/\`, producing confusing \"runaway multi-line // string\" errors when followed by \`do { ... }\` blocks or comments containing slashes.

Three sites fixed:

| File | Line | Was |
|---|---|---|
| `lib/.../CMPValidator.pm` | 84 | `my $client = $self->{http_client} // do { ... }` |
| `lib/.../Validator/Reason.pm` | 107 | `return $_CODE_TO_STRING{$code} // "unknown..."` |
| `bin/iabtcfv2` | 321 | `my $msg = $_[0] // ''` |

Each replaced with `defined($x) ? $x : $y` (or an `unless ( defined ... )` block where it reads more naturally).

Static audit confirms no other 5.10+ features (`state`, `~~`, `use feature`) in `lib/` or `bin/`.

## Test plan

- [x] `prove -lr t` (17547 tests, all pass)
- [x] `AUTHOR_TESTING=1 prove -lr xt` (perlcritic + perltidy clean)
- [x] CI green on devel target
- [ ] Follow-up (separate PR): consider adding Perl 5.8.9 to the GHA Linux matrix to lock this in

🤖 Generated with [Claude Code](https://claude.com/claude-code)