### PR TITLE
chore(cmp-validator): drop local $VERSION declaration

### DIFF
--- a/lib/GDPR/IAB/TCFv2/CMPValidator.pm
+++ b/lib/GDPR/IAB/TCFv2/CMPValidator.pm
@@ -8,8 +8,6 @@ use JSON::PP     ();
 use Scalar::Util qw<blessed>;
 use Time::Piece;
 
-our $VERSION = '0.001';
-
 sub new {
     my ( $klass, %args ) = @_;
 


### PR DESCRIPTION
## Summary

CMPValidator carried its own `our $VERSION = '0.001'`, the only sub-package in the distribution to do so. Every other module under `lib/GDPR/IAB/TCFv2/` derives its version from the dist's `VERSION_FROM` in Makefile.PL, which means the `provides` map in META reports the dist version uniformly across the family.

Removing the line brings CMPValidator into the same convention. The `provides` entry will now report `"0"` (the `MM->parse_version` fallback when no `$VERSION` is found), matching how every other sibling module is shipped today.

## Test plan

- [x] `prove -lr t` passes
- [x] `AUTHOR_TESTING=1 prove -lr xt` (perlcritic + perltidy clean)
- [x] CI green on devel target

🤖 Generated with [Claude Code](https://claude.com/claude-code)