### PR TITLE
fix: omit file path and line number from CLI error messages

### DIFF
--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -278,7 +278,7 @@ sub run_validate {
     }
 
     if (my $err = $@) {
-      chomp $err;
+      $err = _clean_error($err);
       warn "validate: $err\n";
       exit 2;
     }
@@ -288,7 +288,7 @@ sub run_validate {
 
   my $validator = eval { GDPR::IAB::TCFv2::Validator->new(%vargs) };
   if (my $err = $@) {
-    chomp $err;
+    $err = _clean_error($err);
     warn "validate: $err\n";
     exit 2;
   }

--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -21,6 +21,16 @@ sub _json_true {
   return JSON->can('true') ? JSON->true() : JSON::PP::true();
 }
 
+sub _clean_error {
+  my $err = shift;
+  return "" unless defined $err;
+
+  # Strip Perl/Carp's automatic " at ... line ..." location suffix
+  $err =~ s/ at \S+ line \d+\.?\n?\z//;
+  chomp $err;
+  return $err;
+}
+
 my %global_opts;
 GetOptions('help|h' => \$global_opts{help}, 'man' => \$global_opts{man}, 'version|V' => \$global_opts{version},)
   or pod2usage(-input => $script_path, -exitval => 2, -verbose => 99, -sections => "SYNOPSIS|OPTIONS|SUBCOMMANDS|BUGS");
@@ -131,7 +141,7 @@ sub _process_string {
 
     return if $o->{'ignore-errors'};
 
-    chomp $err;
+    $err = _clean_error($err);
     $output_data = {tc_string => $str, error => $err, success => _json_false(),};
 
     if ($o->{'errors-to-stderr'}) {
@@ -324,7 +334,7 @@ sub _validate_string {
 
     return if $o->{'ignore-errors'};
 
-    chomp $err;
+    $err = _clean_error($err);
     my $output_data = {tc_string => $str, error => $err, success => _json_false(),};
 
     if ($o->{'errors-to-stderr'}) {

--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -25,6 +25,9 @@ sub _clean_error {
   my $err = shift;
   return "" unless defined $err;
 
+  # If it's a reference (e.g. an exception object), return it as-is
+  return $err if ref $err;
+
   # Strip Perl/Carp's automatic " at ... line ..." location suffix
   $err =~ s/ at \S+ line \d+\.?\n?\z//;
   chomp $err;

--- a/t/10-cli-iabtcfv2.t
+++ b/t/10-cli-iabtcfv2.t
@@ -269,6 +269,32 @@ subtest 'validate subcommand' => sub {
   my $ignore_out = `$perl -Ilib $bin validate -iv 32 INVALID_STRING 2>$devnull`;
   is($ignore_out, '', '--ignore-errors silences parse error JSON');
   is($? >> 8,     1,  '--ignore-errors still exits 1');
+
+  subtest 'Clean error messages' => sub {
+    my $malformed_str = "Foo";
+
+    # Dump error
+    my $dump_err      = `$perl -Ilib $bin dump $malformed_str 2>$devnull`;
+    my $dump_err_data = decode_helper($dump_err);
+    ok($dump_err_data && $dump_err_data->{error}, "Dump got error for malformed string");
+    unlike($dump_err_data->{error}, qr/ at \S+ line \d+/, "Dump error message is clean (no location info)");
+
+    # Validate error
+    my $val_err      = `$perl -Ilib $bin validate -v 32 $malformed_str 2>$devnull`;
+    my $val_err_data = decode_helper($val_err);
+    ok($val_err_data && $val_err_data->{error}, "Validate got error for malformed string");
+    unlike($val_err_data->{error}, qr/ at \S+ line \d+/, "Validate error message is clean (no location info)");
+
+    # Initialization error (invalid CLI arg value)
+    my $init_stderr = File::Spec->catfile(File::Spec->tmpdir(), "tcf_init_stderr_$$");
+    `$perl -Ilib $bin validate -v 32 --cmp-list /non/existent/file $tc_string 2>$init_stderr`;
+    open my $fh, '<', $init_stderr or die "open $init_stderr: $!";
+    my $init_msg = do { local $/ = undef; <$fh> };
+    close $fh;
+    unlink $init_stderr;
+    ok($init_msg, "Got initialization error");
+    unlike($init_msg, qr/ at \S+ line \d+/, "Initialization error message is clean");
+  };
 };
 
 subtest '--cmp-list integration' => sub {


### PR DESCRIPTION
This PR improves the CLI user experience by stripping internal Perl/Carp location metadata (`at ... line ...`) from parse and validation error messages. End-users typically don't need to know the internal implementation details of where an error was caught.

Changes:
- Added `_clean_error` helper to `bin/iabtcfv2`.
- Applied sanitization to both `dump` and `validate` subcommands.