### PR TITLE
chore(pod): normalize parser-family abstracts to "TCF v2.3"

### DIFF
--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -1053,7 +1053,7 @@ __END__
 
 =head1 NAME
 
-GDPR::IAB::TCFv2 - Transparency & Consent String version 2 parser 
+GDPR::IAB::TCFv2 - TCF v2.3 (Transparency & Consent String) parser
 
 =head1 SYNOPSIS
 

--- a/lib/GDPR/IAB/TCFv2/BitField.pm
+++ b/lib/GDPR/IAB/TCFv2/BitField.pm
@@ -111,7 +111,7 @@ __END__
 
 =head1 NAME
 
-GDPR::IAB::TCFv2::BitField - Transparency & Consent String version 2 bitfield parser
+GDPR::IAB::TCFv2::BitField - TCF v2.3 bitfield parser
 
 =head1 SYNOPSIS
 

--- a/lib/GDPR/IAB/TCFv2/BitUtils.pm
+++ b/lib/GDPR/IAB/TCFv2/BitUtils.pm
@@ -179,9 +179,9 @@ sub _add_padding {
 1;
 __END__
 
-=head1 NAME 
+=head1 NAME
 
-GDPR::IAB::TCFv2::BitUtils - utilities functions to manage bits
+GDPR::IAB::TCFv2::BitUtils - TCF v2.3 bit-level decoding utilities
  
 =head1 SYNOPSIS
     use GDPR::IAB::TCFv2::BitUtils qw<get_uint16>;

--- a/lib/GDPR/IAB/TCFv2/Constants/RestrictionType.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/RestrictionType.pm
@@ -32,7 +32,7 @@ __END__
 
 =head1 NAME
 
-GDPR::IAB::TCFv2::Constants::RestrictionType - TCF v2.3 publisher restriction type for vendor 
+GDPR::IAB::TCFv2::Constants::RestrictionType - TCF v2.3 publisher restriction types
 
 =head1 SYNOPSIS
 

--- a/lib/GDPR/IAB/TCFv2/Publisher.pm
+++ b/lib/GDPR/IAB/TCFv2/Publisher.pm
@@ -104,7 +104,7 @@ __END__
 
 =head1 NAME
 
-GDPR::IAB::TCFv2::Publisher - Transparency & Consent String version 2 publisher
+GDPR::IAB::TCFv2::Publisher - TCF v2.3 publisher section parser
 
 Combines the creation of L<GDPR::IAB::TCFv2::PublisherRestrictions> and L<GDPR::IAB::TCFv2::PublisherTC> based on the data available.
 

--- a/lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm
+++ b/lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm
@@ -153,7 +153,7 @@ __END__
 
 =head1 NAME
 
-GDPR::IAB::TCFv2::PublisherRestrictions - Transparency & Consent String version 2 publisher restriction
+GDPR::IAB::TCFv2::PublisherRestrictions - TCF v2.3 publisher restrictions parser
 
 =head1 SYNOPSIS
 

--- a/lib/GDPR/IAB/TCFv2/PublisherTC.pm
+++ b/lib/GDPR/IAB/TCFv2/PublisherTC.pm
@@ -195,7 +195,7 @@ __END__
 
 =head1 NAME
 
-GDPR::IAB::TCFv2::PublisherTC - Transparency & Consent String version 2 publisher tc
+GDPR::IAB::TCFv2::PublisherTC - TCF v2.3 publisher TC section parser
 
 =head1 SYNOPSIS
 

--- a/lib/GDPR/IAB/TCFv2/RangeSection.pm
+++ b/lib/GDPR/IAB/TCFv2/RangeSection.pm
@@ -206,7 +206,7 @@ __END__
 
 =head1 NAME
 
-GDPR::IAB::TCFv2::RangeSection - Transparency & Consent String version 2 range section parser
+GDPR::IAB::TCFv2::RangeSection - TCF v2.3 range section parser
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
## Summary

The `=head1 NAME` abstracts in the parser family used a mix of *"Transparency & Consent String version 2 X"* and *"TCF v2.3 X"*. Three modules (`Constants/Purpose`, `Constants/SpecialFeature`, the relevant `Constants/RestrictionType`) already used the shorter *"TCF v2.3 X"* form; the remaining six did not.

Normalize the parser family to one canonical form so MetaCPAN, kwalitee abstracts, and the dist's `provides` map present a consistent vocabulary:

| Module | New abstract |
|---|---|
| `GDPR::IAB::TCFv2` | TCF v2.3 (Transparency & Consent String) parser |
| `GDPR::IAB::TCFv2::BitField` | TCF v2.3 bitfield parser |
| `GDPR::IAB::TCFv2::BitUtils` | TCF v2.3 bit-level decoding utilities |
| `GDPR::IAB::TCFv2::Publisher` | TCF v2.3 publisher section parser |
| `GDPR::IAB::TCFv2::PublisherRestrictions` | TCF v2.3 publisher restrictions parser |
| `GDPR::IAB::TCFv2::PublisherTC` | TCF v2.3 publisher TC section parser |
| `GDPR::IAB::TCFv2::RangeSection` | TCF v2.3 range section parser |
| `GDPR::IAB::TCFv2::Constants::RestrictionType` | TCF v2.3 publisher restriction types |

Also fixes two stray trailing spaces on `=head1 NAME` lines (BitUtils, RestrictionType).

The validator family (`Validator`, `CMPValidator`, `Validator::Failure`, `Validator::Result`, `Validator::Reason`) keeps existing role-based abstracts since they describe a role within the dist rather than the spec.

## Test plan

- [x] `prove -lr t` (17547 tests, all pass)
- [x] `AUTHOR_TESTING=1 prove -lr xt` (perlcritic + perltidy clean)
- [x] CI green on devel target

🤖 Generated with [Claude Code](https://claude.com/claude-code)