### PR TITLE
chore(docs): maintenance-mode handover (TODO.pod + ECOSYSTEM)

### DIFF
--- a/CONTRIBUTING.pod
+++ b/CONTRIBUTING.pod
@@ -21,6 +21,21 @@ to render it in a terminal:
 
     perldoc CONTRIBUTING.pod
 
+=head1 PROJECT STATUS
+
+As of 2026-05-08 (the v0.400 release), C<GDPR-IAB-TCFv2> is in
+B<maintenance mode>. Bug fixes, security fixes, CPAN-tester
+regressions, and IAB-spec updates remain in scope. Larger feature work
+-- roadmap Phases 7-9, the distribution items (DockerHub automation,
+Debian package), and the sister-distribution ideas -- is now tracked
+as B<help-wanted> issues on GitHub.
+
+If you are looking for a place to contribute, the
+L<help-wanted issues|https://github.com/peczenyj/GDPR-IAB-TCFv2/issues?q=is%3Aopen+label%3Ahelp-wanted>
+are the curated entry point. F<TODO.pod> at the repository root has
+the full ecosystem and roadmap context, including suggested API
+sketches and test scopes for each item.
+
 =head1 PATCHING, STEP BY STEP
 
 =over 4

--- a/MANIFEST
+++ b/MANIFEST
@@ -46,3 +46,4 @@ t/corpus/gdpr_subset.txt
 t/corpus/golden.jsonl.gz
 t/corpus/validator_scenarios.pl
 t/generate_golden.pl
+TODO.pod

--- a/README.md
+++ b/README.md
@@ -30,6 +30,25 @@
 
 GDPR::IAB::TCFv2 - TCF v2.3 (Transparency & Consent String) parser
 
+# PROJECT STATUS
+
+`GDPR::IAB::TCFv2` entered **maintenance mode** on 2026-05-08 with the
+v0.400 release. The core parser, validator, and CMP-validator surfaces
+are considered feature-complete for the IAB TCF v2.3 specification.
+
+In maintenance mode the maintainer commits to bug fixes, security
+fixes, CPAN-tester regression triage, and tracking IAB-spec updates
+(TCF v2.4 / v3 if and when they ship). Larger feature work -- the
+remaining roadmap phases (GVL-aware validator, Special Features /
+Special Purposes, CLI configuration loading), the distribution items
+(DockerHub automation, Debian package), and the sister-distribution
+ideas in ["ECOSYSTEM"](#ecosystem) -- is now tracked as `help-wanted` issues on
+GitHub.
+
+Patches and PRs from the community are welcome and will continue to be
+reviewed. See `TODO.pod` at the repository root for the full
+help-wanted list and `CONTRIBUTING.pod` for the patching workflow.
+
 # SYNOPSIS
 
 The purpose of this package is to parse Transparency & Consent String (TC String) as defined by IAB version 2.
@@ -614,6 +633,44 @@ using [ISO\_8601](https://en.wikipedia.org/wiki/ISO_8601). This behaviour can be
 ## looksLikeIsConsentVersion2
 
 Will check if a given tc string starts with a literal `C`.
+
+# ECOSYSTEM
+
+The following **sister distributions** are intentionally left as
+`help-wanted` ideas rather than shipped from this module. Each one is
+companion glue for a popular Perl framework and would add a runtime
+dependency on its host framework, so they belong as separate CPAN
+distributions rather than features of `GDPR::IAB::TCFv2` itself.
+
+- [GDPR::IAB::TCFv2::Validator::LIVR](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3AValidator%3A%3ALIVR)
+
+    LIVR rule-engine binding for JSON-shaped TC string payloads.
+
+- [GDPR::IAB::TCFv2::Validator::TypeTiny](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3AValidator%3A%3ATypeTiny)
+
+    Reusable Type::Tiny constraints (parameterized by purpose / vendor
+    sets) for Moo, Moose, or pure-Perl callers that prefer type-level
+    enforcement.
+
+- [Plack::Middleware::GDPR::TCFv2](https://metacpan.org/pod/Plack%3A%3AMiddleware%3A%3AGDPR%3A%3ATCFv2)
+
+    Plack middleware that decodes a TC string from a request header or
+    cookie, attaches a parsed `GDPR::IAB::TCFv2` object to `$env`,
+    and short-circuits the response when consent is missing or invalid.
+
+- [GDPR::IAB::TCFv2::Validator::Moose](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3AValidator%3A%3AMoose)
+
+    Moose attribute traits and role-based validation for Moose-end-to-end
+    projects.
+
+- [GDPR::IAB::TCFv2::Validator::FormValidator](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3AValidator%3A%3AFormValidator)
+
+    `Data::FormValidator` profile glue for legacy applications that drive
+    business validation through DFV.
+
+The `help-wanted` issues on GitHub track each of these ideas; see
+[https://github.com/peczenyj/GDPR-IAB-TCFv2/issues?q=label%3Aecosystem](https://github.com/peczenyj/GDPR-IAB-TCFv2/issues?q=label%3Aecosystem)
+and `TODO.pod` for context.
 
 # SEE ALSO
 

--- a/TODO.pod
+++ b/TODO.pod
@@ -1,0 +1,338 @@
+# To read this file, run:
+#    perldoc TODO.pod
+
+=encoding utf8
+
+=head1 NAME
+
+TODO - Roadmap, ecosystem, and help-wanted items for GDPR::IAB::TCFv2
+
+=head1 STATUS
+
+C<GDPR-IAB-TCFv2> entered B<maintenance mode> on 2026-05-08 with the
+v0.400 release. The core parser, validator, and CMP-validator surfaces
+are considered feature-complete for IAB TCF v2.3.
+
+In maintenance mode the maintainer commits to:
+
+=over 4
+
+=item *
+
+bug fixes,
+
+=item *
+
+security fixes,
+
+=item *
+
+CPAN-tester regression triage,
+
+=item *
+
+tracking IAB-spec updates (TCF v2.4 / v3 if and when they ship).
+
+=back
+
+Larger feature work -- the three remaining roadmap phases below, the
+distribution items, and the sister-distribution ideas -- is now tracked
+as B<help-wanted> issues on GitHub. Patches and PRs from the community
+are still welcome and will continue to be reviewed.
+
+This document supersedes the older flat F<TODO.md>, which will be
+removed in a follow-up cleanup PR after v0.400 lands on CPAN.
+
+=head1 COMPLETED PHASES
+
+The phases below shipped between v0.270 and v0.400. They are listed
+here for historical context only; details live in F<CHANGELOG.md> and
+the linked PRs.
+
+=over 4
+
+=item Phase 0 -- Core legal-basis predicates
+
+C<is_vendor_consent_allowed>, C<is_vendor_legitimate_interest_allowed>,
+C<is_vendor_allowed_for_flexible_purpose>, plus C<strict> mode.
+
+=item Phase 1 -- TCF v2.3 segments and parser robustness
+
+Disclosed Vendors / Allowed Vendors segments, multi-segment safety,
+C<has_vendor_disclosure>, C<has_publisher_restrictions>, the
+C<vendor_id> filter on C<TO_JSON>, and the automated release workflow.
+
+=item Phase 2 -- Declarative validator interface
+
+C<GDPR::IAB::TCFv2::Validator> with C<validate> / C<validate_all> and
+C<Validator::Result>.
+
+=item Phase 3 -- Alignment and cleanup
+
+Purpose names normalized to TCF v2.3 wording; POD streamlined.
+
+=item Phase 4 -- Performance pass
+
+Bitfield decode optimizations and golden-corpus benchmarks.
+
+=item Phase 5 -- CMP validator
+
+C<GDPR::IAB::TCFv2::CMPValidator> with file / JSON / URL loading,
+staleness warning, and integration into the main validator as a rule.
+
+=item Phase 6 -- Structured failure reporting
+
+Five sub-phases (6.1 -- 6.5) delivering C<Validator::Reason> codes,
+C<Validator::Failure> objects, the TCF LI carve-out, distinct
+publisher-restriction reasons, and per-call list overrides.
+
+=back
+
+=head1 HELP WANTED -- ROADMAP PHASES
+
+Three roadmap phases were originally planned for inclusion in this
+distribution but are now open for community contribution. Each is
+self-contained and can ship as an independent PR; pick one and open
+(or claim) the corresponding C<help-wanted> + C<roadmap> issue on
+GitHub.
+
+=head2 Phase 7 -- GVL-Aware Validator
+
+Bridge the IAB Global Vendor List schema to the Phase 2 validator so
+callers do not have to translate vendor entries by hand.
+
+Scope:
+
+=over 4
+
+=item *
+
+C<from_gvl_vendor_entry($vendor_entry)> -- accept a single GVL vendor
+entry (C<{ id, purposes, legIntPurposes, flexiblePurposes }>) and
+return the keyword-argument list expected by C<< Validator->new >>.
+
+=item *
+
+C<from_gvl($gvl_doc, $vendor_id)> -- look up the vendor in a parsed
+GVL document and return a fully configured C<Validator>; fail fast
+if the vendor ID is missing.
+
+=item *
+
+Flexible GVL input: file path, raw JSON string, or pre-parsed hashref.
+
+=item *
+
+CLI integration: C<iabtcfv2 validate --gvl path/to/gvl.json -v 32 ...>
+should derive C<-C> / C<-L> / C<-F> from the GVL entry.
+
+=item *
+
+Tests: golden GVL fixture covering vendors with and without flexible
+purposes; round-trip C<from_gvl_vendor_entry> against a hand-crafted
+entry.
+
+=back
+
+=head2 Phase 8 -- Features, Special Features, Special Purposes
+
+Extend the validator beyond standard purposes to cover the rest of the
+TCF taxonomy. Should consume the C<REASON_*> codes introduced in
+Phase 6.
+
+Scope:
+
+=over 4
+
+=item *
+
+Validator support for B<Special Features> (opt-in, e.g. precise
+geolocation): require the bit in the TC string when listed.
+
+=item *
+
+Validator support for B<Features> (vendor-declared): no consent
+required, but cross-check the vendor's GVL declaration once Phase 7
+lands.
+
+=item *
+
+Validator support for B<Special Purposes>: legitimate-interest-only by
+spec; check vendor declaration without requiring a consent bit.
+
+=item *
+
+Surface on the CLI as C<--special-features> / C<--features> /
+C<--special-purposes> (comma-separated, same shape as C<-C> / C<-L>).
+
+=item *
+
+Tests: extend F<t/06-validator.t> with subtests per category; extend
+F<t/10-cli-iabtcfv2.t> with CLI subtests.
+
+=back
+
+=head2 Phase 9 -- CLI Configuration Loading
+
+Reduce CLI boilerplate by letting common flags come from the
+environment or a config file.
+
+Scope:
+
+=over 4
+
+=item *
+
+Map a curated set of env vars to CLI flags: C<IABTCFV2_VENDOR_ID>,
+C<IABTCFV2_CONSENT_PURPOSES>,
+C<IABTCFV2_LEGITIMATE_INTEREST_PURPOSES>,
+C<IABTCFV2_FLEXIBLE_PURPOSES>, C<IABTCFV2_MIN_POLICY_VERSION>.
+Explicit CLI flags always win.
+
+=item *
+
+Optional config-file discovery: F<.iabtcfv2rc> in C<$PWD> or C<$HOME>
+(plus C<.env>-style loading if present). Documented precedence:
+CLI > env > file > built-in defaults.
+
+=item *
+
+C<iabtcfv2 config> (or C<validate --print-config>) to dump the resolved
+configuration as JSON for debugging.
+
+=item *
+
+Tests: a CLI subtest that sets the env vars, runs C<validate> without
+the matching flags, and asserts the same outcome as the explicit
+invocation.
+
+=back
+
+=head1 HELP WANTED -- DISTRIBUTION
+
+These items are about packaging the existing code, not about adding
+features.
+
+=head2 DockerHub publication
+
+A F<Dockerfile> already lives at the repo root and is exercised in CI.
+Outstanding work: a GitHub Actions workflow that builds and pushes
+C<peczenyj/gdpr-iab-tcfv2:VERSION> and C<:latest> to DockerHub on every
+C<v*> tag push. The release narrative in F<CONTRIBUTING.pod> step 9
+already references the expected image name.
+
+=head2 Debian package (libgdpr-iab-tcfv2-perl)
+
+Generate C<debian/> metadata via C<dh-make-perl> and wire up a build
+pipeline that produces signed C<.deb> artifacts. Useful for Debian and
+Ubuntu deployments that prefer apt over CPAN.
+
+=head1 ECOSYSTEM -- SISTER DISTRIBUTIONS
+
+The following ideas are intentionally B<separate CPAN distributions>
+rather than features of this one. Each adds a runtime dependency on
+its host framework, so packaging them separately keeps
+C<GDPR::IAB::TCFv2>'s own deps lean.
+
+=head2 Highest priority
+
+=over 4
+
+=item *
+
+L<GDPR::IAB::TCFv2::Validator::LIVR>
+
+LIVR rule-engine binding for JSON-shaped TC payloads.
+
+=item *
+
+L<GDPR::IAB::TCFv2::Validator::TypeTiny>
+
+Reusable Type::Tiny constraints (parameterized by purpose / vendor
+sets) for Moo, Moose, or pure-Perl callers that prefer type-level
+enforcement.
+
+=item *
+
+L<Plack::Middleware::GDPR::TCFv2>
+
+Plack middleware that decodes a TC string from a request header or
+cookie, attaches the parsed C<GDPR::IAB::TCFv2> object to C<< $env >>,
+and short-circuits the response when consent is missing or invalid.
+
+=back
+
+=head2 Nice to have
+
+=over 4
+
+=item *
+
+L<GDPR::IAB::TCFv2::Validator::Moose>
+
+Moose attribute traits and role-based validation for projects that
+already use Moose end-to-end.
+
+=item *
+
+L<GDPR::IAB::TCFv2::Validator::FormValidator>
+
+C<Data::FormValidator> profile glue for legacy applications that drive
+business validation through DFV.
+
+=back
+
+=head1 HOW TO CLAIM AN ITEM
+
+=over 4
+
+=item 1.
+
+Open a GitHub issue (or comment on the existing one) referencing the
+phase or sister-distribution name above. Include a rough scoping
+sketch: what API you are proposing, what tests you will add, and which
+existing module the work will touch.
+
+=item 2.
+
+Wait for a maintainer to assign the issue. This avoids duplicate
+effort and surfaces any spec questions early.
+
+=item 3.
+
+Follow the patching workflow in F<CONTRIBUTING.pod>: branch from
+C<devel>, run the full test suite (C<prove -lr t> plus
+C<AUTHOR_TESTING=1 prove -lr xt>), open a PR.
+
+=back
+
+=head1 OUT OF SCOPE
+
+The following are intentionally B<not> on the roadmap:
+
+=over 4
+
+=item *
+
+C<TCF v1> support (legacy, no longer maintained by the IAB).
+
+=item *
+
+Network-side discovery of CMP or GVL endpoints. The library accepts
+pre-loaded data; fetching is the caller's responsibility (or the
+optional C<HTTP::Tiny> path inside C<CMPValidator>).
+
+=item *
+
+Persistent caching of parsed strings. TC strings are cheap to parse;
+caching is a deployment concern, not a library concern.
+
+=back
+
+=head1 SEE ALSO
+
+L<GDPR::IAB::TCFv2>, L<GDPR::IAB::TCFv2::Validator>,
+L<GDPR::IAB::TCFv2::CMPValidator>, F<CONTRIBUTING.pod>,
+F<CHANGELOG.md>.
+
+=cut

--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -907,6 +907,25 @@ __END__
 
 GDPR::IAB::TCFv2 - TCF v2.3 (Transparency & Consent String) parser
 
+=head1 PROJECT STATUS
+
+C<GDPR::IAB::TCFv2> entered B<maintenance mode> on 2026-05-08 with the
+v0.400 release. The core parser, validator, and CMP-validator surfaces
+are considered feature-complete for the IAB TCF v2.3 specification.
+
+In maintenance mode the maintainer commits to bug fixes, security
+fixes, CPAN-tester regression triage, and tracking IAB-spec updates
+(TCF v2.4 / v3 if and when they ship). Larger feature work -- the
+remaining roadmap phases (GVL-aware validator, Special Features /
+Special Purposes, CLI configuration loading), the distribution items
+(DockerHub automation, Debian package), and the sister-distribution
+ideas in L</ECOSYSTEM> -- is now tracked as C<help-wanted> issues on
+GitHub.
+
+Patches and PRs from the community are welcome and will continue to be
+reviewed. See F<TODO.pod> at the repository root for the full
+help-wanted list and F<CONTRIBUTING.pod> for the patching workflow.
+
 =head1 SYNOPSIS
 
 The purpose of this package is to parse Transparency & Consent String (TC String) as defined by IAB version 2.
@@ -1541,6 +1560,58 @@ using L<ISO_8601|https://en.wikipedia.org/wiki/ISO_8601>. This behaviour can be 
 =head2 looksLikeIsConsentVersion2
 
 Will check if a given tc string starts with a literal C<C>.
+
+=head1 ECOSYSTEM
+
+The following B<sister distributions> are intentionally left as
+C<help-wanted> ideas rather than shipped from this module. Each one is
+companion glue for a popular Perl framework and would add a runtime
+dependency on its host framework, so they belong as separate CPAN
+distributions rather than features of C<GDPR::IAB::TCFv2> itself.
+
+=over 4
+
+=item *
+
+L<GDPR::IAB::TCFv2::Validator::LIVR>
+
+LIVR rule-engine binding for JSON-shaped TC string payloads.
+
+=item *
+
+L<GDPR::IAB::TCFv2::Validator::TypeTiny>
+
+Reusable Type::Tiny constraints (parameterized by purpose / vendor
+sets) for Moo, Moose, or pure-Perl callers that prefer type-level
+enforcement.
+
+=item *
+
+L<Plack::Middleware::GDPR::TCFv2>
+
+Plack middleware that decodes a TC string from a request header or
+cookie, attaches a parsed C<GDPR::IAB::TCFv2> object to C<< $env >>,
+and short-circuits the response when consent is missing or invalid.
+
+=item *
+
+L<GDPR::IAB::TCFv2::Validator::Moose>
+
+Moose attribute traits and role-based validation for Moose-end-to-end
+projects.
+
+=item *
+
+L<GDPR::IAB::TCFv2::Validator::FormValidator>
+
+C<Data::FormValidator> profile glue for legacy applications that drive
+business validation through DFV.
+
+=back
+
+The C<help-wanted> issues on GitHub track each of these ideas; see
+L<https://github.com/peczenyj/GDPR-IAB-TCFv2/issues?q=label%3Aecosystem>
+and F<TODO.pod> for context.
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
## Summary

Stages the v0.400 transition into a maintenance-mode posture without removing anything yet. This is **Phase B** of the multi-PR release plan; PRs C/D/E follow once this lands.

### What changes

- **New `TODO.pod`** at the repo root. Reframes the work as:
  - **Completed phases** (0-6.5) — historical context for v0.270 → v0.400.
  - **Help-wanted roadmap** — Phases 7 (GVL-aware validator), 8 (Special Features / Special Purposes), 9 (CLI configuration loading), each with API sketches and test scopes.
  - **Help-wanted distribution** — DockerHub automation, Debian package.
  - **Ecosystem (sister distributions)** — five separate-CPAN-dist ideas: `Validator::LIVR`, `Validator::TypeTiny`, `Plack::Middleware::GDPR::TCFv2`, `Validator::Moose`, `Validator::FormValidator`.
  - **How to claim an item** + **Out of scope** sections.

  The old `TODO.md` is **intentionally kept** until v0.400 ships — a follow-up cleanup PR removes it post-release.

- **`lib/GDPR/IAB/TCFv2.pm`** — adds `=head1 PROJECT STATUS` after `NAME` and `=head1 ECOSYSTEM` before `SEE ALSO`. Both surface in the regenerated README and on MetaCPAN.

- **`CONTRIBUTING.pod`** — adds `=head1 PROJECT STATUS` between `DESCRIPTION` and `PATCHING`, pointing readers at the `help-wanted` issues and `TODO.pod`.

- **`README.md`** — regenerated via `pod2markdown lib/GDPR/IAB/TCFv2.pm`.

- **`MANIFEST`** — `make manifest` adds the new `TODO.pod` entry.

### Verified locally

- `podchecker TODO.pod CONTRIBUTING.pod lib/GDPR/IAB/TCFv2.pm` → OK (the two pre-existing whitespace warnings inside the SYNOPSIS code blocks are unrelated to this change)
- `prove -lr t` → **17548 pass**
- `AUTHOR_TESTING=1 prove -lr xt` → 54 pass (tidy + critic clean)

### Out of scope (intentionally)

- **No code changes**, no version bump, no `CHANGELOG` entry. This PR is documentation-only so the v0.400 release-prep PR (Phase D) stays purely about the version bump.
- **No GitHub issues created yet** — that is Phase C, after this merges, so the issues can link to `TODO.pod` on `devel`.
- **`TODO.md` is not deleted** — Phase E does that after v0.400 lands on CPAN, so anyone with a bookmarked link still sees a valid file during the transition.

## Test plan

- [x] `prove -lr t` (17548 tests pass)
- [x] `AUTHOR_TESTING=1 prove -lr xt` (POD + perltidy + perlcritic clean)
- [x] `podchecker` clean on all touched POD files
- [x] `pod2markdown lib/GDPR/IAB/TCFv2.pm > README.md` produces the committed README
- [x] `make manifest` produces no further diff
- [ ] CI green on Linux / Windows / macOS / Perl latest matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)