### PR TITLE
chore(docker): bump to perl:5.42-slim, use --with-recommends

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # --- Stage 1: Build & Install ---
-FROM perl:5.40-slim AS builder
+FROM perl:5.42-slim AS builder
 
-# Install build dependencies
+# Build dependencies (compiler + headers for any XS deps that recommends pulls
+# in -- JSON::XS, Net::SSLeay, IO::Socket::SSL, etc.).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     make \
     gcc \
@@ -10,43 +11,45 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install cpanminus
 RUN cpanm --notest App::cpanminus
 
 WORKDIR /build
 
-# Copy the entire project
 COPY . .
 
-# Install dependencies and the module itself
-# We include JSON::XS for performance and Net::SSLeay for SSL support
-RUN cpanm --notest --installdeps . \
-    && cpanm --notest JSON::XS Net::SSLeay IO::Socket::SSL DateTimeX::TO_JSON
+# Install runtime + recommends in one shot.
+#   --installdeps .       : honors PREREQ_PM
+#   --with-recommends     : pulls JSON::PP, Time::Piece, HTTP::Tiny, JSON,
+#                           JSON::XS, DateTimeX::TO_JSON from the META
+#                           recommends block. Net::SSLeay / IO::Socket::SSL
+#                           come in transitively through HTTP::Tiny for HTTPS.
+#   --with-test-recommends: include test-side recommends so a CI rebuild of
+#                           this image can reproduce the full test environment.
+RUN cpanm --notest --with-recommends --with-test-recommends --installdeps .
 
-# Install the module to /usr/local
 RUN perl Makefile.PL \
     && make \
     && make install
 
 # --- Stage 2: Runtime ---
-FROM perl:5.40-slim
+FROM perl:5.42-slim
 
-# Install runtime SSL libraries
+# Runtime SSL libs only; build-time toolchain is left in stage 1.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl3 \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy installed files from builder
-# We copy /usr/local completely to ensure all libs and binaries are present
+# Copy installed Perl modules + the iabtcfv2 binary.
 COPY --from=builder /usr/local /usr/local
 
-# Set environment variables
-ENV PERL5LIB=/usr/local/lib/perl5/site_perl/5.40.0:/usr/local/share/perl5/site_perl/5.40.0
+# Discover the perl version dynamically rather than hard-coding 5.42.0; the
+# base image bumps will then only require touching the FROM line above.
 ENV PATH="/usr/local/bin:${PATH}"
 
-# Smoke test (iabtcfv2 --help exits with 1)
-RUN iabtcfv2 --help; if [ $? -ne 1 ]; then exit 1; else exit 0; fi
+# Smoke test: --version exits 0 cleanly and confirms the dist + the iabtcfv2
+# CLI loaded together.
+RUN iabtcfv2 --version
 
 ENTRYPOINT ["iabtcfv2"]
 CMD ["--help"]


### PR DESCRIPTION
## Summary

Aligns the Docker image with the optional-dep model introduced for CMPValidator (PR #70).

- `FROM perl:5.40-slim` → `perl:5.42-slim` (latest stable Perl, mid-2025)
- `cpanm` now runs with `--with-recommends --with-test-recommends`, so the META `recommends` block (JSON::PP, Time::Piece, HTTP::Tiny, JSON, JSON::XS, DateTimeX::TO_JSON) materializes in the image. Net::SSLeay and IO::Socket::SSL come in transitively via HTTP::Tiny for HTTPS.
- Drop the now-redundant explicit `cpanm --notest JSON::XS Net::SSLeay IO::Socket::SSL DateTimeX::TO_JSON` line; `--with-recommends` covers it.
- Drop the hard-coded `PERL5LIB` env (`5.40.0`). The base perl image already has site_perl in `@INC` by default; future bumps now only require touching the `FROM` lines.
- Smoke test changed from `iabtcfv2 --help` (exits 1) to `iabtcfv2 --version` (exits 0). Cleaner success signal.

## Test plan

- [x] `docker build -t gdpr-iab-tcfv2:test .` succeeds locally
- [x] `iabtcfv2 --version` runs in the image (exit 0)
- [x] `echo TC_STRING | docker run --rm -i gdpr-iab-tcfv2:test dump` produces valid JSON output

## Notes

The `--help` exit-code idiom (`pod2usage(... -exitval => 1)`) is still in `bin/iabtcfv2`; flipping it to `0` would be a separate behavior change for CLI conventions and isn't bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)