### PR TITLE
docs: align POD and error messages with implementation

### DIFF
--- a/lib/GDPR/IAB/TCFv2/BitUtils.pm
+++ b/lib/GDPR/IAB/TCFv2/BitUtils.pm
@@ -196,6 +196,14 @@ Will fetch 2 bits from data since bit offset and convert it an unsigned int.
 
     my $value = get_uint2( $data, $offset );
 
+=head2 get_uint3
+
+Receive two parameters: data and bit offset.
+
+Will fetch 3 bits from data since bit offset and convert it an unsigned int.
+
+    my $segment_type = get_uint3( $data, 0 );
+
 =head2 get_uint6
 
 Receive two parameters: data and bit offset.
@@ -204,17 +212,16 @@ Will fetch 6 bits from data since bit offset and convert it an unsigned int.
 
     my $version = get_uint6( $data, 0 );
 
-=head2 get_char6
-
-Similar to L<GDPR::IAB::TCFv2::BitUtils::get_uint6> but perform increment the value with the ascii value of "A" letter and convert to a character.
-
 =head2 get_char6_pair
 
-Receives the data, bit offset and sequence size n.
+Receives the data and bit offset.
 
-Returns a string of size n by concatenate L<GDPR::IAB::TCFv2::BitUtils::get_char6> calls.
+Reads two consecutive 6-bit values starting at C<$offset>, increments each
+by the ASCII value of the letter C<A>, and returns the resulting two-letter
+string. Used to decode the C<consent_language> and C<publisher_country_code>
+fields of the TCF v2 core string.
 
-    my $consent_language = get_char6_pair($data, 108, 2) # returns two letter country encoded as ISO_639-1 
+    my $consent_language = get_char6_pair($data, 108); # returns two letter country encoded as ISO_639-1
 
 =head2 get_uint12
 
@@ -239,5 +246,5 @@ Receives the data and bit offset.
 Will fetch 36 bits from data since bit offset and convert it an unsigned int (long).
 
     my $deciseconds = get_uint36( $data, 6 );
-    my $created = $deciseconds/2;
+    my $created = $deciseconds/10;
 

--- a/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
@@ -302,7 +302,7 @@ Illustrations:
 
 =item *
 
-A technology platform working withA technology platform working with a social media provider notices a growth in mobile app users, and sees based on their profiles that many of them are connecting through mobile connections. It uses a new technology to deliver ads that are formatted for mobile devices and that are low-bandwidth, to improve their performance. a social media provider notices a growth in mobile app users, and sees based on their profiles that many of them are connecting through mobile connections. It uses a new technology to deliver ads that are formatted for mobile devices and that are low-bandwidth, to improve their performance.
+A technology platform working with a social media provider notices a growth in mobile app users, and sees based on their profiles that many of them are connecting through mobile connections. It uses a new technology to deliver ads that are formatted for mobile devices and that are low-bandwidth, to improve their performance.
 
 =item *
 

--- a/lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
@@ -71,11 +71,10 @@ With your acceptance, your precise location (within a radius of less than 500 me
 Special feature id 2: Actively scan device characteristics for identification
 
 With your acceptance, certain characteristics specific to your device might be requested and used to distinguish it from other devices (such as the installed fonts or plugins, the resolution of your screen) in support of the purposes explained in this notice.
-      "description": 
 
 =head2 SpecialFeatureDescription
 
-Returns a hashref with a mapping between all restriction types and their description.
+Returns a hashref with a mapping between all special feature ids and their description.
 
 =head1 NAME ALIASES
 

--- a/lib/GDPR/IAB/TCFv2/Publisher.pm
+++ b/lib/GDPR/IAB/TCFv2/Publisher.pm
@@ -69,7 +69,7 @@ sub has_restrictions {
 }
 
 sub publisher_tc {
-  my ($self, $callback) = @_;
+  my ($self) = @_;
 
   return $self->{publisher_tc};
 }
@@ -201,7 +201,7 @@ Example, by parsing the consent C<COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4A
          7,
          10
       ],
-      "custom_purpose" : {
+      "custom_purposes" : {
          "consents" : [],
          "legitimate_interests" : []
       },

--- a/lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm
+++ b/lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm
@@ -194,18 +194,20 @@ Example, by parsing the consent C<COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4A
 
 =head2 TO_JSON
 
-Returns a hashref with the following format:
+Returns a hashref keyed by purpose id; each inner hashref maps vendor id
+to the integer C<restriction_type> that vendor was given for that purpose:
 
     {
         '[purpose id]' => {
-            # 0 - Not Allowed
-            # 1 - Require Consent
-            # 2 - Require Legitimate Interest
-            '[vendor id]' => 1,
+            # value is the restriction type:
+            #   0 - Not Allowed
+            #   1 - Require Consent
+            #   2 - Require Legitimate Interest
+            '[vendor id]' => '[restriction type]',
         },
     }
 
-Example, by parsing the consent C<COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA> we can generate this hashref.
+Example, by parsing the consent C<COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA> we can generate this hashref (vendor 32 has restriction type 1 -- Require Consent -- for purpose 7):
 
     {
         "7" => {

--- a/lib/GDPR/IAB/TCFv2/PublisherTC.pm
+++ b/lib/GDPR/IAB/TCFv2/PublisherTC.pm
@@ -173,10 +173,10 @@ GDPR::IAB::TCFv2::PublisherTC - TCF v2.3 publisher TC section parser
         options      => { json => ... },
     );
 
-    say num_custom_purposes;
+    say "publisher declares ", $publisher_tc->num_custom_purposes, " custom purposes";
 
-    say "there is publisher restriction on purpose id 1, type 0 on vendor 284"
-        if $publisher_tc->check_restriction(1, 0, 284);
+    say "publisher consents to purpose 1"
+        if $publisher_tc->is_purpose_consent_allowed(1);
 
 =head1 CONSTRUCTOR
 
@@ -212,7 +212,7 @@ The user's consent value for each Purpose established on the legal basis of cons
 
 =head2 is_purpose_legitimate_interest_allowed
 
-The Purposes transparency requir'ements are met for each Purpose established on the legal basis of legitimate interest and the user has not exercised their "Right to Object" to that Purpose.
+The Purposes transparency requirements are met for each Purpose established on the legal basis of legitimate interest and the user has not exercised their "Right to Object" to that Purpose.
 
 By default or if the user has exercised their "Right to Object to a Purpose", the corresponding bit for that purpose is set to 0
 
@@ -226,24 +226,20 @@ The legitimate Interest disclosure establishment value for each custom purpose i
 
 =head2 TO_JSON
 
-Returns a hashref with the following format:
+Returns a hashref describing the publisher's purpose decisions:
 
     {
-        consents => ...,
+        consents             => ...,
         legitimate_interests => ...,
-        custom_purposes => {
-            consents => ...,
+        custom_purposes      => {
+            consents             => ...,
             legitimate_interests => ...,
         },
-        restrictions => {
-            '[purpose id]' => {
-                # 0 - Not Allowed
-                # 1 - Require Consent
-                # 2 - Require Legitimate Interest
-                '[vendor id]' => 1,
-            },
-        }
     }
+
+Publisher restrictions are emitted by L<GDPR::IAB::TCFv2::PublisherRestrictions/TO_JSON>;
+the L<GDPR::IAB::TCFv2::Publisher/TO_JSON> wrapper combines the two views into a
+single hashref.
 
 Example, by parsing the consent C<COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA.argAC0gAAAAAAAAAAAA> we can generate this compact hashref.
 
@@ -263,13 +259,8 @@ Example, by parsing the consent C<COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4A
          7,
          10
       ],
-      "custom_purpose" : {
+      "custom_purposes" : {
          "consents" : [],
          "legitimate_interests" : []
-      },
-      "restrictions" : {
-         "7" : {
-            "32" : 1
-         }
       }
     }

--- a/lib/GDPR/IAB/TCFv2/RangeSection.pm
+++ b/lib/GDPR/IAB/TCFv2/RangeSection.pm
@@ -24,8 +24,7 @@ sub Parse {
   my $max_id    = $args{max_id};
   my $options   = $args{options};
 
-  Carp::confess "a BitField for vendor consent strings using RangeSections require at least 31 bytes. Got $data_size"
-    if $data_size < 31;
+  Carp::confess "a RangeSection requires at least 31 bits. Got $data_size" if $data_size < 31;
 
   my %prefetch;
   my %cache;
@@ -76,9 +75,9 @@ sub _parse_range {
     ($start, $next_offset) = get_uint16($data, $next_offset);
     ($end,   $next_offset) = get_uint16($data, $next_offset);
 
-    croak "bit $offset range entry exclusion starts at $start, but the min vendor ID is 1" if 1 > $start;
+    croak "bit $offset range entry inclusion starts at $start, but the min vendor ID is 1" if 1 > $start;
 
-    croak "bit $offset range entry exclusion ends at $end, but the max vendor ID is $max_id" if $end > $max_id;
+    croak "bit $offset range entry inclusion ends at $end, but the max vendor ID is $max_id" if $end > $max_id;
 
     croak "start $start can't be bigger than end $end" if $start > $end;
 
@@ -95,7 +94,7 @@ sub _parse_range {
 
   ($vendor_id, $next_offset) = get_uint16($data, $next_offset);
 
-  croak "bit $offset range entry exclusion vendor $vendor_id, but only vendors [1, $max_id] are valid"
+  croak "bit $offset range entry inclusion vendor $vendor_id, but only vendors [1, $max_id] are valid"
     if 1 > $vendor_id || $vendor_id > $max_id;
 
   push @{$self->{ranges}}, [$vendor_id, $vendor_id];


### PR DESCRIPTION
## Summary

Bundle of small doc/code mismatches found while reviewing the v0.400 release. Lands before #91 so v0.400 ships these fixes.

None of these change runtime behaviour for callers passing documented arguments. They fix POD that lied about the implementation, error messages that referred to the wrong type or unit, and one silently-ignored unused parameter.

## Per-file changes

**`lib/GDPR/IAB/TCFv2/BitUtils.pm`**

- Drop the `=head2 get_char6` block — no such sub exists, no caller, no impl.
- `get_char6_pair`: drop the "sequence size n" framing (the impl is fixed at 2 chars); drop the trailing `, 2` from the example call (third arg was silently ignored).
- Add `=head2 get_uint3` — already implemented and exported, used by `PublisherTC` for segment-type decoding, but missing from POD.
- Fix `get_uint36` example: `$deciseconds/10`, not `/2`. TCF v2 timestamps are deciseconds-since-epoch.

**`lib/GDPR/IAB/TCFv2/Publisher.pm`**

- `publisher_tc`: drop the unused `$callback` arg from the signature. Verified zero in-tree callers pass one.
- `TO_JSON` POD example: `"custom_purpose"` → `"custom_purposes"` to match the key actually emitted by `PublisherTC::TO_JSON`.

**`lib/GDPR/IAB/TCFv2/PublisherTC.pm`**

- SYNOPSIS: `$publisher_tc->num_custom_purposes` (was a bareword); drop the `check_restriction` example (that method lives on the `Publisher` wrapper, not here).
- Fix `requir'ements` typo.
- `TO_JSON` POD: scope description to purposes (the impl returns `consents` / `legitimate_interests` / `custom_purposes` only — restrictions are emitted by `PublisherRestrictions::TO_JSON`, and the combined view is in `Publisher::TO_JSON`). Drop the spurious `restrictions` block from the example and fix singular→plural in the example.

**`lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm`**

- `TO_JSON` POD: clarify the inner value is the integer `restriction_type` (0/1/2), not always 1. The impl has stored `int($restriction_type)` since this method was added.

**`lib/GDPR/IAB/TCFv2/RangeSection.pm`**

- Error message at `Parse`: `"a BitField for vendor consent strings using RangeSections"` → `"a RangeSection"`; `"31 bytes"` → `"31 bits"` (data is the unpacked bitstring; threshold compares against bit count).
- Three `"range entry exclusion"` → `"range entry inclusion"` (TCF v2 range entries describe inclusion, not exclusion).

**`lib/GDPR/IAB/TCFv2/Constants/Purpose.pm`**

- `DevelopImprove` illustration: collapse the doubled paragraph back to a single clean copy.

**`lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm`**

- `DeviceScan`: remove the stray `"description":` line left over from some earlier copy/paste.
- `SpecialFeatureDescription` POD: `"between all special feature ids and their description"` (was `"between all restriction types"`).

## Merge order

Per offline plan: this PR merges **before** #91 (v0.400 release prep). After this lands, you rebase `release/v0.400` against devel; merge #91 last.

## Test plan

- [x] `prove -lr t` — all 17,548 tests pass
- [x] `prove -lr xt/critic.t xt/tidy.t` — both pass (RangeSection.pm needed a perltidy reflow after the shorter error message; included)
- [x] `podchecker` clean on every touched file
- [x] No test asserts on the changed error message strings (`grep -rn "exclusion\|31 bytes\|BitField for vendor consent" t/` → no matches)
- [ ] CI green on Linux 5.8.9 / 5.12.2 / latest, macOS, Windows