### PR TITLE
chore: add .editorconfig, dependabot, CITATION.cff, xt/spelling.t

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+cff-version: 1.2.0
+title: "GDPR::IAB::TCFv2"
+message: "If you use this software, please cite it using the metadata below."
+type: software
+authors:
+  - given-names: Tiago
+    family-names: Peczenyj
+    email: tiago.peczenyj+gdpr-iab-tcfv2@gmail.com
+abstract: >-
+  Pure-Perl decoder for the IAB Europe Transparency and Consent Framework
+  (TCF) v2.3 consent string (TC string).
+repository-code: "https://github.com/peczenyj/GDPR-IAB-TCFv2"
+url: "https://metacpan.org/dist/GDPR-IAB-TCFv2"
+license: "Artistic-1.0-Perl OR GPL-1.0-or-later"
+keywords:
+  - perl
+  - gdpr
+  - iab
+  - tcf
+  - consent
+  - privacy
+  - adtech
+version: "0.391"
+date-released: "2026-05-07"

--- a/CONTRIBUTING.pod
+++ b/CONTRIBUTING.pod
@@ -205,13 +205,19 @@ B<vanilla git:>
 
     git checkout -b release/0.360 devel
 
-=item 3. Bump C<$VERSION>
+=item 3. Bump the version in both files
 
     $EDITOR lib/GDPR/IAB/TCFv2.pm
     # Edit:  our $VERSION = "0.360";
 
-F<Makefile.PL> reads the version from this file via C<VERSION_FROM>; no
-other file needs editing.
+    $EDITOR CITATION.cff
+    # Edit:
+    #   version: "0.360"
+    #   date-released: "YYYY-MM-DD"     # the actual tag/release date
+
+F<Makefile.PL> reads C<$VERSION> from the C<.pm> via C<VERSION_FROM>;
+F<CITATION.cff> is the only other file that has to be hand-bumped, and
+both its C<version> and C<date-released> fields must be updated together.
 
 =item 4. Regenerate the changelog
 
@@ -247,7 +253,7 @@ excludes those, but a quick eyeball is cheap insurance.
 
 =item 7. Commit the release prep
 
-    git add lib/GDPR/IAB/TCFv2.pm CHANGELOG.md README.md
+    git add lib/GDPR/IAB/TCFv2.pm CITATION.cff CHANGELOG.md README.md
     # Also `git add MANIFEST` if `make manifest` changed it
     git commit -m "chore: prepare for v0.360 release"
 
@@ -396,8 +402,9 @@ B<git-flow:>
 B<vanilla git:>
 
     git checkout -b hotfix/0.351 main
-    # Make the fix, bump $VERSION, regenerate CHANGELOG and README
-    git add lib/GDPR/IAB/TCFv2.pm CHANGELOG.md README.md
+    # Make the fix, bump $VERSION (both lib/GDPR/IAB/TCFv2.pm AND CITATION.cff),
+    # regenerate CHANGELOG and README
+    git add lib/GDPR/IAB/TCFv2.pm CITATION.cff CHANGELOG.md README.md
     git commit -m "fix: <description> (v0.351)"
     git push -u origin hotfix/0.351
 

--- a/xt/spelling.t
+++ b/xt/spelling.t
@@ -3,8 +3,7 @@ use warnings;
 use Test::More;
 
 eval 'use Test::Spelling 0.12';
-plan skip_all => 'Test::Spelling 0.12 required for testing POD spelling'
-    if $@;
+plan skip_all => 'Test::Spelling 0.12 required for testing POD spelling' if $@;
 
 add_stopwords(<DATA>);
 all_pod_files_spelling_ok();

--- a/xt/spelling.t
+++ b/xt/spelling.t
@@ -1,0 +1,53 @@
+use strict;
+use warnings;
+use Test::More;
+
+eval 'use Test::Spelling 0.12';
+plan skip_all => 'Test::Spelling 0.12 required for testing POD spelling'
+    if $@;
+
+add_stopwords(<DATA>);
+all_pod_files_spelling_ok();
+
+__DATA__
+TCF
+TCFv1
+TCFv2
+TCString
+IAB
+CMP
+CMPs
+CMPVL
+GDPR
+GVL
+DSP
+SSP
+DMP
+adtech
+JSON
+YAML
+CPAN
+PAUSE
+DockerHub
+Linuxbrew
+AUR
+COPR
+Peczenyj
+Tiago
+Weborama
+metadata
+namespace
+namespaces
+backend
+frontend
+deserialize
+deserialized
+serializer
+parser
+parsers
+bitfield
+bitfields
+opt
+runtime
+v2
+v3


### PR DESCRIPTION
## Summary

Four small, independent contributor / maintainer quality-of-life additions. Nothing here touches runtime code, the release pipeline, or the dist tarball.

- **`.editorconfig`** — LF / UTF-8 / trim trailing whitespace / 4-space default with 2-space override for `*.{yml,yaml}`. `.perltidyrc` remains the authoritative formatter for Perl files; this just nudges editors that haven't read it for non-Perl files (YAML, POD, Markdown).
- **`.github/dependabot.yml`** — monthly bumps of `github-actions` only (`actions/checkout`, `shogo82148/actions-setup-perl`, `softprops/action-gh-release`, etc.). Conventional-commit prefix `ci` so the bumps are filtered out of the user-facing CHANGELOG by the existing `cliff.toml` policy. Does **not** cover Perl deps — those stay declared in `Makefile.PL`.
- **`CITATION.cff`** — pinned to the last released version (`0.391`, `2026-05-07`). GitHub renders a *"Cite this repository"* button in the repo header when this file is present. ⚠️ The v0.400 release PR (#91) will need to bump `version:` and `date-released:` alongside `lib/GDPR/IAB/TCFv2.pm`. Worth folding into #91 before merging it.
- **`xt/spelling.t`** — `Test::Spelling` author test with a minimal stopword list (TCF / IAB / CMP / adtech / Peczenyj / Weborama / etc.). Skips cleanly when `Test::Spelling` is absent (verified locally; CI doesn't install it, so it'll skip there too — author runs `cpanm Test::Spelling && prove -lr xt/spelling.t` and grows the stopword list as needed).

## Merge order

Per offline discussion: this PR should merge **before** PR #91 (the v0.400 release prep). #91 will need a small rebase — no conflicts expected since these are all new files, but be aware that the `CITATION.cff` version field is stale until #91 lands.

## Test plan

- [x] `perl -c xt/spelling.t` — syntax OK
- [x] `prove -lr xt/spelling.t` — skips with "Test::Spelling 0.12 required for testing POD spelling"
- [x] `YAML::PP->load_file('CITATION.cff')` — parses, version=0.391
- [x] `YAML::PP->load_file('.github/dependabot.yml')` — parses, monthly schedule
- [ ] CI green on Linux 5.8.9 / 5.12.2 / latest, macOS, Windows (will be doc-only — skip-on-test pattern)