### PR TITLE
feat(cli): add opt-in color support

### DIFF
--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -34,11 +34,12 @@ sub _clean_error {
   return $err;
 }
 
-my %global_opts = (color => 'never',);
+my %global_opts;
 
 sub _color {
   my ($str, $color, $local_opts) = @_;
-  my $mode = ($local_opts && exists $local_opts->{color}) ? $local_opts->{color} : $global_opts{color};
+  return $str unless $local_opts && exists $local_opts->{color};
+  my $mode = $local_opts->{color};
 
   # Normalize boolean-ish or empty values from GetOptions
   # --color (no value) -> Sets $mode to '' -> treated as 'always'
@@ -60,7 +61,6 @@ GetOptions(
   'help|h'    => \$global_opts{help},
   'man'       => \$global_opts{man},
   'version|V' => \$global_opts{version},
-  'color:s'   => \$global_opts{color},
 ) or pod2usage(-input => $script_path, -exitval => 2, -verbose => 99, -sections => "SYNOPSIS|OPTIONS|SUBCOMMANDS|BUGS");
 
 if ($global_opts{version}) {
@@ -472,29 +472,6 @@ Print a brief help message and exits.
 
 Print the version and exits.
 
-=item B<--color>[=I<MODE>]
-
-Enable colored output. Mode can be B<auto>, B<always>, or B<never>.
-
-When enabled, the tool uses ANSI colors for text status (e.g. OK/FAIL), TC
-strings, and error prefixes. Requires C<Term::ANSIColor> (core).
-
-=over 4
-
-=item *
-
-B<never> (Default): No colors are used.
-
-=item *
-
-B<always> or B<--color> (without value): Colors are always enabled.
-
-=item *
-
-B<auto>: Colors are enabled only if standard output is a terminal (TTY).
-
-=back
-
 =item B<--man>
 
 Prints the manual page and exits.
@@ -540,6 +517,29 @@ Filter the output to only show data for a specific vendor ID.
 
 Enable strict specification validation. In this mode, the tool will fail if
 mandatory segments are missing (e.g., Disclosed Vendors in TCF v2.3).
+
+=item B<--color>[=I<MODE>]
+
+Enable colored output. Mode can be B<auto>, B<always>, or B<never>.
+
+When enabled, the tool uses ANSI colors for error prefixes and highlight
+metadata. Requires C<Term::ANSIColor> (core).
+
+=over 4
+
+=item *
+
+B<never> (Default): No colors are used.
+
+=item *
+
+B<always> or B<--color> (without value): Colors are always enabled.
+
+=item *
+
+B<auto>: Colors are enabled only if standard output is a terminal (TTY).
+
+=back
 
 =item B<--ignore-errors>, B<-i>
 
@@ -699,6 +699,29 @@ string carries one. Off by default.
 =item B<--strict>, B<-s>
 
 Enable strict spec validation in the underlying parser (see C<dump --strict>).
+
+=item B<--color>[=I<MODE>]
+
+Enable colored output. Mode can be B<auto>, B<always>, or B<never>.
+
+When enabled, the tool uses ANSI colors for text status (e.g. OK/FAIL), TC
+strings, and error prefixes. Requires C<Term::ANSIColor> (core).
+
+=over 4
+
+=item *
+
+B<never> (Default): No colors are used.
+
+=item *
+
+B<always> or B<--color> (without value): Colors are always enabled.
+
+=item *
+
+B<auto>: Colors are enabled only if standard output is a terminal (TTY).
+
+=back
 
 =item B<--min-policy-version>, B<-m> I<N>
 

--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -115,8 +115,17 @@ sub run_dump {
     'enable-warnings|w'  => \$opts{'enable-warnings'},
     'vendor-id|v=i'      => \$opts{'vendor-id'},
     'strict|s'           => \$opts{strict},
-    'color:s'            => \$opts{color},
-    'help|h'             => sub {
+    'color:s'            => sub {
+      my ($n, $v) = @_;
+      if ($v =~ /^(auto|always|never)$/) {
+        $opts{color} = $v;
+      }
+      else {
+        $opts{color} = 'always';
+        unshift @args, $v if defined $v && $v ne '';
+      }
+    },
+    'help|h' => sub {
       pod2usage(-input => $script_path, -exitval => 1, -verbose => 99, -sections => "DUMP|BUGS");
     },
   ) or pod2usage(-input => $script_path, -exitval => 2, -verbose => 99, -sections => "DUMP|BUGS");
@@ -251,8 +260,17 @@ sub run_validate {
     'cmp-list-timeout=i'               => \$opts{'cmp-list-timeout'},
     'all|a'                            => \$opts{all},
     'text|t'                           => \$opts{text},
-    'color:s'                          => \$opts{color},
-    'help|h'                           => sub {
+    'color:s'                          => sub {
+      my ($n, $v) = @_;
+      if ($v =~ /^(auto|always|never)$/) {
+        $opts{color} = $v;
+      }
+      else {
+        $opts{color} = 'always';
+        unshift @args, $v if defined $v && $v ne '';
+      }
+    },
+    'help|h' => sub {
       pod2usage(-input => $script_path, -exitval => 1, -verbose => 99, -sections => "VALIDATE|BUGS");
     },
   ) or pod2usage(-input => $script_path, -exitval => 2, -verbose => 99, -sections => "VALIDATE|BUGS");

--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -34,11 +34,24 @@ sub _clean_error {
   return $err;
 }
 
-my %global_opts = (color => 0,);
+my %global_opts = (color => 'never',);
 
 sub _color {
   my ($str, $color, $local_opts) = @_;
-  return $str unless $global_opts{color} || ($local_opts && $local_opts->{color});
+  my $mode = ($local_opts && exists $local_opts->{color}) ? $local_opts->{color} : $global_opts{color};
+
+  # Normalize boolean-ish or empty values from GetOptions
+  # --color (no value) -> Sets $mode to '' -> treated as 'always'
+  # Missing flag -> $mode is 'never' (default)
+  $mode = 'always' if $mode eq '1' || $mode eq '';
+  $mode = 'never' unless defined $mode;
+
+  return $str if $mode eq 'never';
+
+  if ($mode eq 'auto') {
+    return $str unless -t STDOUT;
+  }
+
   eval { require Term::ANSIColor; 1 } or return $str;
   return Term::ANSIColor::colored([$color], $str);
 }
@@ -47,7 +60,7 @@ GetOptions(
   'help|h'    => \$global_opts{help},
   'man'       => \$global_opts{man},
   'version|V' => \$global_opts{version},
-  'color'     => \$global_opts{color},
+  'color:s'   => \$global_opts{color},
 ) or pod2usage(-input => $script_path, -exitval => 2, -verbose => 99, -sections => "SYNOPSIS|OPTIONS|SUBCOMMANDS|BUGS");
 
 if ($global_opts{version}) {
@@ -88,7 +101,7 @@ sub run_dump {
     'enable-warnings'  => 0,
     'vendor-id'        => undef,
     strict             => 0,
-    color              => 0,
+    color              => 'never',
   );
 
   GetOptionsFromArray(
@@ -102,7 +115,7 @@ sub run_dump {
     'enable-warnings|w'  => \$opts{'enable-warnings'},
     'vendor-id|v=i'      => \$opts{'vendor-id'},
     'strict|s'           => \$opts{strict},
-    'color'              => \$opts{color},
+    'color:s'            => \$opts{color},
     'help|h'             => sub {
       pod2usage(-input => $script_path, -exitval => 1, -verbose => 99, -sections => "DUMP|BUGS");
     },
@@ -214,7 +227,7 @@ sub run_validate {
     'cmp-list-timeout'             => 30,
     all                            => 0,
     text                           => 0,
-    color                          => 0,
+    color                          => 'never',
   );
 
   GetOptionsFromArray(
@@ -238,7 +251,7 @@ sub run_validate {
     'cmp-list-timeout=i'               => \$opts{'cmp-list-timeout'},
     'all|a'                            => \$opts{all},
     'text|t'                           => \$opts{text},
-    'color'                            => \$opts{color},
+    'color:s'                          => \$opts{color},
     'help|h'                           => sub {
       pod2usage(-input => $script_path, -exitval => 1, -verbose => 99, -sections => "VALIDATE|BUGS");
     },
@@ -459,11 +472,28 @@ Print a brief help message and exits.
 
 Print the version and exits.
 
-=item B<--color>
+=item B<--color>[=I<MODE>]
 
-Enable colored output. Off by default. When enabled, the tool uses ANSI colors
-for text status (e.g. OK/FAIL), TC strings, and error prefixes. Requires
-C<Term::ANSIColor> (core).
+Enable colored output. Mode can be B<auto>, B<always>, or B<never>.
+
+When enabled, the tool uses ANSI colors for text status (e.g. OK/FAIL), TC
+strings, and error prefixes. Requires C<Term::ANSIColor> (core).
+
+=over 4
+
+=item *
+
+B<never> (Default): No colors are used.
+
+=item *
+
+B<always> or B<--color> (without value): Colors are always enabled.
+
+=item *
+
+B<auto>: Colors are enabled only if standard output is a terminal (TTY).
+
+=back
 
 =item B<--man>
 

--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -34,9 +34,21 @@ sub _clean_error {
   return $err;
 }
 
-my %global_opts;
-GetOptions('help|h' => \$global_opts{help}, 'man' => \$global_opts{man}, 'version|V' => \$global_opts{version},)
-  or pod2usage(-input => $script_path, -exitval => 2, -verbose => 99, -sections => "SYNOPSIS|OPTIONS|SUBCOMMANDS|BUGS");
+my %global_opts = (color => 0,);
+
+sub _color {
+  my ($str, $color, $local_opts) = @_;
+  return $str unless $global_opts{color} || ($local_opts && $local_opts->{color});
+  eval { require Term::ANSIColor; 1 } or return $str;
+  return Term::ANSIColor::colored([$color], $str);
+}
+
+GetOptions(
+  'help|h'    => \$global_opts{help},
+  'man'       => \$global_opts{man},
+  'version|V' => \$global_opts{version},
+  'color'     => \$global_opts{color},
+) or pod2usage(-input => $script_path, -exitval => 2, -verbose => 99, -sections => "SYNOPSIS|OPTIONS|SUBCOMMANDS|BUGS");
 
 if ($global_opts{version}) {
   print "iabtcfv2 version $GDPR::IAB::TCFv2::VERSION\n";
@@ -76,6 +88,7 @@ sub run_dump {
     'enable-warnings'  => 0,
     'vendor-id'        => undef,
     strict             => 0,
+    color              => 0,
   );
 
   GetOptionsFromArray(
@@ -89,6 +102,7 @@ sub run_dump {
     'enable-warnings|w'  => \$opts{'enable-warnings'},
     'vendor-id|v=i'      => \$opts{'vendor-id'},
     'strict|s'           => \$opts{strict},
+    'color'              => \$opts{color},
     'help|h'             => sub {
       pod2usage(-input => $script_path, -exitval => 1, -verbose => 99, -sections => "DUMP|BUGS");
     },
@@ -136,11 +150,11 @@ sub _process_string {
   };
   if (my $err = $@) {
     if ($o->{'fail-fast'}) {
-      warn "Fatal: Failed to parse TC string '$str' at line $state->{line_num}: $err\n" if $o->{'enable-warnings'};
+      warn _color("Fatal:", "red", $o) . " Failed to parse TC string '$str' at line $state->{line_num}: $err\n" if $o->{'enable-warnings'};
       exit EXIT_PARSE_ERROR;
     }
 
-    warn "Warning: Failed to parse TC string '$str' at line $state->{line_num}: $err\n" if $o->{'enable-warnings'};
+    warn _color("Warning:", "yellow", $o) . " Failed to parse TC string '$str' at line $state->{line_num}: $err\n" if $o->{'enable-warnings'};
 
     return if $o->{'ignore-errors'};
 
@@ -200,6 +214,7 @@ sub run_validate {
     'cmp-list-timeout'             => 30,
     all                            => 0,
     text                           => 0,
+    color                          => 0,
   );
 
   GetOptionsFromArray(
@@ -223,6 +238,7 @@ sub run_validate {
     'cmp-list-timeout=i'               => \$opts{'cmp-list-timeout'},
     'all|a'                            => \$opts{all},
     'text|t'                           => \$opts{text},
+    'color'                            => \$opts{color},
     'help|h'                           => sub {
       pod2usage(-input => $script_path, -exitval => 1, -verbose => 99, -sections => "VALIDATE|BUGS");
     },
@@ -329,11 +345,11 @@ sub _validate_string {
     $state->{any_fail} = 1;
 
     if ($o->{'fail-fast'}) {
-      warn "Fatal: Failed to parse TC string '$str' at line $state->{line_num}: $err\n" if $o->{'enable-warnings'};
+      warn _color("Fatal:", "red", $o) . " Failed to parse TC string '$str' at line $state->{line_num}: $err\n" if $o->{'enable-warnings'};
       exit EXIT_PARSE_ERROR;
     }
 
-    warn "Warning: Failed to parse TC string '$str' at line $state->{line_num}: $err\n" if $o->{'enable-warnings'};
+    warn _color("Warning:", "yellow", $o) . " Failed to parse TC string '$str' at line $state->{line_num}: $err\n" if $o->{'enable-warnings'};
 
     return if $o->{'ignore-errors'};
 
@@ -342,7 +358,7 @@ sub _validate_string {
 
     if ($o->{'errors-to-stderr'}) {
       if ($o->{text}) {
-        warn "ERROR  $str: $err\n";
+        warn _color("ERROR", "red", $o) . "  $str: $err\n";
       }
       else {
         warn $j->encode($output_data) . "\n";
@@ -387,18 +403,25 @@ sub _emit_validate {
     my $vid = $output_data->{vendor_id};
     my $line;
     if (exists $output_data->{error}) {
-      $line = "ERROR  $tc: $output_data->{error}";
+      $line = _color("ERROR", "red", $o) . "  " . _color($tc, "bold", $o) . ": " . $output_data->{error};
     }
     elsif ($output_data->{valid}) {
-      $line = "OK     $tc vendor $vid";
+      $line = _color("OK", "green", $o) . "     " . _color($tc, "bold", $o) . " vendor " . _color($vid, "cyan", $o);
     }
     else {
       my @reasons = $o->{all} ? @{$output_data->{reasons} || []} : ($output_data->{reason});
       if (@reasons == 1) {
-        $line = "FAIL   $tc vendor $vid: $reasons[0]";
+        $line
+          = _color("FAIL", "red", $o) . "   "
+          . _color($tc,  "bold", $o)
+          . " vendor "
+          . _color($vid, "cyan", $o) . ": "
+          . $reasons[0];
       }
       else {
-        $line = join "\n", "FAIL   $tc vendor $vid:", map {"  - $_"} @reasons;
+        $line = join "\n",
+          _color("FAIL", "red", $o) . "   " . _color($tc, "bold", $o) . " vendor " . _color($vid, "cyan", $o) . ":",
+          map {"  - $_"} @reasons;
       }
     }
     print "$line\n";
@@ -435,6 +458,12 @@ Print a brief help message and exits.
 =item B<--version>, B<-V>
 
 Print the version and exits.
+
+=item B<--color>
+
+Enable colored output. Off by default. When enabled, the tool uses ANSI colors
+for text status (e.g. OK/FAIL), TC strings, and error prefixes. Requires
+C<Term::ANSIColor> (core).
 
 =item B<--man>
 


### PR DESCRIPTION
This PR adds explicit opt-in color support to the `iabtcfv2` CLI.

### Changes:
- **New Flag**: Added `--color` (global and subcommand levels) to enable ANSI colored output.
- **Opt-in Only**: Colors are disabled by default to maintain compatibility with pipelines and logs.
- **Targeted Coloring**:
    - `validate --text`: status (`OK`/`FAIL`/`ERROR`), TC string, and vendor ID are highlighted.
    - `Fatal`/`Error` messages use Red.
    - `Warning` messages use Yellow.
- **Efficiency**: `Term::ANSIColor` is only loaded when the `--color` flag is present.