### PR TITLE
fix: post-release audit (hash-form check + POD alignment)

### DIFF
--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -362,8 +362,9 @@ sub check_publisher_restriction {
     $restriction_type = $opts{restriction_type};
     $vendor_id        = $opts{vendor_id};
   }
-
-  ($purpose_id, $restriction_type, $vendor_id) = @_;
+  else {
+    ($purpose_id, $restriction_type, $vendor_id) = @_;
+  }
 
   return $self->{publisher}->check_restriction($purpose_id, $restriction_type, $vendor_id);
 }
@@ -956,14 +957,15 @@ The purpose of this package is to parse Transparency & Consent String (TC String
     say $consent->consent_screen;      # 2
     say $consent->consent_language;    # "EN"
     say $consent->vendor_list_version; # 23
-say "find consent for purpose ids 1, 3, 9 and 10" if 4 == grep {
-    $consent->is_purpose_consent_allowed($_)
-} ( # constants exported by GDPR::IAB::TCFv2::Constants::Purpose
-    InfoStorageAccess,       #  1
-    PersonalizationProfile,  #  3
-    MarketResearch,          #  9
-    DevelopImprove,          # 10
-);
+
+    say "find consent for purpose ids 1, 3, 9 and 10" if 4 == grep {
+        $consent->is_purpose_consent_allowed($_)
+    } ( # constants exported by GDPR::IAB::TCFv2::Constants::Purpose
+        InfoStorageAccess,       #  1
+        PersonalizationProfile,  #  3
+        MarketResearch,          #  9
+        DevelopImprove,          # 10
+    );
 
     say "find consent for vendor id 284 (Weborama)" if $consent->vendor_consent(284);
 
@@ -1520,7 +1522,7 @@ Outputs:
                 7,
                 10
             ],
-            "custom_purpose" : {
+            "custom_purposes" : {
                 "consents" : [],
                 "legitimate_interests" : []
             },

--- a/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
@@ -191,7 +191,7 @@ A profile created for personalised advertising in relation to a person having se
 =back
 
 =head2  ContentProfile
-	
+
 Purpose id 5: Create profiles to personalise content
 
 Information about your activity on this service (for instance, forms you submit, non-advertising content you look at) can be stored and combined with other information about you (such as your previous activity on this service or other websites or apps) or similar users. This is then used to build or improve a profile about you (which might for example include possible interests and personal aspects). Your profile can be used (also later) to present content that appears more relevant based on your possible interests, such as by adapting the order in which content is shown to you, so that it is even easier for you to find content that matches your interests.
@@ -211,7 +211,7 @@ You have viewed three videos on space exploration across different TV apps. An u
 =back
 
 =head2  ContentSelection
-	
+
 Purpose id 6: Use profiles to select personalised content
 
 Content presented to you on this service can be based on your content personalisation profiles, which can reflect your activity on this or other services (for instance, the forms you submit, content you look at), possible interests and personal aspects, such as by adapting the order in which content is shown to you, so that it is even easier for you to find (non-advertising) content that matches your interests.
@@ -224,7 +224,7 @@ Illustrations:
 
 You read articles on vegetarian food on a social media platform and then use the cooking app of an unrelated company. The profile built about you on the social media platform will be used to present you vegetarian recipes on the welcome screen of the cooking app.
 
-=item* 
+=item *
 
 You have viewed three videos about rowing across different websites. An unrelated video sharing platform will recommend five other videos on rowing that may be of interest to you when you use your TV app, based on a profile built about you when you visited those different websites to watch online videos.
 

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -512,9 +512,10 @@ B<silently ignored> (matches legacy behavior).
 
 =item *
 
-C<strict> — boolean. Passed through to the underlying
-C<is_vendor_*_allowed> calls so invalid purpose IDs cause C<croak>
-instead of a silent failure.
+C<strict_legal_basis> — boolean. Passed through to the underlying
+C<is_vendor_*_allowed> calls (as the C<strict> named argument) so
+invalid purpose IDs cause C<croak> instead of a silent failure.
+Defaults to C<0>.
 
 =back
 
@@ -529,10 +530,10 @@ the first failing rule (B<fail-fast> mode) and returns a
 L<GDPR::IAB::TCFv2::Validator::Result> carrying that one reason.
 
 C<%overrides> can replace the constructor values for C<vendor_id>,
-C<strict>, C<verify_disclosed_vendors>, C<min_tcf_policy_version>,
-C<cmp_state_provider>, C<consent_purpose_ids>,
-C<legitimate_interest_purpose_ids>, and C<flexible_purpose_ids> for
-this call only.
+C<strict_legal_basis>, C<verify_disclosed_vendors>,
+C<min_tcf_policy_version>, C<cmp_state_provider>,
+C<consent_purpose_ids>, C<legitimate_interest_purpose_ids>, and
+C<flexible_purpose_ids> for this call only.
 
 The list overrides (C<consent_purpose_ids>,
 C<legitimate_interest_purpose_ids>, C<flexible_purpose_ids>) do B<not>

--- a/t/01-parse.t
+++ b/t/01-parse.t
@@ -441,6 +441,12 @@ subtest "check publisher restriction" => sub {
     ok $consent->check_publisher_restriction(7, 1, 32),
       "must have publisher restriction to vendor 32 regarding purpose id 7 of type 1 'Require Consent'";
 
+    ok $consent->check_publisher_restriction(purpose_id => 7, restriction_type => 1, vendor_id => 32),
+      "hash form: must have publisher restriction to vendor 32 regarding purpose id 7 of type 1 'Require Consent'";
+
+    ok !$consent->check_publisher_restriction(purpose_id => 7, restriction_type => 1, vendor_id => 7),
+      "hash form: should have no publisher restriction to vendor 7 regarding purpose id 7 of type 1 'Require Consent'";
+
     ok !$consent->check_publisher_restriction(7, 1, 7),
       "must have publisher restriction to vendor 7 regarding purpose id 7 of type 1 'Require Consent'";
 


### PR DESCRIPTION
## Summary

Post-release audit of devel after the v0.400 prep wave. One latent code bug plus several POD inconsistencies caught while re-reading every module.

### Bug fix

- **`check_publisher_restriction` named-arg form was silently broken** (`lib/GDPR/IAB/TCFv2.pm:353-369`). The `if (scalar(@_) == 6)` branch parsed `%opts` correctly, but a trailing unconditional `($purpose_id, $restriction_type, $vendor_id) = @_;` immediately clobbered the lexicals with the literal hash keys (`'purpose_id'`, `1`, `'restriction_type'`). The downstream lookup just missed and returned false. The only existing test (`t/01-parse.t:127`) used `ok !$consent->check_publisher_restriction(...)`, so the broken hash form passed by accident. Add an `else` and a positive hash-form assertion.

### POD alignment

- `TCFv2.pm` `TO_JSON` example in SYNOPSIS used `custom_purpose` (singular); the actual emitter writes `custom_purposes` (plural).
- `TCFv2.pm` SYNOPSIS verbatim block had eight lines unindented, breaking out of the code block on metacpan.
- `Validator.pm` POD documented a constructor key called `strict`, but the real key is `strict_legal_basis` (used in tests and SYNOPSIS). Spell out that it is forwarded as the `strict` named argument to the underlying `is_vendor_*_allowed` calls.
- `Constants/Purpose.pm` had `=item*` (no space) and two whitespace-only tab lines after `=head2 ContentProfile` / `=head2 ContentSelection`.

No behavior change beyond the hash-form fix.

## Test plan

- [x] `prove -lr t/` — 17,557 tests pass (was 17,551; +6 from the new hash-form assertions and prior subtest counts)
- [x] `prove -lr xt/` — critic, tidy, synopsis pass; spelling skips (Test::Spelling not installed locally, same as before)
- [x] `podchecker` net-improves on `Constants/Purpose.pm` (4 → 2 pre-existing whitespace-in-paragraph warnings); no new warnings on `TCFv2.pm` or `Validator.pm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)