### PR TITLE
fix: correctly handle trailing padding bits in PublisherRestrictions

### DIFF
--- a/lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm
+++ b/lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm
@@ -29,7 +29,7 @@ sub Parse {
   my $max_id    = ASSUMED_MAX_VENDOR_ID;
   my $options   = $args{options};
 
-  return if ($offset >> 3) >= $data_size;
+  return if $offset + 12 > $data_size;
 
   my ($num_restrictions, $next_offset) = get_uint12($data, $offset);
 


### PR DESCRIPTION
This PR fixes a subtle bug introduced in the performance optimizations where the `PublisherRestrictions` boundary check incorrectly compared the bit-offset to the bit-length using an unexpected conversion. If a TC string had no publisher restrictions but contained trailing base64 padding bits, the parser could crash trying to read the 12-bit `num_restrictions` field. This ensures we gracefully return if there are fewer than 12 bits remaining.

It also updates the `SYNOPSIS` documentation in `BitField`, `BitUtils`, and `RangeSection` to remove `unpack "B*"` examples, aligning them with the new raw binary expectations.