### PR TITLE
fix(cli): provide concise usage errors

### DIFF
--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -80,21 +80,26 @@ sub run_dump {
   require Getopt::Long;
   my $parser = Getopt::Long::Parser->new(config => [qw(no_pass_through require_order bundling)]);
 
-  $parser->getoptionsfromarray(
-    \@args,
-    'pretty|p'             => \$opts{pretty},
-    'compact|c'            => \$opts{compact},
-    'ignore-errors|i'      => \$opts{'ignore-errors'},
-    'fail-fast|f'          => \$opts{'fail-fast'},
-    'errors-to-stderr|e'   => \$opts{'errors-to-stderr'},
-    'quiet|q'              => \$opts{'quiet'},
-    'enable-warnings|w'    => \$opts{'enable-warnings'},
-    'vendor-id|v=i'        => \$opts{'vendor-id'},
-    'strict-legal-basis|s' => \$opts{'strict-legal-basis'},
-    'help|h'               => sub {
-      pod2usage(-input => $script_path, -exitval => 1, -verbose => 99, -sections => "DUMP|BUGS");
-    },
-  ) or pod2usage(-input => $script_path, -exitval => 2, -verbose => 99, -sections => "DUMP/Usage");
+  my $getopt_ok;
+  {
+    local @ARGV = @args;
+    $getopt_ok = $parser->getoptions(
+      'pretty|p'             => \$opts{pretty},
+      'compact|c'            => \$opts{compact},
+      'ignore-errors|i'      => \$opts{'ignore-errors'},
+      'fail-fast|f'          => \$opts{'fail-fast'},
+      'errors-to-stderr|e'   => \$opts{'errors-to-stderr'},
+      'quiet|q'              => \$opts{'quiet'},
+      'enable-warnings|w'    => \$opts{'enable-warnings'},
+      'vendor-id|v=i'        => \$opts{'vendor-id'},
+      'strict-legal-basis|s' => \$opts{'strict-legal-basis'},
+      'help|h'               => sub {
+        pod2usage(-input => $script_path, -exitval => 1, -verbose => 99, -sections => "DUMP|BUGS");
+      },
+    );
+    @args = @ARGV;
+  }
+  $getopt_ok or pod2usage(-input => $script_path, -exitval => 2, -verbose => 99, -sections => "DUMP/Usage");
 
   my $json_pkg = JSON->can('new') ? 'JSON' : 'JSON::PP';
   my $json     = $json_pkg->new->utf8;
@@ -207,31 +212,36 @@ sub run_validate {
   require Getopt::Long;
   my $parser = Getopt::Long::Parser->new(config => [qw(no_pass_through require_order bundling)]);
 
-  $parser->getoptionsfromarray(
-    \@args,
-    'pretty|p'                         => \$opts{pretty},
-    'ignore-errors|i'                  => \$opts{'ignore-errors'},
-    'fail-fast|f'                      => \$opts{'fail-fast'},
-    'errors-to-stderr|e'               => \$opts{'errors-to-stderr'},
-    'quiet|q'                          => \$opts{quiet},
-    'enable-warnings|w'                => \$opts{'enable-warnings'},
-    'vendor-id|v=i'                    => \$opts{'vendor-id'},
-    'consent-purposes|C=s'             => \$opts{'consent-purposes'},
-    'legitimate-interest-purposes|L=s' => \$opts{'legitimate-interest-purposes'},
-    'flexible-purposes|F=s'            => \$opts{'flexible-purposes'},
-    'verify-disclosed-vendors|d'       => \$opts{'verify-disclosed-vendors'},
-    'strict-legal-basis|s'             => \$opts{'strict-legal-basis'},
-    'min-tcf-policy-version|m=i'       => \$opts{'min-tcf-policy-version'},
-    'cmp-state-provider=s'             => \$opts{'cmp-state-provider'},
-    'cmp-state-provider-network-ok'    => \$opts{'cmp-state-provider-network-ok'},
-    'cmp-state-provider-verify-ssl!'   => \$opts{'cmp-state-provider-verify-ssl'},
-    'cmp-state-provider-timeout=i'     => \$opts{'cmp-state-provider-timeout'},
-    'all|a'                            => \$opts{all},
-    'text|t'                           => \$opts{text},
-    'help|h'                           => sub {
-      pod2usage(-input => $script_path, -exitval => 1, -verbose => 99, -sections => "VALIDATE|BUGS");
-    },
-  ) or pod2usage(-input => $script_path, -exitval => 2, -verbose => 99, -sections => "VALIDATE/Usage");
+  my $getopt_ok;
+  {
+    local @ARGV = @args;
+    $getopt_ok = $parser->getoptions(
+      'pretty|p'                         => \$opts{pretty},
+      'ignore-errors|i'                  => \$opts{'ignore-errors'},
+      'fail-fast|f'                      => \$opts{'fail-fast'},
+      'errors-to-stderr|e'               => \$opts{'errors-to-stderr'},
+      'quiet|q'                          => \$opts{quiet},
+      'enable-warnings|w'                => \$opts{'enable-warnings'},
+      'vendor-id|v=i'                    => \$opts{'vendor-id'},
+      'consent-purposes|C=s'             => \$opts{'consent-purposes'},
+      'legitimate-interest-purposes|L=s' => \$opts{'legitimate-interest-purposes'},
+      'flexible-purposes|F=s'            => \$opts{'flexible-purposes'},
+      'verify-disclosed-vendors|d'       => \$opts{'verify-disclosed-vendors'},
+      'strict-legal-basis|s'             => \$opts{'strict-legal-basis'},
+      'min-tcf-policy-version|m=i'       => \$opts{'min-tcf-policy-version'},
+      'cmp-state-provider=s'             => \$opts{'cmp-state-provider'},
+      'cmp-state-provider-network-ok'    => \$opts{'cmp-state-provider-network-ok'},
+      'cmp-state-provider-verify-ssl!'   => \$opts{'cmp-state-provider-verify-ssl'},
+      'cmp-state-provider-timeout=i'     => \$opts{'cmp-state-provider-timeout'},
+      'all|a'                            => \$opts{all},
+      'text|t'                           => \$opts{text},
+      'help|h'                           => sub {
+        pod2usage(-input => $script_path, -exitval => 1, -verbose => 99, -sections => "VALIDATE|BUGS");
+      },
+    );
+    @args = @ARGV;
+  }
+  $getopt_ok or pod2usage(-input => $script_path, -exitval => 2, -verbose => 99, -sections => "VALIDATE/Usage");
 
   unless (defined $opts{'vendor-id'}) {
     pod2usage(

--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -435,6 +435,8 @@ iabtcfv2 - CLI tool for GDPR IAB TCF v2 strings
 
 iabtcfv2 [options] <subcommand> [subcommand-options]
 
+Run with --help for more information.
+
 =head1 OPTIONS
 
 =over 4
@@ -473,6 +475,8 @@ emitting one JSON record per string (or text lines with B<--text>).
 =head2 Usage
 
     iabtcfv2 dump [options] [tc_strings...]
+
+    Run with --help for more information.
 
 =head2 Description
 
@@ -583,6 +587,8 @@ To type strings manually:
 =head2 Usage
 
     iabtcfv2 validate --vendor-id <id> [options] [tc_strings...]
+
+    Run with --help for more information.
 
 =head2 Description
 

--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -36,7 +36,7 @@ sub _clean_error {
 
 my %global_opts;
 GetOptions('help|h' => \$global_opts{help}, 'man' => \$global_opts{man}, 'version|V' => \$global_opts{version},)
-  or pod2usage(-input => $script_path, -exitval => 2, -verbose => 99, -sections => "SYNOPSIS|OPTIONS|SUBCOMMANDS|BUGS");
+  or pod2usage(-input => $script_path, -exitval => 2, -verbose => 0);
 
 if ($global_opts{version}) {
   print "iabtcfv2 version $GDPR::IAB::TCFv2::VERSION\n";
@@ -60,8 +60,7 @@ elsif ($subcommand eq 'help') {
   _show_help(shift @ARGV);
 }
 else {
-  warn "Unknown subcommand: $subcommand\n";
-  pod2usage(-input => $script_path, -exitval => 1, -verbose => 99, -sections => "SYNOPSIS|OPTIONS|SUBCOMMANDS|BUGS");
+  pod2usage(-input => $script_path, -exitval => 2, -message => "Unknown subcommand: $subcommand", -verbose => 0);
 }
 
 sub run_dump {
@@ -78,7 +77,10 @@ sub run_dump {
     'strict-legal-basis' => 0,
   );
 
-  GetOptionsFromArray(
+  require Getopt::Long;
+  my $parser = Getopt::Long::Parser->new(config => [qw(no_pass_through require_order bundling)]);
+
+  $parser->getoptionsfromarray(
     \@args,
     'pretty|p'             => \$opts{pretty},
     'compact|c'            => \$opts{compact},
@@ -92,7 +94,7 @@ sub run_dump {
     'help|h'               => sub {
       pod2usage(-input => $script_path, -exitval => 1, -verbose => 99, -sections => "DUMP|BUGS");
     },
-  ) or pod2usage(-input => $script_path, -exitval => 2, -verbose => 99, -sections => "DUMP|BUGS");
+  ) or pod2usage(-input => $script_path, -exitval => 2, -verbose => 99, -sections => "DUMP/Usage");
 
   my $json_pkg = JSON->can('new') ? 'JSON' : 'JSON::PP';
   my $json     = $json_pkg->new->utf8;
@@ -202,7 +204,10 @@ sub run_validate {
     text                            => 0,
   );
 
-  GetOptionsFromArray(
+  require Getopt::Long;
+  my $parser = Getopt::Long::Parser->new(config => [qw(no_pass_through require_order bundling)]);
+
+  $parser->getoptionsfromarray(
     \@args,
     'pretty|p'                         => \$opts{pretty},
     'ignore-errors|i'                  => \$opts{'ignore-errors'},
@@ -226,11 +231,16 @@ sub run_validate {
     'help|h'                           => sub {
       pod2usage(-input => $script_path, -exitval => 1, -verbose => 99, -sections => "VALIDATE|BUGS");
     },
-  ) or pod2usage(-input => $script_path, -exitval => 2, -verbose => 99, -sections => "VALIDATE|BUGS");
+  ) or pod2usage(-input => $script_path, -exitval => 2, -verbose => 99, -sections => "VALIDATE/Usage");
 
   unless (defined $opts{'vendor-id'}) {
-    warn "validate: --vendor-id|-v is required\n";
-    pod2usage(-input => $script_path, -exitval => 2, -verbose => 99, -sections => "VALIDATE|BUGS");
+    pod2usage(
+      -input    => $script_path,
+      -exitval  => 2,
+      -message  => "validate: --vendor-id|-v is required",
+      -verbose  => 99,
+      -sections => "VALIDATE/Usage"
+    );
   }
 
   require GDPR::IAB::TCFv2::Validator;
@@ -460,6 +470,12 @@ emitting one JSON record per string (or text lines with B<--text>).
 
 =head1 DUMP
 
+=head2 Usage
+
+    iabtcfv2 dump [options] [tc_strings...]
+
+=head2 Description
+
 Parses TC strings and outputs them as JSON.
 
 =head2 Options
@@ -563,6 +579,12 @@ To type strings manually:
     docker run -it --rm peczenyj/gdpr-iab-tcfv2 dump
 
 =head1 VALIDATE
+
+=head2 Usage
+
+    iabtcfv2 validate --vendor-id <id> [options] [tc_strings...]
+
+=head2 Description
 
 Validates TC strings against a vendor identity and a set of declared purpose
 lists. The vendor must be allowed for every purpose in C<--consent-purposes>


### PR DESCRIPTION
This PR improves the CLI user experience by emitting concise usage hints when parameters are missing or invalid, instead of dumping the full POD help.

### Changes:
- **POD Restructuring**: Isolated `Usage` from `Description` in `DUMP` and `VALIDATE` sections.
- **Concise Errors**: Updated `pod2usage` calls to show only the relevant `Usage` line on error.
- **Strict Option Parsing**: Enabled `no_pass_through` for subcommands, ensuring unknown options or invalid values (e.g., non-integer for `--vendor-id`) are caught and reported cleanly.
- **Consistency**: Applied the same pattern to global options and unknown subcommand errors.