### PR TITLE
chore: declare MIN_PERL_VERSION 5.8.9 (last change before v0.400)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        perl: ["5.12.2"]
+        perl: ["5.8.9", "5.12.2"]
         include:
           - perl: 'latest'
             coverage: true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,12 @@ jobs:
           perl-version: ${{ matrix.perl }}
       - run: perl -V
       - run: cpanm -v
-      - run: cpanm File::ShareDir::Install Test::CheckManifest Test::CPAN::Meta::JSON Test::CPAN::Meta Test::Pod
+      # Test::CheckManifest is omitted: its dep tree (Pod::Coverage::TrustPod ->
+      # Mixin::Linewise -> Sub::Exporter ...) requires Perl 5.12+, which would
+      # break the 5.8.9 matrix entry. Nothing in this repo uses it (no
+      # t/00-checkmanifest.t); `cpanm --installdeps .` below pulls in the
+      # actual TEST_REQUIRES from Makefile.PL.
+      - run: cpanm File::ShareDir::Install Test::CPAN::Meta::JSON Test::CPAN::Meta Test::Pod
       - name: Install Author Test Dependencies
         if: ${{ matrix.coverage }}
         run: cpanm -n Test::Perl::Critic Test::PerlTidy

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,7 +28,13 @@ jobs:
       # break the 5.8.9 matrix entry. Nothing in this repo uses it (no
       # t/00-checkmanifest.t); `cpanm --installdeps .` below pulls in the
       # actual TEST_REQUIRES from Makefile.PL.
-      - run: cpanm File::ShareDir::Install Test::CPAN::Meta::JSON Test::CPAN::Meta Test::Pod
+      #
+      # Test::More is forced here because Perl 5.12.2 ships Test::More 0.94
+      # (exactly our declared floor), and that vintage has subtest handling
+      # bugs that mis-report inner failures as "no plan was declared". Older
+      # Perls (5.8.9) ship something older, so cpanm upgrades them anyway;
+      # 5.12.2 needs the explicit nudge.
+      - run: cpanm Test::More File::ShareDir::Install Test::CPAN::Meta::JSON Test::CPAN::Meta Test::Pod
       - name: Install Author Test Dependencies
         if: ${{ matrix.coverage }}
         run: cpanm -n Test::Perl::Critic Test::PerlTidy

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,7 +6,7 @@ WriteMakefile(
   LICENSE          => "perl_5",
   ABSTRACT_FROM    => 'lib/GDPR/IAB/TCFv2.pm',
   VERSION_FROM     => 'lib/GDPR/IAB/TCFv2.pm',
-  MIN_PERL_VERSION => 5.008,
+  MIN_PERL_VERSION => '5.008009',
   EXE_FILES        => ['bin/iabtcfv2'],
   TEST_REQUIRES    => {
 


### PR DESCRIPTION
## Summary

- Bumps `MIN_PERL_VERSION` from `5.008` to `'5.008009'` in `Makefile.PL`. Quoted form so MakeMaker preserves the trailing-`9` precision on every Perl.
- Adds `5.8.9` to the Linux CI matrix (`5.12.2` and `latest` were already there). The floor is now exercised on every push, not just declared.
- META.json now reports `"perl": "5.008009"` after `perl Makefile.PL`.

This is the **last code change before the v0.400 release** -- the next PR is the version bump itself.

## Why 5.8.9

The Phase 6.x work and the recent observation fixes (notably #71's `// -> defined()` swap) all targeted Perl 5.8 explicitly. 5.8.9 is the oldest version a serious downstream is still on, and is the floor we are willing to support in maintenance mode. Anything older is out of scope.

## Verified locally

- `perl Makefile.PL` -> `MYMETA.json` shows `"perl": "5.008009"`.
- `prove -lr t` -> **17548 pass**.
- `AUTHOR_TESTING=1 prove -lr xt` -> **54 pass** (tidy + critic clean).

## Test plan

- [x] `prove -lr t`
- [x] `AUTHOR_TESTING=1 prove -lr xt`
- [x] `MYMETA.json` reports `5.008009`
- [x] CI green on the new `Perl 5.8.9 on ubuntu` matrix entry, plus `5.12.2`, `latest`, macOS, Windows, Docker.

## Out of scope

No CHANGELOG entry here -- the v0.400 release-prep PR (next) groups all the unreleased changes (perltidyrc swap, Dockerfile bump, observation fixes, this min-perl bump) into a single CHANGELOG block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)