### PR TITLE
refactor!: rename cmp_state_provider to cmp_validator

### DIFF
--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -201,10 +201,10 @@ sub run_validate {
     'verify-disclosed-vendors'      => 0,
     'strict-legal-basis'            => 0,
     'min-tcf-policy-version'        => undef,
-    'cmp-state-provider'            => undef,
-    'cmp-state-provider-network-ok' => 0,
-    'cmp-state-provider-verify-ssl' => 1,
-    'cmp-state-provider-timeout'    => 30,
+    'cmp-validator'            => undef,
+    'cmp-validator-network-ok' => 0,
+    'cmp-validator-verify-ssl' => 1,
+    'cmp-validator-timeout'    => 30,
     all                             => 0,
     text                            => 0,
   );
@@ -229,10 +229,10 @@ sub run_validate {
       'verify-disclosed-vendors|d'       => \$opts{'verify-disclosed-vendors'},
       'strict-legal-basis|s'             => \$opts{'strict-legal-basis'},
       'min-tcf-policy-version|m=i'       => \$opts{'min-tcf-policy-version'},
-      'cmp-state-provider=s'             => \$opts{'cmp-state-provider'},
-      'cmp-state-provider-network-ok'    => \$opts{'cmp-state-provider-network-ok'},
-      'cmp-state-provider-verify-ssl!'   => \$opts{'cmp-state-provider-verify-ssl'},
-      'cmp-state-provider-timeout=i'     => \$opts{'cmp-state-provider-timeout'},
+      'cmp-validator=s'             => \$opts{'cmp-validator'},
+      'cmp-validator-network-ok'    => \$opts{'cmp-validator-network-ok'},
+      'cmp-validator-verify-ssl!'   => \$opts{'cmp-validator-verify-ssl'},
+      'cmp-validator-timeout=i'     => \$opts{'cmp-validator-timeout'},
       'all|a'                            => \$opts{all},
       'text|t'                           => \$opts{text},
       'help|h'                           => sub {
@@ -266,16 +266,16 @@ sub run_validate {
   $vargs{flexible_purpose_ids}   = _parse_id_list($opts{'flexible-purposes'}) if defined $opts{'flexible-purposes'};
   $vargs{min_tcf_policy_version} = $opts{'min-tcf-policy-version'} if defined $opts{'min-tcf-policy-version'};
 
-  if (defined $opts{'cmp-state-provider'}) {
+  if (defined $opts{'cmp-validator'}) {
     require GDPR::IAB::TCFv2::CMPValidator;
 
-    my $src = $opts{'cmp-state-provider'};
+    my $src = $opts{'cmp-validator'};
     my %cmp_args
-      = (verify_ssl => $opts{'cmp-state-provider-verify-ssl'}, timeout => $opts{'cmp-state-provider-timeout'},);
+      = (verify_ssl => $opts{'cmp-validator-verify-ssl'}, timeout => $opts{'cmp-validator-timeout'},);
 
     if ($src =~ m{^https?://}i) {
       $cmp_args{url}        = $src;
-      $cmp_args{network_ok} = 1 if $opts{'cmp-state-provider-network-ok'};
+      $cmp_args{network_ok} = 1 if $opts{'cmp-validator-network-ok'};
     }
     else {
       $cmp_args{file} = $src;
@@ -286,7 +286,7 @@ sub run_validate {
     # opted into warnings (--enable-warnings); otherwise filter it
     # out so routine CLI use stays quiet. Other warnings flow
     # through unchanged.
-    my $cmp_v;
+    my $cmp_validator;
     {
       local $SIG{__WARN__} = sub {
         my $msg = defined($_[0]) ? $_[0] : '';
@@ -295,7 +295,7 @@ sub run_validate {
         }
         if !$opts{'enable-warnings'};
 
-      $cmp_v = eval { GDPR::IAB::TCFv2::CMPValidator->new(%cmp_args) };
+      $cmp_validator = eval { GDPR::IAB::TCFv2::CMPValidator->new(%cmp_args) };
     }
 
     if (my $err = $@) {
@@ -304,7 +304,7 @@ sub run_validate {
       exit 2;
     }
 
-    $vargs{cmp_state_provider} = $cmp_v;
+    $vargs{cmp_validator} = $cmp_validator;
   }
 
   my $validator = eval { GDPR::IAB::TCFv2::Validator->new(%vargs) };
@@ -686,7 +686,7 @@ Enable strict spec validation in the underlying parser (see C<dump --strict>).
 Reject TC strings whose Global Vendor List policy version is below I<N>.
 Checked first, before any vendor- or purpose-level rules.
 
-=item B<--cmp-state-provider> I<PATH-OR-URL>
+=item B<--cmp-validator> I<PATH-OR-URL>
 
 Validate the C<cmp_id> embedded in each TC string against an IAB CMP
 registry snapshot. The argument is detected as a URL when it starts
@@ -698,24 +698,24 @@ When the argument is a URL, the standard HTTP-proxy environment
 variables (C<https_proxy>, C<http_proxy>, C<no_proxy>) are honored
 automatically.
 
-=item B<--cmp-state-provider-network-ok>
+=item B<--cmp-validator-network-ok>
 
-Required when B<--cmp-state-provider> is a URL. Without this flag, URL fetching
+Required when B<--cmp-validator> is a URL. Without this flag, URL fetching
 is refused (mirrors the library's C<network_ok =E<gt> 1> opt-in:
 fetching from an arbitrary URL is intentional, never accidental).
-Has no effect when B<--cmp-state-provider> is a file path.
+Has no effect when B<--cmp-validator> is a file path.
 
-=item B<--cmp-state-provider-verify-ssl>, B<--no-cmp-state-provider-verify-ssl>
+=item B<--cmp-validator-verify-ssl>, B<--no-cmp-validator-verify-ssl>
 
 Verify TLS certificates when fetching from an HTTPS URL. On by default;
-disable with B<--no-cmp-state-provider-verify-ssl> only when targeting a server
+disable with B<--no-cmp-validator-verify-ssl> only when targeting a server
 with a self-signed or otherwise non-public-CA certificate. Has no
-effect when B<--cmp-state-provider> is a file path.
+effect when B<--cmp-validator> is a file path.
 
-=item B<--cmp-state-provider-timeout> I<SECONDS>
+=item B<--cmp-validator-timeout> I<SECONDS>
 
 Per-request timeout for the URL fetch, in seconds. Defaults to 30.
-Has no effect when B<--cmp-state-provider> is a file path.
+Has no effect when B<--cmp-validator> is a file path.
 
 =item B<--all>, B<-a>
 
@@ -761,7 +761,7 @@ Route parse-error records to B<STDERR> instead of B<STDOUT>.
 =item B<--enable-warnings>, B<-w>
 
 Emit human-readable warning messages on B<STDERR> when a TC string fails to
-parse, and when the B<--cmp-state-provider> registry snapshot is older than 28 days.
+parse, and when the B<--cmp-validator> registry snapshot is older than 28 days.
 Off by default.
 
 =item B<--quiet>, B<-q>
@@ -787,7 +787,7 @@ B<1> — at least one TC string failed validation or could not be parsed.
 =item *
 
 B<2> — bad CLI usage (missing C<--vendor-id>, incoherent purpose lists,
-unreachable C<--cmp-state-provider> source).
+unreachable C<--cmp-validator> source).
 
 =back
 
@@ -809,13 +809,13 @@ unreachable C<--cmp-state-provider> source).
 
     # Reject TC strings that name an unknown or deleted CMP, using a
     # local snapshot of the IAB CMP registry.
-    iabtcfv2 validate -v 32 --cmp-state-provider /etc/iab/cmp-list.json CO...AAA
+    iabtcfv2 validate -v 32 --cmp-validator /etc/iab/cmp-list.json CO...AAA
 
     # Same, but fetching the registry over HTTPS through whatever
     # proxy `https_proxy` points at.
     iabtcfv2 validate -v 32 \
-        --cmp-state-provider https://cmplist.consensu.org/v2/cmp-list.json \
-        --cmp-state-provider-network-ok \
+        --cmp-validator https://cmplist.consensu.org/v2/cmp-list.json \
+        --cmp-validator-network-ok \
         CO...AAA
 
 =head1 DESCRIPTION

--- a/lib/GDPR/IAB/TCFv2/CMPValidator.pm
+++ b/lib/GDPR/IAB/TCFv2/CMPValidator.pm
@@ -197,11 +197,11 @@ GDPR::IAB::TCFv2::CMPValidator - IAB Registry-based Consent Management Platform 
     use GDPR::IAB::TCFv2::CMPValidator;
 
     # Load from a local snapshot of the IAB CMP registry JSON
-    my $cmp_v = GDPR::IAB::TCFv2::CMPValidator->new(
+    my $cmp_validator = GDPR::IAB::TCFv2::CMPValidator->new(
         file => '/path/to/cmp-list.json',
     );
 
-    if ( $cmp_v->is_valid(21) ) {
+    if ( $cmp_validator->is_valid(21) ) {
         print "CMP 21 exists and has not been retired\n";
     }
 
@@ -210,7 +210,7 @@ GDPR::IAB::TCFv2::CMPValidator - IAB Registry-based Consent Management Platform 
 
     my $validator = GDPR::IAB::TCFv2::Validator->new(
         vendor_id     => 284,
-        cmp_state_provider => $cmp_v,
+        cmp_validator => $cmp_validator,
     );
 
     my $tc_string = '...';
@@ -388,7 +388,7 @@ pre-built object via C<http_client>:
     sub new { bless { responses => $_[1] }, $_[0] }
     sub get { my $self = shift; shift @{ $self->{responses} } }
 
-    my $cmp_v = GDPR::IAB::TCFv2::CMPValidator->new(
+    my $cmp_validator = GDPR::IAB::TCFv2::CMPValidator->new(
         url         => 'https://does-not-matter.example/',
         network_ok  => 1,
         http_client => FakeHttp->new( [
@@ -414,6 +414,6 @@ from it.
 =head1 SEE ALSO
 
 L<GDPR::IAB::TCFv2::Validator> for the rule engine that composes this
-class as the C<cmp_state_provider> rule.
+class as the C<cmp_validator> rule.
 
 =cut

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -20,11 +20,11 @@ sub new {
 
   _check_coherence($consent, $legitimate_interest, $flexible);
 
-  # Compute cmp_state_provider in scalar context so a bare `return` from the
+  # Compute cmp_validator in scalar context so a bare `return` from the
   # coercer correctly yields undef -- a list-context call inside the
   # anonymous-hash construction below would collapse the key/value
   # pair instead.
-  my $cmp_v = _coerce_cmp_state_provider($args{cmp_state_provider});
+  my $cmp_validator = _coerce_cmp_validator($args{cmp_validator});
 
   my $self = {
     vendor_id                       => $args{vendor_id},
@@ -34,7 +34,7 @@ sub new {
     _flexible_set                   => {map { $_ => 1 } @{$flexible}},
     verify_disclosed_vendors        => $args{verify_disclosed_vendors} || 0,
     min_tcf_policy_version          => $args{min_tcf_policy_version},
-    cmp_state_provider              => $cmp_v,
+    cmp_validator                   => $cmp_validator,
     strict_legal_basis              => exists $args{strict_legal_basis} ? $args{strict_legal_basis} : 0,
   };
 
@@ -45,16 +45,16 @@ sub new {
 # (auto-instantiated lazily on the first call), or undef.  Defer the
 # `require` so callers who never opt into the CMP rule never pay for
 # loading JSON::PP / Time::Piece.
-sub _coerce_cmp_state_provider {
+sub _coerce_cmp_validator {
   my ($spec) = @_;
 
   # Bare `return` is fine -- callers always invoke this in scalar
-  # context (see the explicit `my $cmp_v = ...` in `new` and the
-  # `my $cmp_state_provider = ...` in `_run_validation`).
+  # context (see the explicit `my $cmp_validator = ...` in `new` and the
+  # `my $cmp_validator = ...` in `_run_validation`).
   return unless defined $spec;
   return $spec if blessed($spec) && $spec->isa('GDPR::IAB::TCFv2::CMPValidator');
 
-  croak "cmp_state_provider must be a GDPR::IAB::TCFv2::CMPValidator object " . "or a hashref of constructor arguments"
+  croak "cmp_validator must be a GDPR::IAB::TCFv2::CMPValidator object " . "or a hashref of constructor arguments"
     unless ref($spec) eq 'HASH';
 
   require GDPR::IAB::TCFv2::CMPValidator;
@@ -105,10 +105,8 @@ sub _run_validation {
     : $self->{verify_disclosed_vendors};
   my $min_tcf_policy_version
     = exists $overrides{min_tcf_policy_version} ? $overrides{min_tcf_policy_version} : $self->{min_tcf_policy_version};
-  my $cmp_state_provider
-    = exists $overrides{cmp_state_provider}
-    ? _coerce_cmp_state_provider($overrides{cmp_state_provider})
-    : $self->{cmp_state_provider};
+  my $cmp_validator
+    = exists $overrides{cmp_validator} ? _coerce_cmp_validator($overrides{cmp_validator}) : $self->{cmp_validator};
 
   # Per-call list overrides. Coherence is not re-validated here:
   # orphan flexible purposes (a pid in flexible_purpose_ids that
@@ -135,7 +133,7 @@ sub _run_validation {
   $self->_check_min_tcf_policy_version($tc, $min_tcf_policy_version, \@failures);
   return $self->_make_result(0, \@failures) if $stop_on_first && @failures;
 
-  $self->_check_cmp_state_provider($tc, $cmp_state_provider, \@failures);
+  $self->_check_cmp_validator($tc, $cmp_validator, \@failures);
   return $self->_make_result(0, \@failures) if $stop_on_first && @failures;
 
   $self->_check_disclosed($tc, $vendor_id, $verify_disclosed, $min_tcf_policy_version, \@failures);
@@ -154,13 +152,13 @@ sub _run_validation {
   return $self->_make_result(1, []);
 }
 
-sub _check_cmp_state_provider {
-  my ($self, $tc, $cmp_state_provider, $failures) = @_;
+sub _check_cmp_validator {
+  my ($self, $tc, $cmp_validator, $failures) = @_;
 
-  return unless defined $cmp_state_provider;
+  return unless defined $cmp_validator;
 
   my $cmp_id = $tc->cmp_id;
-  unless ($cmp_state_provider->is_valid($cmp_id)) {
+  unless ($cmp_validator->is_valid($cmp_id)) {
     push @{$failures},
       GDPR::IAB::TCFv2::Validator::Failure->new(
       code    => ReasonInvalidCMP,
@@ -531,7 +529,7 @@ L<GDPR::IAB::TCFv2::Validator::Result> carrying that one reason.
 
 C<%overrides> can replace the constructor values for C<vendor_id>,
 C<strict_legal_basis>, C<verify_disclosed_vendors>,
-C<min_tcf_policy_version>, C<cmp_state_provider>,
+C<min_tcf_policy_version>, C<cmp_validator>,
 C<consent_purpose_ids>, C<legitimate_interest_purpose_ids>, and
 C<flexible_purpose_ids> for this call only.
 

--- a/t/10-cli-iabtcfv2.t
+++ b/t/10-cli-iabtcfv2.t
@@ -287,7 +287,7 @@ subtest 'validate subcommand' => sub {
 
     # Initialization error (invalid CLI arg value)
     my $init_stderr = File::Spec->catfile(File::Spec->tmpdir(), "tcf_init_stderr_$$");
-    `$perl -Ilib $bin validate -v 32 --cmp-state-provider /non/existent/file $tc_string 2>$init_stderr`;
+    `$perl -Ilib $bin validate -v 32 --cmp-validator /non/existent/file $tc_string 2>$init_stderr`;
     open my $fh, '<', $init_stderr or die "open $init_stderr: $!";
     my $init_msg = do { local $/ = undef; <$fh> };
     close $fh;
@@ -297,23 +297,19 @@ subtest 'validate subcommand' => sub {
   };
 };
 
-subtest '--cmp-state-provider integration' => sub {
+subtest '--cmp-validator integration' => sub {
   my $cmp_file   = File::Spec->catfile('t', 'corpus', 'cmp-list.json');
   my $tc_known   = $tc_string;                                                 # CMP 21, present in fixture
   my $tc_unknown = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
 
   # Known CMP: should still validate.
-  my $ok_out  = `$perl -Ilib $bin validate -v 1 --cmp-state-provider $cmp_file $tc_known 2>$devnull`;
+  my $ok_out  = `$perl -Ilib $bin validate -v 1 --cmp-validator $cmp_file $tc_known 2>$devnull`;
   my $ok_data = decode_helper($ok_out);
   ok($ok_data, "known-CMP validate emits JSON");
-  is(
-    $ok_data->{valid},
-    JSON->can('true') ? JSON->true() : JSON::PP::true(),
-    "known CMP passes the cmp_state_provider rule"
-  );
+  is($ok_data->{valid}, JSON->can('true') ? JSON->true() : JSON::PP::true(), "known CMP passes the cmp_validator rule");
 
   # Unknown CMP: should fail with an unknown-CMP reason.
-  my $bad_out  = `$perl -Ilib $bin validate -v 1 --cmp-state-provider $cmp_file $tc_unknown 2>$devnull`;
+  my $bad_out  = `$perl -Ilib $bin validate -v 1 --cmp-validator $cmp_file $tc_unknown 2>$devnull`;
   my $bad_code = $? >> 8;
   my $bad_data = decode_helper($bad_out);
   ok($bad_data, "unknown-CMP validate emits JSON");
@@ -321,12 +317,12 @@ subtest '--cmp-state-provider integration' => sub {
   like($bad_data->{reason}, qr/CMP\s+\d+\s+is not valid/, "reason names the bad CMP");
   is($bad_code, 1, "unknown CMP exits 1");
 
-  # URL without --cmp-state-provider-network-ok: refused (exit 2, message on stderr).
+  # URL without --cmp-validator-network-ok: refused (exit 2, message on stderr).
   my $stderr_capture = File::Spec->catfile(File::Spec->tmpdir(), "tcf_cmp_url_stderr_$$");
   my $url_out
-    = `$perl -Ilib $bin validate -v 1 --cmp-state-provider https://example.invalid/x.json $tc_known 2>$stderr_capture`;
+    = `$perl -Ilib $bin validate -v 1 --cmp-validator https://example.invalid/x.json $tc_known 2>$stderr_capture`;
   my $url_code = $? >> 8;
-  is($url_code, 2,  "URL without --cmp-state-provider-network-ok exits 2 (bad usage)");
+  is($url_code, 2,  "URL without --cmp-validator-network-ok exits 2 (bad usage)");
   is($url_out,  '', "URL refusal emits no stdout");
   open my $fh, '<', $stderr_capture or die "Could not read $stderr_capture: $!";
   my $stderr = do { local $/ = undef; <$fh> };
@@ -334,25 +330,25 @@ subtest '--cmp-state-provider integration' => sub {
   unlink $stderr_capture;
   like($stderr, qr/network_ok was not set/, "URL refusal mentions network_ok in the diagnostic");
 
-  # --no-cmp-state-provider-verify-ssl is accepted as a flag (file path makes
+  # --no-cmp-validator-verify-ssl is accepted as a flag (file path makes
   # the SSL setting moot at runtime, but Getopt::Long must accept it).
   my $no_verify_out
-    = `$perl -Ilib $bin validate -v 1 --cmp-state-provider $cmp_file --no-cmp-state-provider-verify-ssl $tc_known 2>$devnull`;
+    = `$perl -Ilib $bin validate -v 1 --cmp-validator $cmp_file --no-cmp-validator-verify-ssl $tc_known 2>$devnull`;
   my $no_verify_data = decode_helper($no_verify_out);
-  ok($no_verify_data, "--no-cmp-state-provider-verify-ssl is accepted");
+  ok($no_verify_data, "--no-cmp-validator-verify-ssl is accepted");
   is(
     $no_verify_data->{valid},
     JSON->can('true') ? JSON->true() : JSON::PP::true(),
-    "--no-cmp-state-provider-verify-ssl does not affect file-path use"
+    "--no-cmp-validator-verify-ssl does not affect file-path use"
   );
 
-  # --cmp-state-provider-timeout takes an integer.
+  # --cmp-validator-timeout takes an integer.
   my $timeout_out
-    = `$perl -Ilib $bin validate -v 1 --cmp-state-provider $cmp_file --cmp-state-provider-timeout 5 $tc_known 2>$devnull`;
-  ok(decode_helper($timeout_out), "--cmp-state-provider-timeout is accepted");
+    = `$perl -Ilib $bin validate -v 1 --cmp-validator $cmp_file --cmp-validator-timeout 5 $tc_known 2>$devnull`;
+  ok(decode_helper($timeout_out), "--cmp-validator-timeout is accepted");
 };
 
-subtest '--cmp-state-provider staleness warning gate' => sub {
+subtest '--cmp-validator staleness warning gate' => sub {
   my $cmp_file = File::Spec->catfile('t', 'corpus', 'cmp-list.json');
 
   # Fixture lastUpdated is 2026-04-01. The repo policy is that this
@@ -367,7 +363,7 @@ subtest '--cmp-state-provider staleness warning gate' => sub {
   my $stderr_loud  = File::Spec->catfile(File::Spec->tmpdir(), "tcf_cmp_stale_loud_$$");
 
   # Without --enable-warnings: staleness carp is suppressed.
-  `$perl -Ilib $bin validate -v 1 --cmp-state-provider $cmp_file $tc_string 2>$stderr_quiet`;
+  `$perl -Ilib $bin validate -v 1 --cmp-validator $cmp_file $tc_string 2>$stderr_quiet`;
   open my $qfh, '<', $stderr_quiet or die "open $stderr_quiet: $!";
   my $quiet = do { local $/ = undef; <$qfh> };
   close $qfh;
@@ -375,7 +371,7 @@ subtest '--cmp-state-provider staleness warning gate' => sub {
   unlike($quiet, qr/CMP list is older than 28 days/, "no staleness warning without --enable-warnings");
 
   # With --enable-warnings: staleness carp surfaces on stderr.
-  `$perl -Ilib $bin validate -wv 1 --cmp-state-provider $cmp_file $tc_string 2>$stderr_loud`;
+  `$perl -Ilib $bin validate -wv 1 --cmp-validator $cmp_file $tc_string 2>$stderr_loud`;
   open my $lfh, '<', $stderr_loud or die "open $stderr_loud: $!";
   my $loud = do { local $/ = undef; <$lfh> };
   close $lfh;

--- a/t/14-cmp-validator.t
+++ b/t/14-cmp-validator.t
@@ -118,8 +118,8 @@ subtest "CMPValidator: URL fetch is opt-in" => sub {
   }
 };
 
-subtest "Validator integration: cmp_state_provider object" => sub {
-  my $cmp_v = GDPR::IAB::TCFv2::CMPValidator->new(file => $cmp_file, now => $now_fresh,);
+subtest "Validator integration: cmp_validator object" => sub {
+  my $cmp_validator = GDPR::IAB::TCFv2::CMPValidator->new(file => $cmp_file, now => $now_fresh,);
 
   # CMP 21 -- known and active in the fixture
   my $tc_known = 'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA';
@@ -127,7 +127,7 @@ subtest "Validator integration: cmp_state_provider object" => sub {
   # CMP 888 -- not in the fixture
   my $tc_unknown = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
 
-  my $validator = GDPR::IAB::TCFv2::Validator->new(vendor_id => 1, cmp_state_provider => $cmp_v,);
+  my $validator = GDPR::IAB::TCFv2::Validator->new(vendor_id => 1, cmp_validator => $cmp_validator,);
 
   ok $validator->validate($tc_known)->is_valid, "validation passes when CMP is known";
 
@@ -136,11 +136,11 @@ subtest "Validator integration: cmp_state_provider object" => sub {
   is(($bad->reasons)[0], "CMP 888 is not valid/disclosed", "reason names the bad CMP");
 };
 
-subtest "Validator integration: cmp_state_provider hashref auto-instantiates" => sub {
+subtest "Validator integration: cmp_validator hashref auto-instantiates" => sub {
   my $tc_known = 'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA';
 
   my $validator
-    = GDPR::IAB::TCFv2::Validator->new(vendor_id => 1, cmp_state_provider => {file => $cmp_file, now => $now_fresh},);
+    = GDPR::IAB::TCFv2::Validator->new(vendor_id => 1, cmp_validator => {file => $cmp_file, now => $now_fresh},);
 
   ok $validator->validate($tc_known)->is_valid, "hashref form works as well as object form";
 };
@@ -148,20 +148,20 @@ subtest "Validator integration: cmp_state_provider hashref auto-instantiates" =>
 subtest "Validator integration: per-call override" => sub {
   my $tc_unknown = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
 
-  # Validator constructed without a cmp_state_provider -- the rule is off
+  # Validator constructed without a cmp_validator -- the rule is off
   my $validator = GDPR::IAB::TCFv2::Validator->new(vendor_id => 1);
   ok $validator->validate($tc_unknown)->is_valid, "no cmp rule -> CMP 888 passes";
 
   # Per-call override turns the rule on.  Hashref form gets coerced.
-  my $bad = $validator->validate($tc_unknown, cmp_state_provider => {file => $cmp_file, now => $now_fresh},);
-  ok !$bad->is_valid, "per-call cmp_state_provider override fails the bad CMP";
+  my $bad = $validator->validate($tc_unknown, cmp_validator => {file => $cmp_file, now => $now_fresh},);
+  ok !$bad->is_valid, "per-call cmp_validator override fails the bad CMP";
 };
 
-subtest "Validator integration: bad cmp_state_provider value croaks" => sub {
+subtest "Validator integration: bad cmp_validator value croaks" => sub {
   throws_ok {
-    GDPR::IAB::TCFv2::Validator->new(vendor_id => 1, cmp_state_provider => 42,);
+    GDPR::IAB::TCFv2::Validator->new(vendor_id => 1, cmp_validator => 42,);
   }
-  qr/cmp_state_provider must be a GDPR::IAB::TCFv2::CMPValidator/, "non-object, non-hashref cmp_state_provider croaks";
+  qr/cmp_validator must be a GDPR::IAB::TCFv2::CMPValidator/, "non-object, non-hashref cmp_validator croaks";
 };
 
 # A minimal HTTP::Tiny-compatible fake. One method (get); returns a

--- a/t/16-validator-failures.t
+++ b/t/16-validator-failures.t
@@ -248,7 +248,7 @@ subtest 'Validator::Result: invalid CMP carries ReasonInvalidCMP' => sub {
   my $tc_unknown_cmp = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
 
   my $validator
-    = GDPR::IAB::TCFv2::Validator->new(vendor_id => 1, cmp_state_provider => {file => $cmp_file, now => 1776254400},);
+    = GDPR::IAB::TCFv2::Validator->new(vendor_id => 1, cmp_validator => {file => $cmp_file, now => 1776254400},);
   my $result = $validator->validate($tc_unknown_cmp);
 
   ok(!$result, 'unknown CMP fails validation');

--- a/t/corpus/validator_scenarios.pl
+++ b/t/corpus/validator_scenarios.pl
@@ -25,7 +25,7 @@ use FindBin;
 #   - Two flexible-purpose scenarios exist (consent default vs LI
 #     default) so the corpus exercises is_vendor_allowed_for_flexible_purpose
 #     for both default bases.
-#   - The cmp_state_provider scenario uses the small fixture in
+#   - The cmp_validator scenario uses the small fixture in
 #     t/corpus/cmp-list.json with `now` pinned so the deletedDate /
 #     stale-warning checks are deterministic.
 
@@ -52,8 +52,8 @@ return [
   {
     name => 'v284_cmp_registry',
     args => {
-      vendor_id          => 284,
-      cmp_state_provider => {
+      vendor_id     => 284,
+      cmp_validator => {
         file => $cmp_file,
         now  => 1776254400,    # 2026-04-15, fixture is fresh
       },


### PR DESCRIPTION
## Summary

Align the Perl half of the CMP-validator integration with its own class name (`GDPR::IAB::TCFv2::CMPValidator`). The previous `cmp_state_provider` naming was inherited from Go, where the type was `CMPStateValidator`; with Go renaming its type, the Perl side can drop the now-misleading `state` infix.

**Rename map:**

| Before | After |
| --- | --- |
| `cmp_state_provider => $obj` (constructor + per-call override) | `cmp_validator => $obj` |
| `--cmp-state-provider PATH` (CLI) | `--cmp-validator PATH` |
| `--cmp-state-provider-network-ok` | `--cmp-validator-network-ok` |
| `--cmp-state-provider-verify-ssl` | `--cmp-validator-verify-ssl` |
| `--cmp-state-provider-timeout SECS` | `--cmp-validator-timeout SECS` |
| `_coerce_cmp_state_provider`, `_check_cmp_state_provider` | `_coerce_cmp_validator`, `_check_cmp_validator` |
| `$cmp_v` | `$cmp_validator` |

## Breaking change

⚠️ **No backward-compatibility shim.** Callers passing `cmp_state_provider` or using the old `--cmp-state-provider*` CLI flags will get a constructor croak / `Getopt::Long` error after this lands. The PR title carries the conventional `!` to signal this.

## Test plan

- [x] `prove -lr t/` — 17,548 tests pass
- [x] `prove -lr xt/` — critic, tidy (after perltidy re-run on 3 files), synopsis pass; spelling skips locally (Test::Spelling not installed)
- [x] No residual `cmp_state` / `cmp-state` / `$cmp_v` tokens remain in `lib/`, `bin/`, `t/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)