### PR TITLE
feat: Validator flexible-purposes redesign (Phase 2)

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -12,6 +12,8 @@ lib/GDPR/IAB/TCFv2/Publisher.pm
 lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm
 lib/GDPR/IAB/TCFv2/PublisherTC.pm
 lib/GDPR/IAB/TCFv2/RangeSection.pm
+lib/GDPR/IAB/TCFv2/Validator.pm
+lib/GDPR/IAB/TCFv2/Validator/Result.pm
 LICENSE
 Makefile.PL
 MANIFEST
@@ -23,6 +25,7 @@ t/02-json-bitfield.t
 t/03-json-range.t
 t/04-legal-basis.t
 t/05-tcf-v23.t
+t/06-validator.t
 t/07-golden.t
 t/09-predicates.t
 t/10-cli-iabtcfv2.t

--- a/TODO.md
+++ b/TODO.md
@@ -58,6 +58,34 @@
     *   **Tests:** use fixed reference dates so the `deletedDate` / staleness checks are deterministic across execution environments.
 *   **Reference:** PR [#38](https://github.com/peczenyj/GDPR-IAB-TCFv2/pull/38) (`feat/phase-5-cmp-validator`, currently OPEN).
 
+## Phase 6: GVL-Aware Validator
+*   **Goal:** Bridge the IAB Global Vendor List schema to the Phase 2 validator so callers do not have to translate vendor entries by hand.
+*   **Depends on:** Phase 2 (Validator Interface).
+*   **Tasks:**
+    *   Reintroduce `from_gvl_vendor_entry` (deferred from Phase 2): convert a single GVL vendor entry (`{ id, purposes, legIntPurposes, flexiblePurposes }`) into the constructor argument list expected by `Validator->new`.
+    *   Add a higher-level `from_gvl(...)` helper that takes a parsed GVL document and a target vendor ID, performs the lookup, and returns a configured `Validator` instance — failing fast if the vendor is missing.
+    *   Support flexible GVL input: local file path, raw JSON string, or a parsed hashref.
+    *   CLI integration: `iabtcfv2 validate --gvl path/to/gvl.json -v 32 ...` derives the purpose lists from the GVL entry instead of requiring `-C` / `-L` / `-F` on the command line.
+    *   **Tests:** golden GVL fixture covering vendors with and without flexible purposes; round-trip `from_gvl_vendor_entry` against a hand-crafted entry.
+
+## Phase 7: Features, Special Features, and Special Purposes
+*   **Goal:** Extend the validator beyond standard purposes to cover the rest of the TCF taxonomy.
+*   **Depends on:** Phase 2 (Validator Interface).
+*   **Tasks:**
+    *   Validator support for **Special Features** (opt-in, e.g. precise geolocation): require the bit to be set in the TC string when listed.
+    *   Validator support for **Features** (vendor-declared): no consent required, but cross-check that the vendor declares the feature in the GVL once Phase 6 lands.
+    *   Validator support for **Special Purposes**: legitimate-interest-only by spec; check vendor declaration without requiring a consent bit.
+    *   Surface these on the CLI as `--special-features`, `--features`, `--special-purposes` (comma-separated, same shape as `-C` / `-L`).
+    *   **Tests:** extend `t/06-validator.t` with subtests per category; add CLI subtests in `t/10-cli-iabtcfv2.t`.
+
+## Phase 8: CLI Configuration Loading
+*   **Goal:** Reduce boilerplate on the command line by letting common flags come from the environment or a config file.
+*   **Tasks:**
+    *   Map a curated set of environment variables to CLI flags (e.g. `IABTCFV2_VENDOR_ID`, `IABTCFV2_CONSENT_PURPOSES`, `IABTCFV2_LEGITIMATE_INTEREST_PURPOSES`, `IABTCFV2_FLEXIBLE_PURPOSES`, `IABTCFV2_MIN_POLICY_VERSION`). Explicit CLI flags always win.
+    *   Optional config file discovery: `.iabtcfv2rc` in the current directory or `$HOME`, plus `.env`-style loading if the file is present. Document the precedence (CLI > env > file > built-in defaults).
+    *   Add `iabtcfv2 config` (or `validate --print-config`) to dump the resolved configuration as JSON for debugging.
+    *   **Tests:** a CLI subtest that sets the env vars, runs `validate` without the matching flags, and asserts the same outcome as the explicit invocation.
+
 ## Distribution
 *   [ ] Distribute CLI tool as Docker image via DockerHub.
     *   Create multi-stage `Dockerfile`.

--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -93,6 +93,7 @@ sub run_dump {
         'fail-fast'        => 0,
         'errors-to-stderr' => 0,
         'quiet'            => 0,
+        'enable-warnings'  => 0,
         'vendor-id'        => undef,
         strict             => 0,
     );
@@ -106,6 +107,7 @@ sub run_dump {
         'fail-fast|f'        => \$opts{'fail-fast'},
         'errors-to-stderr|e' => \$opts{'errors-to-stderr'},
         'quiet|q'            => \$opts{'quiet'},
+        'enable-warnings|w'  => \$opts{'enable-warnings'},
         'vendor-id|v=i'      => \$opts{'vendor-id'},
         'strict|s'           => \$opts{strict},
         'help|h'             => sub {
@@ -126,7 +128,7 @@ sub run_dump {
         $json->pretty(1);
         $json->indent_length(4) if $json->isa('JSON::PP');
     }
-    if ( $opts{'json-array'} ) {
+    if ( $opts{'json-array'} && !$opts{'quiet'} ) {
         print "[\n";
     }
 
@@ -152,7 +154,7 @@ sub run_dump {
     }
 
 
-    if ( $opts{'json-array'} ) {
+    if ( $opts{'json-array'} && !$opts{'quiet'} ) {
         print "\n]\n";
     }
 
@@ -177,13 +179,14 @@ sub _process_string {
     if ( my $err = $@ ) {
         if ( $o->{'fail-fast'} ) {
             warn
-              "Fatal: Failed to parse TC string '$str' at line $state->{line_num}: $err\n";
+              "Fatal: Failed to parse TC string '$str' at line $state->{line_num}: $err\n"
+              if $o->{'enable-warnings'};
             exit EXIT_PARSE_ERROR;
         }
 
         warn
           "Warning: Failed to parse TC string '$str' at line $state->{line_num}: $err\n"
-          unless $o->{'quiet'};
+          if $o->{'enable-warnings'};
 
         return if $o->{'ignore-errors'};
 
@@ -199,6 +202,8 @@ sub _process_string {
             return;
         }
     }
+
+    return if $o->{'quiet'};
 
     my $out = $j->encode($output_data);
 
@@ -302,9 +307,17 @@ Stop processing and exit the program immediately upon the first parse error.
 
 Output JSON error objects to B<STDERR> instead of B<STDOUT>.
 
+=item B<--enable-warnings>, B<-w>
+
+Emit human-readable warning messages on B<STDERR> when a TC string fails to
+parse. Off by default; enable to get diagnostic context alongside the JSON
+error object.
+
 =item B<--quiet>, B<-q>
 
-Suppress human-readable warning messages on B<STDERR>.
+Suppress all output on B<STDOUT>. The exit code still reflects whether parsing
+succeeded, which is convenient for shell-style C<if iabtcfv2 dump -q "$tc">
+checks. Combine with C<--enable-warnings> if you want diagnostics on B<STDERR>.
 
 =back
 
@@ -324,11 +337,11 @@ Suppress human-readable warning messages on B<STDERR>.
 Single-character flags can be bundled together after a single dash. The last
 option in the bundle may take a value as the next argument.
 
-    # Equivalent of `--pretty --quiet`
-    iabtcfv2 dump -pq CPi...AAA
+    # Equivalent of `--pretty --ignore-errors`
+    iabtcfv2 dump -pi CPi...AAA
 
-    # Equivalent of `--pretty --ignore-errors --quiet`
-    iabtcfv2 dump -piq CPi...AAA
+    # Equivalent of `--compact --pretty`
+    iabtcfv2 dump -cp CPi...AAA
 
     # Last bundled short can take a value: -p (pretty) + -v <id> (vendor-id)
     iabtcfv2 dump -pv 284 CPi...AAA

--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -490,6 +490,8 @@ sub _emit_validate {
 
 __END__
 
+=encoding utf8
+
 =head1 NAME
 
 iabtcfv2 - CLI tool for GDPR IAB TCF v2 strings

--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -21,6 +21,10 @@ sub _json_false {
     return JSON->can('false') ? JSON->false() : JSON::PP::false();
 }
 
+sub _json_true {
+    return JSON->can('true') ? JSON->true() : JSON::PP::true();
+}
+
 my %global_opts;
 GetOptions(
     'help|h'    => \$global_opts{help},
@@ -38,17 +42,7 @@ if ( $global_opts{version} ) {
 }
 
 if ( $global_opts{help} ) {
-    my $topic = $ARGV[0];
-    if ( $topic && $topic eq 'dump' ) {
-        pod2usage(
-            -input    => $script_path, -exitval => 1, -verbose => 99,
-            -sections => "DUMP|BUGS"
-        );
-    }
-    pod2usage(
-        -input    => $script_path, -exitval => 1, -verbose => 99,
-        -sections => "SYNOPSIS|OPTIONS|SUBCOMMANDS|BUGS"
-    );
+    _show_help( $ARGV[0] );
 }
 pod2usage( -input => $script_path, -exitval => 1, -verbose => 2 )
   if $global_opts{man};
@@ -59,21 +53,10 @@ if ( $subcommand eq 'dump' ) {
     run_dump(@ARGV);
 }
 elsif ( $subcommand eq 'validate' ) {
-    warn "The 'validate' subcommand is not yet implemented.\n";
-    exit EXIT_PARSE_ERROR;
+    run_validate(@ARGV);
 }
 elsif ( $subcommand eq 'help' ) {
-    my $topic = shift @ARGV;
-    if ( $topic && $topic eq 'dump' ) {
-        pod2usage(
-            -input    => $script_path, -exitval => 1, -verbose => 99,
-            -sections => "DUMP|BUGS"
-        );
-    }
-    pod2usage(
-        -input    => $script_path, -exitval => 1, -verbose => 99,
-        -sections => "SYNOPSIS|OPTIONS|SUBCOMMANDS|BUGS"
-    );
+    _show_help( shift @ARGV );
 }
 else {
     warn "Unknown subcommand: $subcommand\n";
@@ -224,6 +207,287 @@ sub _indent {
     return $text;
 }
 
+sub _show_help {
+    my $topic = shift;
+
+    if ( $topic && $topic eq 'dump' ) {
+        pod2usage(
+            -input    => $script_path, -exitval => 1, -verbose => 99,
+            -sections => "DUMP|BUGS"
+        );
+    }
+    if ( $topic && $topic eq 'validate' ) {
+        pod2usage(
+            -input    => $script_path, -exitval => 1, -verbose => 99,
+            -sections => "VALIDATE|BUGS"
+        );
+    }
+    pod2usage(
+        -input    => $script_path, -exitval => 1, -verbose => 99,
+        -sections => "SYNOPSIS|OPTIONS|SUBCOMMANDS|BUGS"
+    );
+}
+
+sub _parse_id_list {
+    my $s = shift;
+    return [] unless defined $s && length $s;
+    return [ map { 0 + $_ } grep { length $_ } split /\s*,\s*/, $s ];
+}
+
+sub run_validate {
+    my @args = @_;
+    my %opts = (
+        pretty                         => 0,
+        'json-array'                   => 0,
+        'ignore-errors'                => 0,
+        'fail-fast'                    => 0,
+        'errors-to-stderr'             => 0,
+        quiet                          => 0,
+        'enable-warnings'              => 0,
+        'vendor-id'                    => undef,
+        'consent-purposes'             => undef,
+        'legitimate-interest-purposes' => undef,
+        'flexible-purposes'            => undef,
+        'check-disclosed-vendors'      => 0,
+        strict                         => 0,
+        'min-policy-version'           => undef,
+        all                            => 0,
+        text                           => 0,
+    );
+
+    GetOptionsFromArray(
+        \@args,
+        'pretty|p'                         => \$opts{pretty},
+        'json-array'                       => \$opts{'json-array'},
+        'ignore-errors|i'                  => \$opts{'ignore-errors'},
+        'fail-fast|f'                      => \$opts{'fail-fast'},
+        'errors-to-stderr|e'               => \$opts{'errors-to-stderr'},
+        'quiet|q'                          => \$opts{quiet},
+        'enable-warnings|w'                => \$opts{'enable-warnings'},
+        'vendor-id|v=i'                    => \$opts{'vendor-id'},
+        'consent-purposes|C=s'             => \$opts{'consent-purposes'},
+        'legitimate-interest-purposes|L=s' =>
+          \$opts{'legitimate-interest-purposes'},
+        'flexible-purposes|F=s'     => \$opts{'flexible-purposes'},
+        'check-disclosed-vendors|d' => \$opts{'check-disclosed-vendors'},
+        'strict|s'                  => \$opts{strict},
+        'min-policy-version|m=i'    => \$opts{'min-policy-version'},
+        'all|a'                     => \$opts{all},
+        'text|t'                    => \$opts{text},
+        'help|h'                    => sub {
+            pod2usage(
+                -input    => $script_path, -exitval => 1, -verbose => 99,
+                -sections => "VALIDATE|BUGS"
+            );
+        },
+      )
+      or pod2usage(
+        -input    => $script_path, -exitval => 2, -verbose => 99,
+        -sections => "VALIDATE|BUGS"
+      );
+
+    unless ( defined $opts{'vendor-id'} ) {
+        warn "validate: --vendor-id|-v is required\n";
+        pod2usage(
+            -input    => $script_path, -exitval => 2, -verbose => 99,
+            -sections => "VALIDATE|BUGS"
+        );
+    }
+
+    if ( $opts{'json-array'} && $opts{text} ) {
+        warn "validate: --text and --json-array are mutually exclusive\n";
+        pod2usage(
+            -input    => $script_path, -exitval => 2, -verbose => 99,
+            -sections => "VALIDATE|BUGS"
+        );
+    }
+
+    require GDPR::IAB::TCFv2::Validator;
+
+    my %vargs = (
+        vendor_id               => $opts{'vendor-id'},
+        check_disclosed_vendors => $opts{'check-disclosed-vendors'},
+        strict                  => $opts{strict},
+    );
+    $vargs{consent_purpose_ids} = _parse_id_list( $opts{'consent-purposes'} )
+      if defined $opts{'consent-purposes'};
+    $vargs{legitimate_interest_purpose_ids} =
+      _parse_id_list( $opts{'legitimate-interest-purposes'} )
+      if defined $opts{'legitimate-interest-purposes'};
+    $vargs{flexible_purpose_ids} = _parse_id_list( $opts{'flexible-purposes'} )
+      if defined $opts{'flexible-purposes'};
+    $vargs{min_policy_version} = $opts{'min-policy-version'}
+      if defined $opts{'min-policy-version'};
+
+    my $validator = eval { GDPR::IAB::TCFv2::Validator->new(%vargs) };
+    if ( my $err = $@ ) {
+        chomp $err;
+        warn "validate: $err\n";
+        exit 2;
+    }
+
+    my $json_pkg = JSON->can('new') ? 'JSON' : 'JSON::PP';
+    my $json     = $json_pkg->new->utf8;
+    if ( $opts{pretty} ) {
+        $json->pretty(1);
+        $json->indent_length(4) if $json->isa('JSON::PP');
+    }
+
+    my $array_brackets =
+      $opts{'json-array'} && !$opts{quiet} && !$opts{text};
+
+    print "[\n" if $array_brackets;
+
+    my $state = {
+        count    => 0,
+        line_num => 0,
+        any_fail => 0,
+    };
+
+    if (@args) {
+        foreach my $str (@args) {
+            $state->{line_num}++;
+            _validate_string( $str, $state, \%opts, $json, $validator );
+        }
+    }
+    else {
+        binmode( STDIN, ':utf8' ) if -t STDIN;
+        while ( my $line = <STDIN> ) {
+            $state->{line_num}++;
+            chomp $line;
+            next unless $line =~ /\S/;
+            _validate_string( $line, $state, \%opts, $json, $validator );
+        }
+    }
+
+    print "\n]\n" if $array_brackets;
+
+    exit( $state->{any_fail} ? EXIT_PARSE_ERROR : EXIT_SUCCESS );
+}
+
+sub _validate_string {
+    my ( $str, $state, $o, $j, $validator ) = @_;
+
+    my $result = eval {
+        $o->{all}
+          ? $validator->validate_all($str)
+          : $validator->validate($str);
+    };
+    if ( my $err = $@ ) {
+        $state->{any_fail} = 1;
+
+        if ( $o->{'fail-fast'} ) {
+            warn
+              "Fatal: Failed to parse TC string '$str' at line $state->{line_num}: $err\n"
+              if $o->{'enable-warnings'};
+            exit EXIT_PARSE_ERROR;
+        }
+
+        warn
+          "Warning: Failed to parse TC string '$str' at line $state->{line_num}: $err\n"
+          if $o->{'enable-warnings'};
+
+        return if $o->{'ignore-errors'};
+
+        chomp $err;
+        my $output_data = {
+            tc_string => $str,
+            error     => $err,
+            success   => _json_false(),
+        };
+
+        if ( $o->{'errors-to-stderr'} ) {
+            if ( $o->{text} ) {
+                warn "ERROR  $str: $err\n";
+            }
+            else {
+                warn $j->encode($output_data) . "\n";
+            }
+            return;
+        }
+
+        return if $o->{quiet};
+        _emit_validate( $output_data, $state, $o, $j );
+        return;
+    }
+
+    my $output_data;
+    if ( $result->is_valid ) {
+        $output_data = {
+            tc_string => $str,
+            vendor_id => $o->{'vendor-id'},
+            valid     => _json_true(),
+        };
+    }
+    else {
+        $state->{any_fail} = 1;
+        my @reasons = $result->reasons;
+        $output_data = {
+            tc_string => $str,
+            vendor_id => $o->{'vendor-id'},
+            valid     => _json_false(),
+            $o->{all} ? ( reasons => \@reasons ) : ( reason => $reasons[0] ),
+        };
+    }
+
+    return if $o->{quiet};
+
+    _emit_validate( $output_data, $state, $o, $j );
+
+    if ( !$result->is_valid && $o->{'fail-fast'} ) {
+        print "\n]\n" if $o->{'json-array'} && !$o->{text};
+        exit EXIT_PARSE_ERROR;
+    }
+
+    return;
+}
+
+sub _emit_validate {
+    my ( $output_data, $state, $o, $j ) = @_;
+
+    if ( $o->{text} ) {
+        my $tc  = $output_data->{tc_string};
+        my $vid = $output_data->{vendor_id};
+        my $line;
+        if ( exists $output_data->{error} ) {
+            $line = "ERROR  $tc: $output_data->{error}";
+        }
+        elsif ( $output_data->{valid} ) {
+            $line = "OK     $tc vendor $vid";
+        }
+        else {
+            my @reasons =
+              $o->{all}
+              ? @{ $output_data->{reasons} || [] }
+              : ( $output_data->{reason} );
+            if ( @reasons == 1 ) {
+                $line = "FAIL   $tc vendor $vid: $reasons[0]";
+            }
+            else {
+                $line = join "\n",
+                  "FAIL   $tc vendor $vid:",
+                  map { "  - $_" } @reasons;
+            }
+        }
+        print "$line\n";
+        $state->{count}++;
+        return;
+    }
+
+    my $out = $j->encode($output_data);
+
+    if ( $o->{'json-array'} ) {
+        print ",\n" if $state->{count} > 0;
+        print $o->{pretty} ? _indent($out) : $out;
+    }
+    else {
+        print "$out\n";
+    }
+    $state->{count}++;
+
+    return;
+}
+
 __END__
 
 =head1 NAME
@@ -262,7 +526,8 @@ Parses TC strings and outputs them as JSON.
 
 =item B<validate>
 
-Validates TC strings against provided business rules (Stub).
+Validates TC strings against a vendor identity and a set of purpose lists,
+emitting one JSON record per string (or text lines with B<--text>).
 
 =back
 
@@ -373,7 +638,180 @@ To type strings manually:
 
 =head1 VALIDATE
 
-Validates TC strings against provided business rules. (Not yet implemented).
+Validates TC strings against a vendor identity and a set of declared purpose
+lists. The vendor must be allowed for every purpose in C<--consent-purposes>
+on a consent basis, and for every purpose in
+C<--legitimate-interest-purposes> on a legitimate-interest basis. Purposes
+listed in C<--flexible-purposes> are checked using the GVL flexible-purpose
+semantics, with the default basis derived from which list also contains the
+purpose. See L<GDPR::IAB::TCFv2::Validator> for the underlying rule engine.
+
+By default the subcommand emits one JSON object per input TC string on
+B<STDOUT>. With B<--text> it emits one human-readable line per string
+instead.
+
+=head2 Output shape
+
+A successful validation produces:
+
+    {"tc_string":"CO...","vendor_id":32,"valid":true}
+
+A failure in default (fail-fast) mode produces a singular C<reason>:
+
+    {"tc_string":"CO...","vendor_id":32,"valid":false,
+     "reason":"vendor 32 not allowed for purpose 1 (consent)"}
+
+A failure in B<--all> mode produces a plural C<reasons> array:
+
+    {"tc_string":"CO...","vendor_id":32,"valid":false,
+     "reasons":["...","..."]}
+
+A parse error produces the same shape as the C<dump> subcommand:
+
+    {"tc_string":"INVALID","error":"...","success":false}
+
+=head2 Required options
+
+=over 4
+
+=item B<--vendor-id>, B<-v> I<ID>
+
+The numeric vendor ID to validate against. Required.
+
+=back
+
+=head2 Purpose options
+
+=over 4
+
+=item B<--consent-purposes>, B<-C> I<1,2,3>
+
+Comma-separated list of purpose IDs that the vendor must be allowed to
+process on a B<consent> basis.
+
+=item B<--legitimate-interest-purposes>, B<-L> I<1,2,3>
+
+Comma-separated list of purpose IDs that the vendor must be allowed to
+process on a B<legitimate interest> basis.
+
+=item B<--flexible-purposes>, B<-F> I<1,2,3>
+
+Comma-separated list of purpose IDs that the vendor declared as flexible.
+Each ID listed here MUST also appear in either C<--consent-purposes> or
+C<--legitimate-interest-purposes>; the membership determines the default
+legal basis used for the flexible-purpose check.
+
+=back
+
+=head2 Rule options
+
+=over 4
+
+=item B<--check-disclosed-vendors>, B<-d>
+
+Require the vendor to appear in the Disclosed Vendors segment when the TC
+string carries one. Off by default.
+
+=item B<--strict>, B<-s>
+
+Enable strict spec validation in the underlying parser (see C<dump --strict>).
+
+=item B<--min-policy-version>, B<-m> I<N>
+
+Reject TC strings whose Global Vendor List policy version is below I<N>.
+Checked first, before any vendor- or purpose-level rules.
+
+=item B<--all>, B<-a>
+
+Accumulate every failing rule into a C<reasons> array instead of
+short-circuiting on the first failure. The output JSON uses plural
+C<reasons> (array) instead of singular C<reason> (string).
+
+=back
+
+=head2 Output options
+
+=over 4
+
+=item B<--pretty>, B<-p>
+
+Output human-readable, indented JSON.
+
+=item B<--json-array>
+
+Output a single JSON array containing all validation records.
+
+=item B<--text>, B<-t>
+
+Output one human-readable line per TC string instead of JSON. Format:
+
+    OK     <tc>  vendor <id>
+    FAIL   <tc>  vendor <id>: <reason>
+    ERROR  <tc>: <parse error>
+
+In B<--all> mode, multi-reason failures span multiple indented lines.
+Mutually exclusive with C<--json-array>.
+
+=item B<--ignore-errors>, B<-i>
+
+Skip parse errors silently (still bumps the exit code). Validation failures
+are still emitted.
+
+=item B<--fail-fast>, B<-f>
+
+Exit immediately on the first parse error or the first invalid TC string.
+Validation failures are emitted before exiting; parse errors are not (matches
+the C<dump> contract).
+
+=item B<--errors-to-stderr>, B<-e>
+
+Route parse-error records to B<STDERR> instead of B<STDOUT>.
+
+=item B<--enable-warnings>, B<-w>
+
+Emit human-readable warning messages on B<STDERR> when a TC string fails to
+parse. Off by default.
+
+=item B<--quiet>, B<-q>
+
+Suppress all output on B<STDOUT>. The exit code still reflects validity,
+which is convenient for shell-style C<if iabtcfv2 validate -q -v 32 ... "$tc">
+checks.
+
+=back
+
+=head2 Exit codes
+
+=over 4
+
+=item *
+
+B<0> — every input TC string was parsed and validated cleanly.
+
+=item *
+
+B<1> — at least one TC string failed validation or could not be parsed.
+
+=item *
+
+B<2> — bad CLI usage (missing C<--vendor-id>, incoherent purpose lists,
+mutually exclusive flags).
+
+=back
+
+=head2 Examples
+
+    # Single string, fail-fast
+    iabtcfv2 validate -v 32 -C 1,3 -L 7 CO...AAA
+
+    # All reasons, pretty JSON, text-friendly
+    iabtcfv2 validate -av 32 -C 1,3 -L 7 -t CO...AAA
+
+    # Pipeline-friendly: just the exit code
+    if iabtcfv2 validate -q -v 32 -C 1,3 "$tc"; then ...
+
+    # Many strings as a single JSON array
+    iabtcfv2 validate -v 32 -C 1,3 --json-array CO...AAA CO...BBB
 
 =head1 DESCRIPTION
 

--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -369,7 +369,7 @@ sub _validate_string {
     my ( $str, $state, $o, $j, $validator ) = @_;
 
     my $result = eval {
-        $o->{all}
+            $o->{all}
           ? $validator->validate_all($str)
           : $validator->validate($str);
     };
@@ -466,7 +466,7 @@ sub _emit_validate {
             else {
                 $line = join "\n",
                   "FAIL   $tc vendor $vid:",
-                  map { "  - $_" } @reasons;
+                  map {"  - $_"} @reasons;
             }
         }
         print "$line\n";

--- a/docs/superpowers/plans/2026-05-06-validator-flexible-purposes-redesign.md
+++ b/docs/superpowers/plans/2026-05-06-validator-flexible-purposes-redesign.md
@@ -1,0 +1,736 @@
+# Validator Flexible-Purposes Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the validator's mixed-shape `flexible_purpose_ids` parameter with a flat int array whose default basis is **derived structurally** from membership in the existing `consent_purpose_ids` / `legitimate_interest_purpose_ids` lists, so the API mirrors the IAB GVL vendor-entry schema 1:1.
+
+**Architecture:** `flexible_purpose_ids` becomes `ArrayRef[Int]`. The `_check_flexible_purposes` helper is removed. `_check_consent_purposes` and `_check_li_purposes` gain a single check: if a purpose appears in `flexible_purpose_ids`, dispatch through `is_vendor_allowed_for_flexible_purpose` with the appropriate default basis instead of through the strict-basis method. Construction-time coherence checks `croak` on incoherent inputs (a purpose listed in both `consent_purpose_ids` and `legitimate_interest_purpose_ids`, or a flexible purpose listed in neither). A bonus public function `from_gvl_vendor_entry` accepts a parsed GVL vendor entry hashref and returns a hash of constructor arguments, letting users feed GVL JSON straight in.
+
+**Tech Stack:** Perl 5.008+, `Test::More`, `Test::Exception`, `Test::Warn`. No new dependencies.
+
+**Operational note:** Per `AGENTS.md`, all work happens on a feature branch (`feat/phase-2-validator-v2`, the existing PR #54 branch). Do not commit to `devel`/`main`, do not merge into them, do not create tags. CI will re-run on each push to `feat/phase-2-validator-v2`. Test deps already declare `Test::Warn` (PR #49); no new `TEST_REQUIRES` needed.
+
+**Style strictness reminder:** CI runs `xt/critic.t` (`Test::Perl::Critic`) and `xt/tidy.t` (`Test::PerlTidy`); they fail the build on violations. After non-trivial edits, run `make tidy && prove -lr xt`; delete the `.bak` files perltidy leaves behind (they're already excluded via `MANIFEST.SKIP`, but never stage them).
+
+**Branch:** `feat/phase-2-validator-v2` (already exists; pushed to remote; PR #54 open against `devel`).
+
+**Pre-flight (run before Task 1):**
+
+```bash
+git fetch origin
+git checkout feat/phase-2-validator-v2
+git pull --ff-only
+perl Makefile.PL && make
+prove -lr t          # baseline must be green: 8287 tests (post-review-fixups)
+prove -lr xt         # baseline must be green: 41 tests (perlcritic + perltidy)
+```
+
+If baseline isn't green, stop and investigate.
+
+---
+
+## File Structure
+
+| File | Role | Change |
+|---|---|---|
+| `lib/GDPR/IAB/TCFv2/Validator.pm` | The validator class | Modify: remove `_check_flexible_purposes`; teach `_check_consent_purposes` and `_check_li_purposes` to dispatch through `is_vendor_allowed_for_flexible_purpose` when a purpose is also in `flexible_purpose_ids`; add construction-time coherence checks; add `from_gvl_vendor_entry` public function; rewrite the POD `=item *` for `flexible_purpose_ids` and document `from_gvl_vendor_entry`. |
+| `lib/GDPR/IAB/TCFv2/Validator/Result.pm` | Result object | No change. |
+| `t/06-validator.t` | Validator tests | Modify: rewrite the two flexible-purpose subtests for the new shape; add coherence-check subtests; add `from_gvl_vendor_entry` subtest. |
+| `MANIFEST` | Dist manifest | No change. |
+
+Total new lines of code: ~60 (`from_gvl_vendor_entry` + coherence checks + POD). Total deleted: ~30 (the `_check_flexible_purposes` helper and its associated branching). Net change: small.
+
+---
+
+## Task 1: Remove `_check_flexible_purposes` and rewire consent/LI helpers
+
+**Issue addressed:** Replace `flexible_purpose_ids` semantics. Today each entry can be a scalar or `{purpose_id, default_is_li}` hashref; this becomes a flat int array. The default basis is derived from which of `consent_purpose_ids` or `legitimate_interest_purpose_ids` the purpose ID appears in.
+
+**Files:**
+- Modify: `lib/GDPR/IAB/TCFv2/Validator.pm` — `_run_validation`, `_check_consent_purposes`, `_check_li_purposes`; remove `_check_flexible_purposes`
+- Modify: `t/06-validator.t` — rewrite the two flexible-purpose subtests
+
+- [ ] **Step 1: Read the current `_check_flexible_purposes` helper to confirm what's being removed**
+
+```bash
+grep -n -A 27 "^sub _check_flexible_purposes" lib/GDPR/IAB/TCFv2/Validator.pm
+```
+
+Expected: a 25-line subroutine that pops `purpose_id`/`default_is_li` from each entry of `flexible_purpose_ids` and calls `is_vendor_allowed_for_flexible_purpose`.
+
+- [ ] **Step 2: Write the failing test for the new shape**
+
+In `t/06-validator.t`, replace the two existing `flexible_purpose_ids - scalar form` and `flexible_purpose_ids - hashref form` subtests with:
+
+```perl
+subtest "flexible_purpose_ids derives default basis from membership" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+
+    # Vendor 1, Purpose 6: consent=1, LI=1.  P6 is in consent_purpose_ids
+    # AND flexible_purpose_ids → flexible with default consent.  Passes.
+    my $v_consent_default = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id            => 1,
+        consent_purpose_ids  => [6],
+        flexible_purpose_ids => [6],
+    );
+    ok $v_consent_default->validate($tc_string),
+      'flexible P6 with default consent (because P6 is in consent_purpose_ids) passes';
+
+    # Vendor 2, Purpose 2: consent=0, LI=1.  P2 is in
+    # legitimate_interest_purpose_ids AND flexible_purpose_ids → flexible
+    # with default LI.  Passes (LI bit is set).
+    my $v_li_default = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id                       => 2,
+        legitimate_interest_purpose_ids => [2],
+        flexible_purpose_ids            => [2],
+    );
+    ok $v_li_default->validate($tc_string),
+      'flexible P2 with default LI (because P2 is in legitimate_interest_purpose_ids) passes';
+
+    # P2 in consent_purpose_ids AND flexible_purpose_ids → default consent.
+    # Vendor 2 has consent=0 for P2 → fails.
+    my $v_p2_consent_flex = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id            => 2,
+        consent_purpose_ids  => [2],
+        flexible_purpose_ids => [2],
+    );
+    ok !$v_p2_consent_flex->validate($tc_string),
+      'flexible P2 with default consent fails for vendor 2 (no consent bit)';
+};
+```
+
+- [ ] **Step 3: Run the test, confirm it fails**
+
+```bash
+prove -lv t/06-validator.t
+```
+
+Expected: subtest `flexible_purpose_ids derives default basis from membership` fails, because the existing implementation expects `flexible_purpose_ids` entries to be either scalars (with implicit `default_is_li=0`) or hashrefs (with explicit `default_is_li`). The new shape — same purpose ID in both `consent_purpose_ids` and `flexible_purpose_ids` — currently produces a "purpose 6 not allowed for purpose 6 (consent)"-style failure for the consent-default case, or success-by-accident for the LI-default case. The exact failure messages don't matter; what matters is that the new behaviour we're testing for isn't yet implemented.
+
+- [ ] **Step 4: Modify `_check_consent_purposes` and `_check_li_purposes` to dispatch through the flexible helper when applicable**
+
+Replace `lib/GDPR/IAB/TCFv2/Validator.pm:100-134` (the `_check_consent_purposes` and `_check_li_purposes` subs) with:
+
+```perl
+sub _check_consent_purposes {
+    my ( $self, $tc, $vendor_id, $strict, $reasons, $stop_on_first ) = @_;
+
+    foreach my $pid ( @{ $self->{consent_purpose_ids} } ) {
+        my $allowed =
+          $self->{_flexible_set}->{$pid}
+          ? $tc->is_vendor_allowed_for_flexible_purpose(
+            $vendor_id, $pid, 0, strict => $strict
+          )
+          : $tc->is_vendor_consent_allowed(
+            $vendor_id, $pid, strict => $strict
+          );
+
+        unless ($allowed) {
+            push @{$reasons},
+              "vendor $vendor_id not allowed for purpose $pid (consent)";
+            return if $stop_on_first;
+        }
+    }
+    return;
+}
+
+sub _check_li_purposes {
+    my ( $self, $tc, $vendor_id, $strict, $reasons, $stop_on_first ) = @_;
+
+    foreach my $pid ( @{ $self->{legitimate_interest_purpose_ids} } ) {
+        my $allowed =
+          $self->{_flexible_set}->{$pid}
+          ? $tc->is_vendor_allowed_for_flexible_purpose(
+            $vendor_id, $pid, 1, strict => $strict
+          )
+          : $tc->is_vendor_legitimate_interest_allowed(
+            $vendor_id, $pid, strict => $strict
+          );
+
+        unless ($allowed) {
+            push @{$reasons},
+              "vendor $vendor_id not allowed for purpose $pid (legitimate interest)";
+            return if $stop_on_first;
+        }
+    }
+    return;
+}
+```
+
+The `$self->{_flexible_set}` is a hashref-as-set (`{ 2 => 1, 7 => 1 }`) built once at construction time for O(1) membership lookup; we'll add it in Task 2.
+
+- [ ] **Step 5: Remove the standalone `_check_flexible_purposes` helper**
+
+In `lib/GDPR/IAB/TCFv2/Validator.pm`, delete the entire `sub _check_flexible_purposes { ... }` block (was lines 136-162 before edits; locate it with `grep -n '^sub _check_flexible_purposes' lib/GDPR/IAB/TCFv2/Validator.pm`).
+
+- [ ] **Step 6: Remove the call to `_check_flexible_purposes` from `_run_validation`**
+
+In `lib/GDPR/IAB/TCFv2/Validator.pm`, find this block in `_run_validation`:
+
+```perl
+    $self->_check_flexible_purposes(
+        $tc, $vendor_id, $strict, \@reasons,
+        $stop_on_first
+    );
+```
+
+…and delete it. The four lines before it (the `_check_li_purposes` call + its short-circuit `return`) remain unchanged.
+
+- [ ] **Step 7: Build the `_flexible_set` lookup in the constructor**
+
+In `lib/GDPR/IAB/TCFv2/Validator.pm`, modify `sub new` (currently lines 10-24). Replace it with:
+
+```perl
+sub new {
+    my ( $klass, %args ) = @_;
+
+    my $consent             = $args{consent_purpose_ids}             || [];
+    my $legitimate_interest = $args{legitimate_interest_purpose_ids} || [];
+    my $flexible            = $args{flexible_purpose_ids}            || [];
+
+    my $self = {
+        vendor_id                       => $args{vendor_id},
+        consent_purpose_ids             => $consent,
+        legitimate_interest_purpose_ids => $legitimate_interest,
+        flexible_purpose_ids            => $flexible,
+        _flexible_set                   => { map { $_ => 1 } @{$flexible} },
+        check_disclosed_vendors         => $args{check_disclosed_vendors} || 0,
+        strict                  => exists $args{strict} ? $args{strict} : 0,
+    };
+
+    return bless $self, $klass;
+}
+```
+
+`_flexible_set` is a private (underscore-prefixed) cache used by `_check_consent_purposes` / `_check_li_purposes`. Storing as a hash makes per-purpose lookup O(1).
+
+- [ ] **Step 8: Run the suite + xt**
+
+```bash
+prove -lv t/06-validator.t
+prove -lr t
+prove -lr xt
+```
+
+Expected: all three commands green. The new subtest from Step 2 passes; xt passes (no critic/tidy regressions yet — but if perltidy reformats the new code, follow up with `make tidy` and re-run `prove -lr xt` until clean; remove any `.bak` files produced).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add lib/GDPR/IAB/TCFv2/Validator.pm t/06-validator.t
+git commit -m "refactor(validator): derive flexible-purpose default basis from membership
+
+flexible_purpose_ids is now a flat ArrayRef[Int].  The default
+legal basis for each flexible purpose is derived structurally:
+
+  * Purpose in consent_purpose_ids   AND flexible_purpose_ids
+        -> flexible with default consent
+  * Purpose in legitimate_interest_purpose_ids AND flexible_purpose_ids
+        -> flexible with default legitimate interest
+
+This mirrors the IAB GVL vendor-entry schema 1:1 (purposes /
+legIntPurposes / flexiblePurposes) and removes the mixed-shape
+parameter that accepted both scalars and {purpose_id, default_is_li}
+hashrefs."
+```
+
+---
+
+## Task 2: Add construction-time coherence checks
+
+**Issue addressed:** With the new shape, two configurations are structurally incoherent and should `croak` at construction time rather than producing surprising results at validation time:
+
+1. A purpose appearing in **both** `consent_purpose_ids` and `legitimate_interest_purpose_ids` (a vendor cannot declare the same purpose under both bases per the GVL schema).
+2. A purpose in `flexible_purpose_ids` that appears in **neither** `consent_purpose_ids` nor `legitimate_interest_purpose_ids` (no default basis can be derived).
+
+**Files:**
+- Modify: `lib/GDPR/IAB/TCFv2/Validator.pm` — `sub new`
+- Modify: `t/06-validator.t` — add coherence subtest
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `t/06-validator.t`:
+
+```perl
+subtest "Validator coherence checks at construction time" => sub {
+
+    # A purpose can't be in both consent_purpose_ids and
+    # legitimate_interest_purpose_ids — the GVL schema treats those as
+    # mutually exclusive declarations.
+    throws_ok {
+        GDPR::IAB::TCFv2::Validator->new(
+            vendor_id                       => 1,
+            consent_purpose_ids             => [3],
+            legitimate_interest_purpose_ids => [3],
+        );
+    }
+    qr/purpose 3 cannot be in both consent_purpose_ids and legitimate_interest_purpose_ids/,
+      'croaks when a purpose is listed under both bases';
+
+    # A flexible purpose must be listed under one of the two bases —
+    # otherwise no default can be derived.
+    throws_ok {
+        GDPR::IAB::TCFv2::Validator->new(
+            vendor_id            => 1,
+            flexible_purpose_ids => [5],
+        );
+    }
+    qr/flexible purpose 5 must also appear in consent_purpose_ids or legitimate_interest_purpose_ids/,
+      'croaks when a flexible purpose has no derivable default basis';
+
+    # Sanity: a properly-coherent config still constructs.
+    lives_ok {
+        GDPR::IAB::TCFv2::Validator->new(
+            vendor_id                       => 1,
+            consent_purpose_ids             => [ 1, 6 ],
+            legitimate_interest_purpose_ids => [ 2, 10 ],
+            flexible_purpose_ids            => [ 6, 2 ],
+        );
+    }
+    'coherent configuration constructs without error';
+};
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+```bash
+prove -lv t/06-validator.t
+```
+
+Expected: the new subtest's `throws_ok` assertions fail because the constructor does not currently `croak` on these configurations.
+
+- [ ] **Step 3: Add the coherence checks to the constructor**
+
+In `lib/GDPR/IAB/TCFv2/Validator.pm`, modify `sub new` to call a new private helper before blessing. Replace the body of `sub new` with:
+
+```perl
+sub new {
+    my ( $klass, %args ) = @_;
+
+    my $consent             = $args{consent_purpose_ids}             || [];
+    my $legitimate_interest = $args{legitimate_interest_purpose_ids} || [];
+    my $flexible            = $args{flexible_purpose_ids}            || [];
+
+    _check_coherence( $consent, $legitimate_interest, $flexible );
+
+    my $self = {
+        vendor_id                       => $args{vendor_id},
+        consent_purpose_ids             => $consent,
+        legitimate_interest_purpose_ids => $legitimate_interest,
+        flexible_purpose_ids            => $flexible,
+        _flexible_set                   => { map { $_ => 1 } @{$flexible} },
+        check_disclosed_vendors         => $args{check_disclosed_vendors} || 0,
+        strict                  => exists $args{strict} ? $args{strict} : 0,
+    };
+
+    return bless $self, $klass;
+}
+
+sub _check_coherence {
+    my ( $consent, $legitimate_interest, $flexible ) = @_;
+
+    my %consent_set = map { $_ => 1 } @{$consent};
+    my %li_set      = map { $_ => 1 } @{$legitimate_interest};
+
+    foreach my $pid ( @{$consent} ) {
+        croak
+          "purpose $pid cannot be in both consent_purpose_ids and legitimate_interest_purpose_ids"
+          if $li_set{$pid};
+    }
+
+    foreach my $pid ( @{$flexible} ) {
+        next if $consent_set{$pid} || $li_set{$pid};
+        croak
+          "flexible purpose $pid must also appear in consent_purpose_ids or legitimate_interest_purpose_ids";
+    }
+
+    return;
+}
+```
+
+`_check_coherence` is a plain function (not a method) — easier to test in isolation, no `$self` to pass around since the constructor hasn't blessed yet.
+
+- [ ] **Step 4: Run the suite + xt**
+
+```bash
+prove -lv t/06-validator.t
+prove -lr t
+prove -lr xt
+```
+
+Expected: all green. If perltidy complains, run `make tidy` and re-stage; remove the `.bak` files.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/GDPR/IAB/TCFv2/Validator.pm t/06-validator.t
+git commit -m "feat(validator): croak on incoherent purpose-list configurations
+
+Two configurations are now caught at construction time rather than
+silently producing strange validation outcomes:
+
+  1. A purpose listed in both consent_purpose_ids and
+     legitimate_interest_purpose_ids (GVL semantics treat those
+     as mutually exclusive vendor declarations).
+  2. A purpose listed in flexible_purpose_ids but neither of the
+     other two lists (no default basis can be derived).
+
+Both croak with explicit messages naming the offending purpose ID."
+```
+
+---
+
+## Task 3: Add the public `from_gvl_vendor_entry` function
+
+**Issue addressed:** Bonus convenience for users who have parsed GVL JSON. `from_gvl_vendor_entry` accepts a single vendor-entry hashref (per the IAB GVL schema) and returns a hash of constructor arguments suitable for splatting into `Validator->new`.
+
+**Files:**
+- Modify: `lib/GDPR/IAB/TCFv2/Validator.pm` — add `from_gvl_vendor_entry`
+- Modify: `t/06-validator.t` — add subtest covering the function
+
+**Design note:** This is a plain function on the package, not a constructor. It returns the *arguments* `Validator->new` needs, so users can mix in extra keys (`check_disclosed_vendors`, `strict`) without conflicting with the GVL data:
+
+```perl
+my %args = GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry($vendor_entry);
+my $v = GDPR::IAB::TCFv2::Validator->new( %args, strict => 1 );
+```
+
+This is consistent with Perl's `wantarray`-on-list-context idiom and keeps the constructor a single entry point.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `t/06-validator.t`:
+
+```perl
+subtest "from_gvl_vendor_entry maps GVL JSON to constructor args" => sub {
+    my $entry = {
+        id               => 284,
+        name             => 'Weborama',                       # ignored
+        purposes         => [ 1, 3, 4, 5, 6 ],
+        legIntPurposes   => [ 2, 7, 8, 9, 10, 11 ],
+        flexiblePurposes => [ 2, 7, 8, 9, 10, 11 ],
+    };
+
+    my %args = GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry($entry);
+
+    is $args{vendor_id}, 284, 'vendor_id maps from id';
+    is_deeply $args{consent_purpose_ids},
+      [ 1, 3, 4, 5, 6 ],
+      'consent_purpose_ids maps from purposes';
+    is_deeply $args{legitimate_interest_purpose_ids},
+      [ 2, 7, 8, 9, 10, 11 ],
+      'legitimate_interest_purpose_ids maps from legIntPurposes';
+    is_deeply $args{flexible_purpose_ids},
+      [ 2, 7, 8, 9, 10, 11 ],
+      'flexible_purpose_ids maps from flexiblePurposes';
+
+    # Returned args splat into the constructor cleanly, mixed with extras.
+    my $v = GDPR::IAB::TCFv2::Validator->new( %args, strict => 1 );
+    isa_ok $v, 'GDPR::IAB::TCFv2::Validator';
+
+    # Croak on missing id
+    throws_ok {
+        GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry(
+            {   purposes         => [],
+                legIntPurposes   => [],
+                flexiblePurposes => [],
+            }
+        );
+    }
+    qr/from_gvl_vendor_entry: missing 'id'/,
+      'croaks on a vendor entry missing the id field';
+
+    # Missing list fields default to empty arrayrefs (a vendor with no
+    # legIntPurposes is valid in the GVL schema).
+    my %sparse = GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry(
+        { id => 1 } );
+    is_deeply $sparse{consent_purpose_ids},             [],
+      'missing purposes defaults to empty arrayref';
+    is_deeply $sparse{legitimate_interest_purpose_ids}, [],
+      'missing legIntPurposes defaults to empty arrayref';
+    is_deeply $sparse{flexible_purpose_ids},            [],
+      'missing flexiblePurposes defaults to empty arrayref';
+};
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+```bash
+prove -lv t/06-validator.t
+```
+
+Expected: subtest `from_gvl_vendor_entry maps GVL JSON to constructor args` fails with `Undefined subroutine &GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry`.
+
+- [ ] **Step 3: Implement `from_gvl_vendor_entry`**
+
+In `lib/GDPR/IAB/TCFv2/Validator.pm`, add this subroutine immediately after `sub _check_coherence` and before `sub validate`:
+
+```perl
+sub from_gvl_vendor_entry {
+    my ($entry) = @_;
+
+    croak "from_gvl_vendor_entry: missing 'id' in vendor entry"
+      unless defined $entry->{id};
+
+    return (
+        vendor_id                       => $entry->{id},
+        consent_purpose_ids             => $entry->{purposes}         || [],
+        legitimate_interest_purpose_ids => $entry->{legIntPurposes}   || [],
+        flexible_purpose_ids            => $entry->{flexiblePurposes} || [],
+    );
+}
+```
+
+This is intentionally:
+
+- A **plain function** (no `$self`), invoked as `GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry($entry)`.
+- Returns a **list of key-value pairs** suitable for splatting into `Validator->new(%args, ...extras)`.
+- Ignores other GVL fields (`name`, `purposeName`, `policyUrl`, `cookieMaxAgeSeconds`, etc.) — they're not relevant to validation.
+- Croaks only on missing `id`. Other fields default to empty arrayrefs because the GVL schema permits a vendor to have no legitimate-interest or flexible purposes.
+
+- [ ] **Step 4: Run the suite + xt**
+
+```bash
+prove -lv t/06-validator.t
+prove -lr t
+prove -lr xt
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/GDPR/IAB/TCFv2/Validator.pm t/06-validator.t
+git commit -m "feat(validator): add from_gvl_vendor_entry helper
+
+Maps a parsed IAB GVL vendor entry hashref to the constructor
+arguments Validator->new expects.  Field aliases:
+
+  id               -> vendor_id
+  purposes         -> consent_purpose_ids
+  legIntPurposes   -> legitimate_interest_purpose_ids
+  flexiblePurposes -> flexible_purpose_ids
+
+Returns a list (key-value pairs) so callers can splat into the
+constructor and add extras:
+
+  my \$v = GDPR::IAB::TCFv2::Validator->new(
+      GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry(\$entry),
+      strict => 1,
+  );
+
+Croaks only on missing 'id'.  Missing list fields default to
+empty arrayrefs per the GVL schema (a vendor may legitimately
+have no LI or flexible purposes)."
+```
+
+---
+
+## Task 4: Update POD to reflect the new design
+
+**Issue addressed:** The Validator's POD (added in PR #54's review fixups) describes the old shape — scalar-or-hashref `flexible_purpose_ids` with `default_is_li`. Needs updating to match the new structural-derivation design and to document `from_gvl_vendor_entry`.
+
+**Files:**
+- Modify: `lib/GDPR/IAB/TCFv2/Validator.pm` — POD section
+
+- [ ] **Step 1: Locate the relevant POD section**
+
+```bash
+grep -n '=item \*\|=head' lib/GDPR/IAB/TCFv2/Validator.pm | tail -30
+```
+
+Expected: a list of `=item *` and `=head*` markers covering CONSTRUCTOR, METHODS, SEE ALSO. The relevant `=item *` is the one that begins with `C<flexible_purpose_ids>`.
+
+- [ ] **Step 2: Rewrite the `flexible_purpose_ids` POD entry**
+
+In `lib/GDPR/IAB/TCFv2/Validator.pm`, find the `=item *` block describing `flexible_purpose_ids` (it documents the old scalar-or-hashref shape). Replace it with:
+
+```pod
+=item *
+
+C<flexible_purpose_ids> — arrayref of purpose IDs that are B<flexible> per the
+vendor's GVL declaration (the basis can flip if a publisher restriction is
+present in the TC string). The default basis is derived structurally:
+
+=over 8
+
+=item *
+
+If the purpose ID also appears in C<consent_purpose_ids>, the default basis
+is consent.
+
+=item *
+
+If the purpose ID also appears in C<legitimate_interest_purpose_ids>, the
+default basis is legitimate interest.
+
+=back
+
+A purpose listed in C<flexible_purpose_ids> must also appear in exactly one
+of the other two lists, or the constructor C<croak>s. Validated via
+L<GDPR::IAB::TCFv2/is_vendor_allowed_for_flexible_purpose>.
+```
+
+- [ ] **Step 3: Add a POD entry for `from_gvl_vendor_entry`**
+
+In the same file, immediately before `=head1 SEE ALSO`, add this section:
+
+```pod
+=head1 FUNCTIONS
+
+=head2 from_gvl_vendor_entry
+
+    my %args = GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry($vendor_entry);
+    my $validator = GDPR::IAB::TCFv2::Validator->new( %args, strict => 1 );
+
+Maps a parsed IAB Global Vendor List vendor-entry hashref to the constructor
+arguments L</new> expects. Field aliases:
+
+=over 4
+
+=item *
+
+C<id> ⟶ C<vendor_id>
+
+=item *
+
+C<purposes> ⟶ C<consent_purpose_ids>
+
+=item *
+
+C<legIntPurposes> ⟶ C<legitimate_interest_purpose_ids>
+
+=item *
+
+C<flexiblePurposes> ⟶ C<flexible_purpose_ids>
+
+=back
+
+Returns a list (key-value pairs), so callers can splat into the constructor
+alongside additional keys like C<strict> and C<check_disclosed_vendors>.
+Other fields on the vendor entry (C<name>, C<policyUrl>, etc.) are ignored —
+they aren't relevant to validation.
+
+C<croak>s only when C<id> is missing. Missing list fields default to empty
+arrayrefs, since the GVL schema permits a vendor to declare no
+legitimate-interest or flexible purposes.
+```
+
+- [ ] **Step 4: Update the SYNOPSIS to use the new shape**
+
+Find the `SYNOPSIS` block in `lib/GDPR/IAB/TCFv2/Validator.pm` and replace the `flexible_purpose_ids` line to use the new flat-int form. The block currently reads:
+
+```pod
+        flexible_purpose_ids            => [
+            { purpose_id => 2, default_is_li => 1 },
+        ],
+```
+
+Replace with:
+
+```pod
+        flexible_purpose_ids            => [ 2 ],
+```
+
+(Reflecting that purpose 2 is in `legitimate_interest_purpose_ids` and is also flexible, with default LI derived from membership.)
+
+- [ ] **Step 5: Verify POD is well-formed**
+
+```bash
+podchecker lib/GDPR/IAB/TCFv2/Validator.pm
+```
+
+Expected: `lib/GDPR/IAB/TCFv2/Validator.pm pod syntax OK.`
+
+- [ ] **Step 6: Run the full suite + xt**
+
+```bash
+prove -lr t
+prove -lr xt
+```
+
+Expected: all green. POD-only changes shouldn't affect tests, but the POD test (`t/99-pod.t`) verifies syntactic well-formedness.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/GDPR/IAB/TCFv2/Validator.pm
+git commit -m "docs(validator): rewrite flexible_purpose_ids POD for the new shape
+
+Document the structural derivation of default basis (membership in
+consent_purpose_ids vs legitimate_interest_purpose_ids), the
+construction-time coherence checks that croak on incoherent inputs,
+and the new from_gvl_vendor_entry public function in a new
+=head1 FUNCTIONS section.  SYNOPSIS updated to use the flat-int
+flexible_purpose_ids shape."
+```
+
+---
+
+## Wrap-up
+
+- [ ] **Final step: Update PR #54 description**
+
+```bash
+prove -lr t && prove -lr xt   # final green-light check (8290 tests, +3 from this plan)
+git push origin feat/phase-2-validator-v2
+```
+
+Then update the PR body via `gh api` (the `gh pr edit --body-file` path hits a known GraphQL deprecation; use REST):
+
+```bash
+cat > /tmp/pr54_body.md <<'PRBODY'
+... existing PR body content ...
+
+## Update: flexible_purpose_ids redesign
+
+The mixed-shape `flexible_purpose_ids` parameter has been replaced with a
+flat ArrayRef[Int]. The default legal basis for each flexible purpose is now
+derived structurally from membership in `consent_purpose_ids` (default
+consent) or `legitimate_interest_purpose_ids` (default LI), mirroring the
+IAB GVL vendor-entry schema 1:1.
+
+Construction-time coherence checks `croak` on:
+
+  * a purpose listed under both bases (mutually exclusive per GVL)
+  * a flexible purpose with no derivable default
+
+A new public function `from_gvl_vendor_entry` aliases parsed GVL JSON
+fields to the constructor's argument names, letting callers plug a parsed
+GVL entry straight in.
+PRBODY
+
+jq -Rs '{body: .}' < /tmp/pr54_body.md > /tmp/pr54_payload.json
+gh api -X PATCH repos/peczenyj/GDPR-IAB-TCFv2/pulls/54 --input /tmp/pr54_payload.json --jq '.title'
+```
+
+(Adapt the actual body content; this is a sketch of the additions, not the full replacement.)
+
+The PR title can stay as is or be retitled to `Phase 2: The Validator Interface (rebased + reviewed + GVL-aligned shape)` — your call.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Concept of flexible-purpose default basis derivation → Task 1 ✓
+- Construction-time coherence enforcement → Task 2 ✓
+- GVL-vendor-entry conversion helper → Task 3 ✓
+- POD updates for new shape → Task 4 ✓
+
+**2. Placeholder scan:**
+- No "TODO", "TBD", or "fill in" instances. ✓
+- Every code step shows actual code. ✓
+- Every command shows the exact invocation and the expected outcome. ✓
+
+**3. Type/symbol consistency:**
+- `_flexible_set` is introduced in Task 1 Step 7 (constructor) and consumed in Task 1 Step 4 (helpers). It's a hashref with integer keys mapping to truthy values; lookup is `$self->{_flexible_set}->{$pid}`. ✓
+- `_check_coherence` is introduced in Task 2 Step 3 as a plain (non-method) sub. Called from `sub new` BEFORE the `bless`, so passing `($consent, $legitimate_interest, $flexible)` rather than `$self`. ✓
+- `from_gvl_vendor_entry` is introduced in Task 3 Step 3 as a plain (non-method) sub returning a list. ✓
+- The constructor in Task 2 Step 3 already includes the `_flexible_set` line from Task 1 Step 7 — these are sequential edits to the same `sub new`, and Task 2 supersedes Task 1's version. ✓
+
+**4. Risk register:**
+- *perltidy will likely reformat the new `_check_coherence` sub.* Mitigation: `make tidy && prove -lr xt` is part of every task's verification step.
+- *Existing tests in t/06-validator.t that pass `flexible_purpose_ids` in the old shape will break.* Mitigation: Task 1 Step 2 explicitly replaces the two old subtests; the rest of the file uses only `consent_purpose_ids` / `legitimate_interest_purpose_ids` and is unaffected.
+- *PR #54 already shipped a 145-line POD for Validator.pm.* Task 4 modifies only one `=item *` and adds a `=head1 FUNCTIONS` section; the rest of the POD is untouched.

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -1,0 +1,139 @@
+package GDPR::IAB::TCFv2::Validator;
+
+use strict;
+use warnings;
+
+use Carp qw<croak>;
+use GDPR::IAB::TCFv2;
+use GDPR::IAB::TCFv2::Validator::Result;
+
+sub new {
+    my ( $klass, %args ) = @_;
+
+    my $self = {
+        vendor_id                       => $args{vendor_id},
+        consent_purpose_ids             => $args{consent_purpose_ids} || [],
+        legitimate_interest_purpose_ids =>
+          $args{legitimate_interest_purpose_ids} || [],
+        flexible_purpose_ids    => $args{flexible_purpose_ids}    || [],
+        check_disclosed_vendors => $args{check_disclosed_vendors} || 0,
+        strict                  => exists $args{strict} ? $args{strict} : 0,
+    };
+
+    return bless $self, $klass;
+}
+
+sub validate {
+    my ( $self, $input, %overrides ) = @_;
+
+    return $self->_run_validation( $input, 1, %overrides );
+}
+
+sub validate_all {
+    my ( $self, $input, %overrides ) = @_;
+
+    return $self->_run_validation( $input, 0, %overrides );
+}
+
+sub _run_validation {
+    my ( $self, $input, $stop_on_first, %overrides ) = @_;
+
+    my $tc =
+      ref($input) eq 'GDPR::IAB::TCFv2'
+      ? $input
+      : GDPR::IAB::TCFv2->Parse($input);
+
+    my $vendor_id =
+      exists $overrides{vendor_id}
+      ? $overrides{vendor_id}
+      : $self->{vendor_id};
+    my $strict =
+      exists $overrides{strict} ? $overrides{strict} : $self->{strict};
+    my $check_disclosed =
+      exists $overrides{check_disclosed_vendors}
+      ? $overrides{check_disclosed_vendors}
+      : $self->{check_disclosed_vendors};
+
+    croak "missing vendor_id" unless defined $vendor_id;
+
+    my @reasons;
+
+    # Check Disclosed Vendors if segment exists and requested
+    if ($check_disclosed) {
+        if ( defined $tc->{disclosed_vendors_data} ) {
+            unless ( $tc->disclosed_vendor($vendor_id) ) {
+                push @reasons, "vendor $vendor_id not disclosed";
+                return $self->_make_result( 0, \@reasons ) if $stop_on_first;
+            }
+        }
+    }
+
+    # Check Consent Purposes
+    foreach my $pid ( @{ $self->{consent_purpose_ids} } ) {
+        unless (
+            $tc->is_vendor_consent_allowed(
+                $vendor_id, $pid, strict => $strict
+            )
+          )
+        {
+            push @reasons,
+              "vendor $vendor_id not allowed for purpose $pid (consent)";
+            return $self->_make_result( 0, \@reasons ) if $stop_on_first;
+        }
+    }
+
+    # Check Legitimate Interest Purposes
+    foreach my $pid ( @{ $self->{legitimate_interest_purpose_ids} } ) {
+        unless (
+            $tc->is_vendor_legitimate_interest_allowed(
+                $vendor_id, $pid, strict => $strict
+            )
+          )
+        {
+            push @reasons,
+              "vendor $vendor_id not allowed for purpose $pid (legitimate interest)";
+            return $self->_make_result( 0, \@reasons ) if $stop_on_first;
+        }
+    }
+
+    # Check Flexible Purposes
+    foreach my $flex ( @{ $self->{flexible_purpose_ids} } ) {
+        my ( $pid, $default_is_li );
+        if ( ref($flex) eq 'HASH' ) {
+            $pid           = $flex->{purpose_id};
+            $default_is_li = $flex->{default_is_li};
+        }
+        else {
+            $pid           = $flex;
+            $default_is_li = 0;
+        }
+
+        unless (
+            $tc->is_vendor_allowed_for_flexible_purpose(
+                $vendor_id, $pid, $default_is_li, strict => $strict
+            )
+          )
+        {
+            push @reasons,
+              "vendor $vendor_id not allowed for flexible purpose $pid";
+            return $self->_make_result( 0, \@reasons ) if $stop_on_first;
+        }
+    }
+
+    if (@reasons) {
+        return $self->_make_result( 0, \@reasons );
+    }
+
+    return $self->_make_result( 1, [] );
+}
+
+sub _make_result {
+    my ( $self, $ok, $reasons ) = @_;
+
+    return GDPR::IAB::TCFv2::Validator::Result->new(
+        ok      => $ok,
+        reasons => $reasons,
+    );
+}
+
+1;

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -58,17 +58,49 @@ sub _run_validation {
 
     my @reasons;
 
-    # Check Disclosed Vendors if segment exists and requested
+    $self->_check_disclosed( $tc, $vendor_id, $check_disclosed, \@reasons );
+    return $self->_make_result( 0, \@reasons ) if $stop_on_first && @reasons;
+
+    $self->_check_consent_purposes(
+        $tc, $vendor_id, $strict, \@reasons,
+        $stop_on_first
+    );
+    return $self->_make_result( 0, \@reasons ) if $stop_on_first && @reasons;
+
+    $self->_check_li_purposes(
+        $tc, $vendor_id, $strict, \@reasons,
+        $stop_on_first
+    );
+    return $self->_make_result( 0, \@reasons ) if $stop_on_first && @reasons;
+
+    $self->_check_flexible_purposes(
+        $tc, $vendor_id, $strict, \@reasons,
+        $stop_on_first
+    );
+
+    if (@reasons) {
+        return $self->_make_result( 0, \@reasons );
+    }
+
+    return $self->_make_result( 1, [] );
+}
+
+sub _check_disclosed {
+    my ( $self, $tc, $vendor_id, $check_disclosed, $reasons ) = @_;
+
     if ($check_disclosed) {
         if ( defined $tc->{disclosed_vendors_data} ) {
             unless ( $tc->disclosed_vendor($vendor_id) ) {
-                push @reasons, "vendor $vendor_id not disclosed";
-                return $self->_make_result( 0, \@reasons ) if $stop_on_first;
+                push @{$reasons}, "vendor $vendor_id not disclosed";
             }
         }
     }
+    return;
+}
 
-    # Check Consent Purposes
+sub _check_consent_purposes {
+    my ( $self, $tc, $vendor_id, $strict, $reasons, $stop_on_first ) = @_;
+
     foreach my $pid ( @{ $self->{consent_purpose_ids} } ) {
         unless (
             $tc->is_vendor_consent_allowed(
@@ -76,13 +108,17 @@ sub _run_validation {
             )
           )
         {
-            push @reasons,
+            push @{$reasons},
               "vendor $vendor_id not allowed for purpose $pid (consent)";
-            return $self->_make_result( 0, \@reasons ) if $stop_on_first;
+            return if $stop_on_first;
         }
     }
+    return;
+}
 
-    # Check Legitimate Interest Purposes
+sub _check_li_purposes {
+    my ( $self, $tc, $vendor_id, $strict, $reasons, $stop_on_first ) = @_;
+
     foreach my $pid ( @{ $self->{legitimate_interest_purpose_ids} } ) {
         unless (
             $tc->is_vendor_legitimate_interest_allowed(
@@ -90,13 +126,17 @@ sub _run_validation {
             )
           )
         {
-            push @reasons,
+            push @{$reasons},
               "vendor $vendor_id not allowed for purpose $pid (legitimate interest)";
-            return $self->_make_result( 0, \@reasons ) if $stop_on_first;
+            return if $stop_on_first;
         }
     }
+    return;
+}
 
-    # Check Flexible Purposes
+sub _check_flexible_purposes {
+    my ( $self, $tc, $vendor_id, $strict, $reasons, $stop_on_first ) = @_;
+
     foreach my $flex ( @{ $self->{flexible_purpose_ids} } ) {
         my ( $pid, $default_is_li );
         if ( ref($flex) eq 'HASH' ) {
@@ -114,18 +154,14 @@ sub _run_validation {
             )
           )
         {
-            push @reasons,
+            push @{$reasons},
               "vendor $vendor_id not allowed for flexible purpose $pid";
-            return $self->_make_result( 0, \@reasons ) if $stop_on_first;
+            return if $stop_on_first;
         }
     }
-
-    if (@reasons) {
-        return $self->_make_result( 0, \@reasons );
-    }
-
-    return $self->_make_result( 1, [] );
+    return;
 }
+
 
 sub _make_result {
     my ( $self, $ok, $reasons ) = @_;

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -205,10 +205,14 @@ GDPR::IAB::TCFv2::Validator - declarative compliance checks for TC strings
         vendor_id                       => 284,
         consent_purpose_ids             => [ 1, 3, 9 ],
         legitimate_interest_purpose_ids => [ 10 ],
-        flexible_purpose_ids            => [
-            { purpose_id => 2, default_is_li => 1 },
-        ],
+        flexible_purpose_ids            => [ 10 ],
         check_disclosed_vendors         => 1,
+    );
+
+    # Or, from a parsed IAB GVL vendor entry:
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry($vendor_entry),
+        check_disclosed_vendors => 1,
     );
 
     # Fail-fast: stops at the first failing rule.
@@ -272,22 +276,28 @@ those are enforced by the underlying parser and surface here as failures.
 
 =item *
 
-C<flexible_purpose_ids> — arrayref of either:
+C<flexible_purpose_ids> — arrayref of purpose IDs that are B<flexible> per
+the vendor's GVL declaration (the basis can flip if a publisher restriction
+is present in the TC string). The default basis is derived structurally
+from the other two lists:
 
 =over 8
 
 =item *
 
-a plain integer (purpose ID, default legal basis = consent), or
+If the purpose ID also appears in C<consent_purpose_ids>, the default basis
+is consent.
 
 =item *
 
-a hashref C<< { purpose_id => N, default_is_li => 0|1 } >> for explicit
-control over the default legal basis.
+If the purpose ID also appears in C<legitimate_interest_purpose_ids>, the
+default basis is legitimate interest.
 
 =back
 
-Validated via L<GDPR::IAB::TCFv2/is_vendor_allowed_for_flexible_purpose>.
+A purpose listed in C<flexible_purpose_ids> must also appear in exactly one
+of the other two lists, or the constructor C<croak>s. Validated via
+L<GDPR::IAB::TCFv2/is_vendor_allowed_for_flexible_purpose>.
 
 =item *
 
@@ -329,6 +339,45 @@ is being validated against multiple policies.
 Identical to L</validate> but runs B<every> rule and accumulates all
 failures into the result. Use when you want a complete error report
 rather than the first failure.
+
+=head1 FUNCTIONS
+
+=head2 from_gvl_vendor_entry
+
+    my %args = GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry($vendor_entry);
+    my $validator = GDPR::IAB::TCFv2::Validator->new( %args, strict => 1 );
+
+Maps a parsed IAB Global Vendor List vendor-entry hashref to the constructor
+arguments L</new> expects. Field aliases:
+
+=over 4
+
+=item *
+
+C<id> ⟶ C<vendor_id>
+
+=item *
+
+C<purposes> ⟶ C<consent_purpose_ids>
+
+=item *
+
+C<legIntPurposes> ⟶ C<legitimate_interest_purpose_ids>
+
+=item *
+
+C<flexiblePurposes> ⟶ C<flexible_purpose_ids>
+
+=back
+
+Returns a list (key-value pairs), so callers can splat into the constructor
+alongside additional keys like C<strict> and C<check_disclosed_vendors>.
+Other fields on the vendor entry (C<name>, C<policyUrl>, etc.) are ignored —
+they aren't relevant to validation.
+
+C<croak>s only when C<id> is missing. Missing list fields default to empty
+arrayrefs, since the GVL schema permits a vendor to declare no
+legitimate-interest or flexible purposes.
 
 =head1 SEE ALSO
 

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -51,6 +51,20 @@ sub _check_coherence {
     return;
 }
 
+sub from_gvl_vendor_entry {
+    my ($entry) = @_;
+
+    croak "from_gvl_vendor_entry: missing 'id' in vendor entry"
+      unless defined $entry->{id};
+
+    return (
+        vendor_id                       => $entry->{id},
+        consent_purpose_ids             => $entry->{purposes}         || [],
+        legitimate_interest_purpose_ids => $entry->{legIntPurposes}   || [],
+        flexible_purpose_ids            => $entry->{flexiblePurposes} || [],
+    );
+}
+
 sub validate {
     my ( $self, $input, %overrides ) = @_;
 

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -23,6 +23,7 @@ sub new {
         flexible_purpose_ids            => $flexible,
         _flexible_set                   => { map { $_ => 1 } @{$flexible} },
         check_disclosed_vendors         => $args{check_disclosed_vendors} || 0,
+        min_policy_version              => $args{min_policy_version},
         strict => exists $args{strict} ? $args{strict} : 0,
     };
 
@@ -94,10 +95,17 @@ sub _run_validation {
       exists $overrides{check_disclosed_vendors}
       ? $overrides{check_disclosed_vendors}
       : $self->{check_disclosed_vendors};
+    my $min_policy_version =
+      exists $overrides{min_policy_version}
+      ? $overrides{min_policy_version}
+      : $self->{min_policy_version};
 
     croak "missing vendor_id" unless defined $vendor_id;
 
     my @reasons;
+
+    $self->_check_min_policy_version( $tc, $min_policy_version, \@reasons );
+    return $self->_make_result( 0, \@reasons ) if $stop_on_first && @reasons;
 
     $self->_check_disclosed( $tc, $vendor_id, $check_disclosed, \@reasons );
     return $self->_make_result( 0, \@reasons ) if $stop_on_first && @reasons;
@@ -118,6 +126,19 @@ sub _run_validation {
     }
 
     return $self->_make_result( 1, [] );
+}
+
+sub _check_min_policy_version {
+    my ( $self, $tc, $min_policy_version, $reasons ) = @_;
+
+    return unless defined $min_policy_version;
+
+    my $actual = $tc->policy_version;
+    if ( $actual < $min_policy_version ) {
+        push @{$reasons},
+          "TC string policy version $actual is below required minimum $min_policy_version";
+    }
+    return;
 }
 
 sub _check_disclosed {

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -355,6 +355,45 @@ Identical to L</validate> but runs B<every> rule and accumulates all
 failures into the result. Use when you want a complete error report
 rather than the first failure.
 
+=head1 FUNCTIONS
+
+=head2 from_gvl_vendor_entry
+
+    my %args = GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry($vendor_entry);
+    my $validator = GDPR::IAB::TCFv2::Validator->new( %args, strict => 1 );
+
+Maps a parsed IAB Global Vendor List vendor-entry hashref to the constructor
+arguments L</new> expects. Field aliases:
+
+=over 4
+
+=item *
+
+C<id> ⟶ C<vendor_id>
+
+=item *
+
+C<purposes> ⟶ C<consent_purpose_ids>
+
+=item *
+
+C<legIntPurposes> ⟶ C<legitimate_interest_purpose_ids>
+
+=item *
+
+C<flexiblePurposes> ⟶ C<flexible_purpose_ids>
+
+=back
+
+Returns a list (key-value pairs), so callers can splat into the constructor
+alongside additional keys like C<strict> and C<check_disclosed_vendors>.
+Other fields on the vendor entry (C<name>, C<policyUrl>, etc.) are ignored —
+they aren't relevant to validation.
+
+C<croak>s only when C<id> is missing. Missing list fields default to empty
+arrayrefs, since the GVL schema permits a vendor to declare no
+legitimate-interest or flexible purposes.
+
 =head1 SEE ALSO
 
 L<GDPR::IAB::TCFv2::Validator::Result> for the result-object API,

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -88,12 +88,11 @@ sub _run_validation {
 sub _check_disclosed {
     my ( $self, $tc, $vendor_id, $check_disclosed, $reasons ) = @_;
 
-    if ($check_disclosed) {
-        if ( defined $tc->{disclosed_vendors_data} ) {
-            unless ( $tc->disclosed_vendor($vendor_id) ) {
-                push @{$reasons}, "vendor $vendor_id not disclosed";
-            }
-        }
+    return unless $check_disclosed;
+    return unless $tc->has_vendor_disclosure;
+
+    unless ( $tc->disclosed_vendor($vendor_id) ) {
+        push @{$reasons}, "vendor $vendor_id not disclosed";
     }
     return;
 }
@@ -173,3 +172,154 @@ sub _make_result {
 }
 
 1;
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+GDPR::IAB::TCFv2::Validator - declarative compliance checks for TC strings
+
+=head1 SYNOPSIS
+
+    use GDPR::IAB::TCFv2::Validator;
+
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id                       => 284,
+        consent_purpose_ids             => [ 1, 3, 9 ],
+        legitimate_interest_purpose_ids => [ 10 ],
+        flexible_purpose_ids            => [
+            { purpose_id => 2, default_is_li => 1 },
+        ],
+        check_disclosed_vendors         => 1,
+    );
+
+    # Fail-fast: stops at the first failing rule.
+    my $result = $validator->validate($tc_string);
+
+    # Accumulate every failure for richer error reporting.
+    my $result = $validator->validate_all($tc_string);
+
+    if ($result) {
+        # All rules passed.
+    }
+    else {
+        warn "Compliance failed:\n$result\n";  # stringification = reasons
+        for my $reason ( $result->reasons ) {
+            log_failure($reason);
+        }
+    }
+
+=head1 DESCRIPTION
+
+C<GDPR::IAB::TCFv2::Validator> is a small rule engine that turns a static
+"compliance policy" — required purposes, expected vendor, optional
+disclosed-vendors check — into a single C<validate> / C<validate_all>
+call against a TC string (or a pre-parsed L<GDPR::IAB::TCFv2> object).
+
+Each rule produces a human-readable B<reason> on failure; reasons are
+collected on a L<GDPR::IAB::TCFv2::Validator::Result> object that
+overloads boolean and string contexts so it drops into typical
+error-handling idioms (C<if (!$result)>, C<print "$result\n">) without
+ceremony.
+
+=head1 CONSTRUCTOR
+
+=head2 new
+
+    my $v = GDPR::IAB::TCFv2::Validator->new( %args );
+
+Recognized keys:
+
+=over 4
+
+=item *
+
+C<vendor_id> — the vendor whose access is being validated. Optional in
+the constructor (can be supplied per call via C<< validate(..., vendor_id
+=> N) >>) but B<one of the two> must be set or C<validate>/C<validate_all>
+will C<croak> with C<"missing vendor_id">.
+
+=item *
+
+C<consent_purpose_ids> — arrayref of purpose IDs that B<must> have
+vendor consent. Validated via L<GDPR::IAB::TCFv2/is_vendor_consent_allowed>.
+
+=item *
+
+C<legitimate_interest_purpose_ids> — arrayref of purpose IDs that B<must>
+have vendor legitimate-interest. Validated via
+L<GDPR::IAB::TCFv2/is_vendor_legitimate_interest_allowed>. The IAB spec
+forbids LI for Purpose 1 always, and for Purposes 3-6 in TCF v2.2+;
+those are enforced by the underlying parser and surface here as failures.
+
+=item *
+
+C<flexible_purpose_ids> — arrayref of either:
+
+=over 8
+
+=item *
+
+a plain integer (purpose ID, default legal basis = consent), or
+
+=item *
+
+a hashref C<< { purpose_id => N, default_is_li => 0|1 } >> for explicit
+control over the default legal basis.
+
+=back
+
+Validated via L<GDPR::IAB::TCFv2/is_vendor_allowed_for_flexible_purpose>.
+
+=item *
+
+C<check_disclosed_vendors> — boolean. When true B<and> the TC string
+carries a Disclosed Vendors segment, the vendor must appear there or
+the rule fails with C<"vendor N not disclosed">. If the segment is
+absent the check is silently skipped — set the parser's C<strict>
+mode at parse time if you need to require the segment's presence.
+
+=item *
+
+C<strict> — boolean. Passed through to the underlying
+C<is_vendor_*_allowed> calls so invalid purpose IDs cause C<croak>
+instead of a silent failure.
+
+=back
+
+=head1 METHODS
+
+=head2 validate
+
+    my $result = $validator->validate( $tc_string_or_object, %overrides );
+
+Runs the configured rules against C<$tc_string_or_object>. Stops at
+the first failing rule (B<fail-fast> mode) and returns a
+L<GDPR::IAB::TCFv2::Validator::Result> carrying that one reason.
+
+C<%overrides> can replace the constructor values for C<vendor_id>,
+C<strict>, and C<check_disclosed_vendors> for this call only. The
+arrayref rules (C<consent_purpose_ids> etc.) are not currently
+overridable per call.
+
+C<$tc_string_or_object> may be either a raw consent string or a
+pre-parsed L<GDPR::IAB::TCFv2> object — handy when the same TC string
+is being validated against multiple policies.
+
+=head2 validate_all
+
+Identical to L</validate> but runs B<every> rule and accumulates all
+failures into the result. Use when you want a complete error report
+rather than the first failure.
+
+=head1 SEE ALSO
+
+L<GDPR::IAB::TCFv2::Validator::Result> for the result-object API,
+including the C<bool> / C<""> overloads and the C<$\>-aware
+stringification.
+
+L<GDPR::IAB::TCFv2> for the underlying parser and the
+C<is_vendor_*_allowed> family of methods this validator is built on.
+
+=cut

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -51,20 +51,6 @@ sub _check_coherence {
     return;
 }
 
-sub from_gvl_vendor_entry {
-    my ($entry) = @_;
-
-    croak "from_gvl_vendor_entry: missing 'id' in vendor entry"
-      unless defined $entry->{id};
-
-    return (
-        vendor_id                       => $entry->{id},
-        consent_purpose_ids             => $entry->{purposes}         || [],
-        legitimate_interest_purpose_ids => $entry->{legIntPurposes}   || [],
-        flexible_purpose_ids            => $entry->{flexiblePurposes} || [],
-    );
-}
-
 sub validate {
     my ( $self, $input, %overrides ) = @_;
 
@@ -230,12 +216,6 @@ GDPR::IAB::TCFv2::Validator - declarative compliance checks for TC strings
         check_disclosed_vendors         => 1,
     );
 
-    # Or, from a parsed IAB GVL vendor entry:
-    my $validator = GDPR::IAB::TCFv2::Validator->new(
-        GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry($vendor_entry),
-        check_disclosed_vendors => 1,
-    );
-
     # Fail-fast: stops at the first failing rule.
     my $result = $validator->validate($tc_string);
 
@@ -360,45 +340,6 @@ is being validated against multiple policies.
 Identical to L</validate> but runs B<every> rule and accumulates all
 failures into the result. Use when you want a complete error report
 rather than the first failure.
-
-=head1 FUNCTIONS
-
-=head2 from_gvl_vendor_entry
-
-    my %args = GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry($vendor_entry);
-    my $validator = GDPR::IAB::TCFv2::Validator->new( %args, strict => 1 );
-
-Maps a parsed IAB Global Vendor List vendor-entry hashref to the constructor
-arguments L</new> expects. Field aliases:
-
-=over 4
-
-=item *
-
-C<id> ⟶ C<vendor_id>
-
-=item *
-
-C<purposes> ⟶ C<consent_purpose_ids>
-
-=item *
-
-C<legIntPurposes> ⟶ C<legitimate_interest_purpose_ids>
-
-=item *
-
-C<flexiblePurposes> ⟶ C<flexible_purpose_ids>
-
-=back
-
-Returns a list (key-value pairs), so callers can splat into the constructor
-alongside additional keys like C<strict> and C<check_disclosed_vendors>.
-Other fields on the vendor entry (C<name>, C<policyUrl>, etc.) are ignored —
-they aren't relevant to validation.
-
-C<croak>s only when C<id> is missing. Missing list fields default to empty
-arrayrefs, since the GVL schema permits a vendor to declare no
-legitimate-interest or flexible purposes.
 
 =head1 SEE ALSO
 

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -14,6 +14,8 @@ sub new {
     my $legitimate_interest = $args{legitimate_interest_purpose_ids} || [];
     my $flexible            = $args{flexible_purpose_ids}            || [];
 
+    _check_coherence( $consent, $legitimate_interest, $flexible );
+
     my $self = {
         vendor_id                       => $args{vendor_id},
         consent_purpose_ids             => $consent,
@@ -25,6 +27,27 @@ sub new {
     };
 
     return bless $self, $klass;
+}
+
+sub _check_coherence {
+    my ( $consent, $legitimate_interest, $flexible ) = @_;
+
+    my %consent_set = map { $_ => 1 } @{$consent};
+    my %li_set      = map { $_ => 1 } @{$legitimate_interest};
+
+    foreach my $pid ( @{$consent} ) {
+        croak
+          "purpose $pid cannot be in both consent_purpose_ids and legitimate_interest_purpose_ids"
+          if $li_set{$pid};
+    }
+
+    foreach my $pid ( @{$flexible} ) {
+        next if $consent_set{$pid} || $li_set{$pid};
+        croak
+          "flexible purpose $pid must also appear in consent_purpose_ids or legitimate_interest_purpose_ids";
+    }
+
+    return;
 }
 
 sub validate {

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -50,6 +50,20 @@ sub _check_coherence {
     return;
 }
 
+sub from_gvl_vendor_entry {
+    my ($entry) = @_;
+
+    croak "from_gvl_vendor_entry: missing 'id' in vendor entry"
+      unless defined $entry->{id};
+
+    return (
+        vendor_id                       => $entry->{id},
+        consent_purpose_ids             => $entry->{purposes}         || [],
+        legitimate_interest_purpose_ids => $entry->{legIntPurposes}   || [],
+        flexible_purpose_ids            => $entry->{flexiblePurposes} || [],
+    );
+}
+
 sub validate {
     my ( $self, $input, %overrides ) = @_;
 

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -10,14 +10,18 @@ use GDPR::IAB::TCFv2::Validator::Result;
 sub new {
     my ( $klass, %args ) = @_;
 
+    my $consent             = $args{consent_purpose_ids}             || [];
+    my $legitimate_interest = $args{legitimate_interest_purpose_ids} || [];
+    my $flexible            = $args{flexible_purpose_ids}            || [];
+
     my $self = {
         vendor_id                       => $args{vendor_id},
-        consent_purpose_ids             => $args{consent_purpose_ids} || [],
-        legitimate_interest_purpose_ids =>
-          $args{legitimate_interest_purpose_ids} || [],
-        flexible_purpose_ids    => $args{flexible_purpose_ids}    || [],
-        check_disclosed_vendors => $args{check_disclosed_vendors} || 0,
-        strict                  => exists $args{strict} ? $args{strict} : 0,
+        consent_purpose_ids             => $consent,
+        legitimate_interest_purpose_ids => $legitimate_interest,
+        flexible_purpose_ids            => $flexible,
+        _flexible_set                   => { map { $_ => 1 } @{$flexible} },
+        check_disclosed_vendors         => $args{check_disclosed_vendors} || 0,
+        strict => exists $args{strict} ? $args{strict} : 0,
     };
 
     return bless $self, $klass;
@@ -71,12 +75,6 @@ sub _run_validation {
         $tc, $vendor_id, $strict, \@reasons,
         $stop_on_first
     );
-    return $self->_make_result( 0, \@reasons ) if $stop_on_first && @reasons;
-
-    $self->_check_flexible_purposes(
-        $tc, $vendor_id, $strict, \@reasons,
-        $stop_on_first
-    );
 
     if (@reasons) {
         return $self->_make_result( 0, \@reasons );
@@ -101,12 +99,17 @@ sub _check_consent_purposes {
     my ( $self, $tc, $vendor_id, $strict, $reasons, $stop_on_first ) = @_;
 
     foreach my $pid ( @{ $self->{consent_purpose_ids} } ) {
-        unless (
-            $tc->is_vendor_consent_allowed(
-                $vendor_id, $pid, strict => $strict
-            )
+        my $allowed = $self->{_flexible_set}->{$pid}
+          ? $tc->is_vendor_allowed_for_flexible_purpose(
+            $vendor_id, $pid, 0,
+            strict => $strict
           )
-        {
+          : $tc->is_vendor_consent_allowed(
+            $vendor_id, $pid,
+            strict => $strict
+          );
+
+        unless ($allowed) {
             push @{$reasons},
               "vendor $vendor_id not allowed for purpose $pid (consent)";
             return if $stop_on_first;
@@ -119,42 +122,19 @@ sub _check_li_purposes {
     my ( $self, $tc, $vendor_id, $strict, $reasons, $stop_on_first ) = @_;
 
     foreach my $pid ( @{ $self->{legitimate_interest_purpose_ids} } ) {
-        unless (
-            $tc->is_vendor_legitimate_interest_allowed(
-                $vendor_id, $pid, strict => $strict
-            )
+        my $allowed = $self->{_flexible_set}->{$pid}
+          ? $tc->is_vendor_allowed_for_flexible_purpose(
+            $vendor_id, $pid, 1,
+            strict => $strict
           )
-        {
+          : $tc->is_vendor_legitimate_interest_allowed(
+            $vendor_id, $pid,
+            strict => $strict
+          );
+
+        unless ($allowed) {
             push @{$reasons},
               "vendor $vendor_id not allowed for purpose $pid (legitimate interest)";
-            return if $stop_on_first;
-        }
-    }
-    return;
-}
-
-sub _check_flexible_purposes {
-    my ( $self, $tc, $vendor_id, $strict, $reasons, $stop_on_first ) = @_;
-
-    foreach my $flex ( @{ $self->{flexible_purpose_ids} } ) {
-        my ( $pid, $default_is_li );
-        if ( ref($flex) eq 'HASH' ) {
-            $pid           = $flex->{purpose_id};
-            $default_is_li = $flex->{default_is_li};
-        }
-        else {
-            $pid           = $flex;
-            $default_is_li = 0;
-        }
-
-        unless (
-            $tc->is_vendor_allowed_for_flexible_purpose(
-                $vendor_id, $pid, $default_is_li, strict => $strict
-            )
-          )
-        {
-            push @{$reasons},
-              "vendor $vendor_id not allowed for flexible purpose $pid";
             return if $stop_on_first;
         }
     }

--- a/lib/GDPR/IAB/TCFv2/Validator/Result.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Result.pm
@@ -33,3 +33,92 @@ sub reasons {
 }
 
 1;
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+GDPR::IAB::TCFv2::Validator::Result - outcome object returned by L<GDPR::IAB::TCFv2::Validator>
+
+=head1 SYNOPSIS
+
+    my $result = $validator->validate($tc_string);
+
+    if ($result) {
+        # Validation passed.
+    }
+    else {
+        warn "$result\n";                 # one reason per line by default
+        for my $reason ( $result->reasons ) { ... }
+    }
+
+    # Use Perl's output record separator to control how reasons join:
+    {
+        local $\ = " | ";
+        print "$result";                  # "reason1 | reason2"
+    }
+
+=head1 DESCRIPTION
+
+A small immutable carrier for the outcome of a
+L<GDPR::IAB::TCFv2::Validator/validate> or
+L<GDPR::IAB::TCFv2::Validator/validate_all> run. It
+overloads boolean and string contexts so it drops into typical
+error-handling idioms without an explicit accessor call.
+
+=head1 OVERLOADS
+
+=head2 Boolean
+
+    if ($result) { ... }
+    if (!$result) { ... }
+
+True when validation passed (no rules failed); false otherwise.
+
+=head2 Stringification
+
+    print "$result\n";
+
+Returns the empty string for a passing result. For a failing result,
+returns the failure reasons joined by Perl's output record separator
+(C<$\>); if C<$\> is undefined, reasons are joined by C<"\n">.
+
+This means:
+
+    print "$result\n";              # one reason per line
+    local $\ = " | ";
+    print "$result\n";              # "reason1 | reason2"
+
+aligns naturally with the way C<print> would have laid out the reasons
+if you had iterated and printed them yourself.
+
+=head1 METHODS
+
+=head2 is_valid
+
+    my $ok = $result->is_valid;
+
+Returns truthy for a passing result, falsy otherwise. Equivalent to the
+boolean overload but available as an explicit method for callers that
+prefer it.
+
+=head2 reasons
+
+    my @reasons = $result->reasons;
+
+Returns the list of human-readable failure reasons. Empty for a passing
+result.
+
+=head1 CONSTRUCTOR
+
+=head2 new
+
+Internal — construct via L<GDPR::IAB::TCFv2::Validator/validate> rather
+than directly.
+
+=head1 SEE ALSO
+
+L<GDPR::IAB::TCFv2::Validator>.
+
+=cut

--- a/lib/GDPR/IAB/TCFv2/Validator/Result.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Result.pm
@@ -1,0 +1,35 @@
+package GDPR::IAB::TCFv2::Validator::Result;
+
+use strict;
+use warnings;
+
+use overload
+  bool => sub { $_[0]->{ok} },
+  '""' => sub {
+    my $self = shift;
+    return '' if $self->{ok};
+
+    # Use $ORS (Output Record Separator) or newline as fallback
+    my $sep = defined($\) ? $\ : "\n";
+    return join( $sep, @{ $self->{reasons} || [] } );
+  };
+
+sub new {
+    my ( $klass, %args ) = @_;
+
+    my $self = {
+        ok      => $args{ok}      || 0,
+        reasons => $args{reasons} || [],
+    };
+
+    return bless $self, $klass;
+}
+
+sub is_valid { $_[0]->{ok} }
+
+sub reasons {
+    my $self = shift;
+    return @{ $self->{reasons} || [] };
+}
+
+1;

--- a/t/06-validator.t
+++ b/t/06-validator.t
@@ -325,4 +325,54 @@ subtest "Validator validate_all accumulates across rule families" => sub {
       'flexible P6 with default consent reports as a consent failure';
 };
 
+subtest "from_gvl_vendor_entry maps GVL JSON to constructor args" => sub {
+    my $entry = {
+        id               => 284,
+        name             => 'Weborama',    # ignored
+        purposes         => [ 1, 3, 4, 5, 6 ],
+        legIntPurposes   => [ 2, 7, 8, 9, 10, 11 ],
+        flexiblePurposes => [ 2, 7, 8, 9, 10, 11 ],
+    };
+
+    my %args = GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry($entry);
+
+    is $args{vendor_id}, 284, 'vendor_id maps from id';
+    is_deeply $args{consent_purpose_ids},
+      [ 1, 3, 4, 5, 6 ],
+      'consent_purpose_ids maps from purposes';
+    is_deeply $args{legitimate_interest_purpose_ids},
+      [ 2, 7, 8, 9, 10, 11 ],
+      'legitimate_interest_purpose_ids maps from legIntPurposes';
+    is_deeply $args{flexible_purpose_ids},
+      [ 2, 7, 8, 9, 10, 11 ],
+      'flexible_purpose_ids maps from flexiblePurposes';
+
+    # Returned args splat into the constructor cleanly, mixed with extras.
+    my $v = GDPR::IAB::TCFv2::Validator->new( %args, strict => 1 );
+    isa_ok $v, 'GDPR::IAB::TCFv2::Validator';
+
+    # Croak on missing id
+    throws_ok {
+        GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry(
+            {   purposes         => [],
+                legIntPurposes   => [],
+                flexiblePurposes => [],
+            }
+        );
+    }
+    qr/from_gvl_vendor_entry: missing 'id'/,
+      'croaks on a vendor entry missing the id field';
+
+    # Missing list fields default to empty arrayrefs (a vendor with no
+    # legIntPurposes is valid in the GVL schema).
+    my %sparse =
+      GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry( { id => 1 } );
+    is_deeply $sparse{consent_purpose_ids}, [],
+      'missing purposes defaults to empty arrayref';
+    is_deeply $sparse{legitimate_interest_purpose_ids}, [],
+      'missing legIntPurposes defaults to empty arrayref';
+    is_deeply $sparse{flexible_purpose_ids}, [],
+      'missing flexiblePurposes defaults to empty arrayref';
+};
+
 done_testing;

--- a/t/06-validator.t
+++ b/t/06-validator.t
@@ -3,7 +3,9 @@ use warnings;
 
 use Test::More;
 use Test::Exception;
+use Test::Warn;
 
+use GDPR::IAB::TCFv2;
 use GDPR::IAB::TCFv2::Validator;
 use GDPR::IAB::TCFv2::Constants::Purpose qw<:all>;
 
@@ -48,7 +50,7 @@ subtest "Validator failures" => sub {
 
         {
             local $\ = " | ";
-            like "$result", qr/purpose 1.* | .*purpose 7/,
+            like "$result", qr/purpose 1.*\Q | \E.*purpose 7/,
               'should join reasons with ORS';
         }
     };
@@ -81,6 +83,144 @@ subtest "Validator with Disclosed Vendors" => sub {
     my $result = $validator->validate( $tc_v23, vendor_id => 9999 );
     ok !$result, 'fail for non-disclosed vendor 9999';
     like "$result", qr/not disclosed/, 'correct failure reason';
+};
+
+subtest "Validator accepts a pre-parsed GDPR::IAB::TCFv2 object" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+    my $consent   = GDPR::IAB::TCFv2->Parse($tc_string);
+
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id           => 1,
+        consent_purpose_ids => [6],
+    );
+
+    my $result = $validator->validate($consent);
+    ok $result, 'passes when given a parsed consent object';
+    is $result->is_valid, 1, 'is_valid is 1 for the parsed-object input';
+};
+
+subtest "Validator without vendor_id" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        consent_purpose_ids => [6],
+    );
+
+    throws_ok { $validator->validate($tc_string) }
+    qr/missing vendor_id/,
+      'validate croaks when vendor_id is missing in both ctor and override';
+
+    ok $validator->validate( $tc_string, vendor_id => 1 ),
+      'override fills the missing vendor_id and validation proceeds';
+};
+
+subtest "Validator legitimate_interest_purpose_ids" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+
+    # Vendor 2 has LI for Purpose 2 in this fixture.
+    my $validator_pass = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id                       => 2,
+        legitimate_interest_purpose_ids => [2],
+    );
+    ok $validator_pass->validate($tc_string),
+      'pass for vendor 2 / LI purpose 2';
+
+    # Purpose 1 LI is forbidden by spec regardless of the bit, so this fails.
+    my $validator_fail = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id                       => 1,
+        legitimate_interest_purpose_ids => [1],
+    );
+    my $result = $validator_fail->validate($tc_string);
+    ok !$result,
+      'fail for purpose 1 LI (spec forbids LI for Purpose 1 always)';
+    like "$result", qr/purpose 1 \(legitimate interest\)/,
+      'reason names the LI rule type';
+};
+
+subtest "Validator flexible_purpose_ids - scalar form" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+
+    # Plain integer means default_is_li = 0 (consent default).
+    # P6/V1 has both consent and LI bits set, so passes either way.
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id            => 1,
+        flexible_purpose_ids => [6],
+    );
+    ok $validator->validate($tc_string),
+      'flexible P6 (default consent) passes for vendor 1';
+};
+
+subtest "Validator flexible_purpose_ids - hashref form" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+
+    # P2/V2 has consent=0 and LI=1, so default_is_li flips the outcome.
+    my $validator_consent_default = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id            => 2,
+        flexible_purpose_ids => [ { purpose_id => 2, default_is_li => 0 } ],
+    );
+    ok !$validator_consent_default->validate($tc_string),
+      'flexible P2/V2 with default_is_li=0 fails (no consent bit)';
+
+    my $validator_li_default = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id            => 2,
+        flexible_purpose_ids => [ { purpose_id => 2, default_is_li => 1 } ],
+    );
+    ok $validator_li_default->validate($tc_string),
+      'flexible P2/V2 with default_is_li=1 passes (LI bit is set)';
+};
+
+subtest "Validator strict mode override" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+
+    # Out-of-range purpose ID 25.
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id           => 1,
+        consent_purpose_ids => [25],
+    );
+
+    # Without strict (the default): the underlying parser warns and returns 0,
+    # so the validator reports a normal failure.  Use Test::Warn to swallow
+    # the warning while asserting on its content.
+    my $result;
+    warning_like {
+        $result = $validator->validate($tc_string);
+    }
+    qr/invalid purpose id 25/,
+      'underlying parser warns about the invalid id without strict';
+    ok !$result, 'invalid purpose id without strict yields a failed result';
+
+    # With strict=1: the underlying parser croaks, and that propagates up
+    # through the validator unchanged.
+    throws_ok {
+        $validator->validate( $tc_string, strict => 1 );
+    }
+    qr/invalid purpose id 25/,
+      'invalid purpose id with strict=1 propagates the parser croak';
+};
+
+subtest "Validator validate_all accumulates across rule families" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+
+  # Three failures, one per rule family:
+  #   - Consent rule: P1/V1 has consent bit = 0     -> "(consent)"
+  #   - LI rule:      P1 LI is spec-forbidden        -> "(legitimate interest)"
+  #   - Flexible:     P7/V1 has consent bit = 0     -> "flexible purpose 7"
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id                       => 1,
+        consent_purpose_ids             => [1],
+        legitimate_interest_purpose_ids => [1],
+        flexible_purpose_ids => [ { purpose_id => 7, default_is_li => 0 } ],
+    );
+
+    my $result = $validator->validate_all($tc_string);
+    ok !$result, 'all-fail validation reports failure';
+    is scalar( $result->reasons ), 3,
+      'one reason per rule family (3 total)';
+
+    my $joined = join '|', $result->reasons;
+    like $joined, qr/\(consent\)/,             'has the consent rule reason';
+    like $joined, qr/\(legitimate interest\)/, 'has the LI rule reason';
+    like $joined, qr/flexible purpose 7/,      'has the flexible rule reason';
 };
 
 done_testing;

--- a/t/06-validator.t
+++ b/t/06-validator.t
@@ -1,0 +1,86 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+
+use GDPR::IAB::TCFv2::Validator;
+use GDPR::IAB::TCFv2::Constants::Purpose qw<:all>;
+
+subtest "Validator basic usage" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id           => 1,
+        consent_purpose_ids => [6],    # Allowed
+    );
+
+    my $result = $validator->validate($tc_string);
+    ok $result, 'validation should pass';
+    is $result->is_valid, 1, 'is_valid should be 1';
+    is "$result", '', 'stringification should be empty for valid result';
+};
+
+subtest "Validator failures" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id           => 1,
+        consent_purpose_ids => [ 1, 6 ],    # 1 is missing consent bit, 6 is OK
+    );
+
+    subtest "validate (first failure)" => sub {
+        my $result = $validator->validate($tc_string);
+        ok !$result, 'validation should fail';
+        is scalar( $result->reasons ), 1, 'should have 1 reason';
+        like "$result", qr/not allowed for purpose 1/,
+          'should have correct reason';
+    };
+
+    subtest "validate_all (all failures)" => sub {
+        my $validator2 = GDPR::IAB::TCFv2::Validator->new(
+            vendor_id           => 1,
+            consent_purpose_ids => [ 1, 7 ],    # Both fail: P1=0, P7=0
+        );
+        my $result = $validator2->validate_all($tc_string);
+        ok !$result, 'validation should fail';
+        is scalar( $result->reasons ), 2, 'should have 2 reasons';
+
+        {
+            local $\ = " | ";
+            like "$result", qr/purpose 1.* | .*purpose 7/,
+              'should join reasons with ORS';
+        }
+    };
+};
+
+subtest "Validator overrides" => sub {
+    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id           => 1,
+        consent_purpose_ids => [6],
+    );
+
+    ok $validator->validate($tc_string), 'pass for vendor 1';
+    ok !$validator->validate( $tc_string, vendor_id => 99 ),
+      'fail for vendor 99 (missing bits)';
+};
+
+subtest "Validator with Disclosed Vendors" => sub {
+    my $tc_v23 =
+      'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA.ILrtR_G__bXlv-bb36ftkeYxf9_hr7sQxBgbJs24FzLvW7JwX32E7NEzatqYKmRIAu3TBIQNtHJjURVChKIgVrzDsaEyUoTtKJ-BkiHMRY2NYCFxvm4tjWQCZ5vr_91d9mT-N7dr-2dzyy7hnv3a9_-S1WJidKYetHfv8bBKT-_IU9_x-_4v4_N7pE2-eS1v_tGvt639-4vP_dpvxt-7yffz____73_e7X__d_______Xf_7____________4AAA';
+
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id               => 284,
+        check_disclosed_vendors => 1,
+    );
+
+    ok $validator->validate($tc_v23), 'pass for disclosed vendor 284';
+
+    my $result = $validator->validate( $tc_v23, vendor_id => 9999 );
+    ok !$result, 'fail for non-disclosed vendor 9999';
+    like "$result", qr/not disclosed/, 'correct failure reason';
+};
+
+done_testing;

--- a/t/06-validator.t
+++ b/t/06-validator.t
@@ -137,6 +137,65 @@ subtest "Validator legitimate_interest_purpose_ids" => sub {
       'reason names the LI rule type';
 };
 
+subtest "Validator min_policy_version" => sub {
+
+    # The 'COwAdDh...' fixture is policy_version 2 (TCF v2.0).
+    my $tc_v20 = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
+
+    # No min_policy_version set: no check, normal behaviour.
+    my $v_default = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id           => 1,
+        consent_purpose_ids => [6],
+    );
+    ok $v_default->validate($tc_v20),
+      'no min_policy_version set: passes for v2.0 string';
+
+    # min_policy_version satisfied (v2.0 string with min=2).
+    my $v_satisfied = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id           => 1,
+        consent_purpose_ids => [6],
+        min_policy_version  => 2,
+    );
+    ok $v_satisfied->validate($tc_v20),
+      'min_policy_version=2 passes for v2.0 string';
+
+    # min_policy_version not satisfied (v2.0 string with min=5).
+    my $v_too_old = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id           => 1,
+        consent_purpose_ids => [6],
+        min_policy_version  => 5,
+    );
+    my $result = $v_too_old->validate($tc_v20);
+    ok !$result, 'min_policy_version=5 fails for v2.0 string';
+    like "$result",
+      qr/TC string policy version 2 is below required minimum 5/,
+      'reason names the actual and required versions';
+
+    # In fail-fast mode, the version check must run FIRST and short-circuit.
+    # Even though consent_purpose_ids includes a deliberately-failing purpose,
+    # only one reason is reported -- the version mismatch.
+    my $v_short_circuit = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id           => 1,
+        consent_purpose_ids => [1],    # would also fail
+        min_policy_version  => 5,
+    );
+    my $r_first = $v_short_circuit->validate($tc_v20);
+    is scalar( $r_first->reasons ), 1,
+      'fail-fast stops after the version-check reason';
+    like "$r_first", qr/policy version/,
+      'first reason is the version-check failure';
+
+    # In --all mode, the version check still runs first but the other
+    # rules continue accumulating.
+    my $r_all = $v_short_circuit->validate_all($tc_v20);
+    is scalar( $r_all->reasons ), 2,
+      'validate_all accumulates version + consent failures';
+    like(
+        ( $r_all->reasons )[0],
+        qr/policy version/, 'version reason comes first'
+    );
+};
+
 subtest "Validator coherence checks at construction time" => sub {
 
     # A purpose can't be in both consent_purpose_ids and

--- a/t/06-validator.t
+++ b/t/06-validator.t
@@ -137,36 +137,39 @@ subtest "Validator legitimate_interest_purpose_ids" => sub {
       'reason names the LI rule type';
 };
 
-subtest "Validator flexible_purpose_ids - scalar form" => sub {
+subtest "flexible_purpose_ids derives default basis from membership" => sub {
     my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
 
-    # Plain integer means default_is_li = 0 (consent default).
-    # P6/V1 has both consent and LI bits set, so passes either way.
-    my $validator = GDPR::IAB::TCFv2::Validator->new(
+    # Vendor 1, Purpose 6: consent=1, LI=1.  P6 is in consent_purpose_ids
+    # AND flexible_purpose_ids -> flexible with default consent.  Passes.
+    my $v_consent_default = GDPR::IAB::TCFv2::Validator->new(
         vendor_id            => 1,
+        consent_purpose_ids  => [6],
         flexible_purpose_ids => [6],
     );
-    ok $validator->validate($tc_string),
-      'flexible P6 (default consent) passes for vendor 1';
-};
+    ok $v_consent_default->validate($tc_string),
+      'flexible P6 with default consent (because P6 is in consent_purpose_ids) passes';
 
-subtest "Validator flexible_purpose_ids - hashref form" => sub {
-    my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
-
-    # P2/V2 has consent=0 and LI=1, so default_is_li flips the outcome.
-    my $validator_consent_default = GDPR::IAB::TCFv2::Validator->new(
-        vendor_id            => 2,
-        flexible_purpose_ids => [ { purpose_id => 2, default_is_li => 0 } ],
+    # Vendor 2, Purpose 2: consent=0, LI=1.  P2 is in
+    # legitimate_interest_purpose_ids AND flexible_purpose_ids -> flexible
+    # with default LI.  Passes (LI bit is set).
+    my $v_li_default = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id                       => 2,
+        legitimate_interest_purpose_ids => [2],
+        flexible_purpose_ids            => [2],
     );
-    ok !$validator_consent_default->validate($tc_string),
-      'flexible P2/V2 with default_is_li=0 fails (no consent bit)';
+    ok $v_li_default->validate($tc_string),
+      'flexible P2 with default LI (because P2 is in legitimate_interest_purpose_ids) passes';
 
-    my $validator_li_default = GDPR::IAB::TCFv2::Validator->new(
+    # P2 in consent_purpose_ids AND flexible_purpose_ids -> default consent.
+    # Vendor 2 has consent=0 for P2 -> fails.
+    my $v_p2_consent_flex = GDPR::IAB::TCFv2::Validator->new(
         vendor_id            => 2,
-        flexible_purpose_ids => [ { purpose_id => 2, default_is_li => 1 } ],
+        consent_purpose_ids  => [2],
+        flexible_purpose_ids => [2],
     );
-    ok $validator_li_default->validate($tc_string),
-      'flexible P2/V2 with default_is_li=1 passes (LI bit is set)';
+    ok !$v_p2_consent_flex->validate($tc_string),
+      'flexible P2 with default consent fails for vendor 2 (no consent bit)';
 };
 
 subtest "Validator strict mode override" => sub {
@@ -201,26 +204,28 @@ subtest "Validator strict mode override" => sub {
 subtest "Validator validate_all accumulates across rule families" => sub {
     my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
 
-  # Three failures, one per rule family:
-  #   - Consent rule: P1/V1 has consent bit = 0     -> "(consent)"
-  #   - LI rule:      P1 LI is spec-forbidden        -> "(legitimate interest)"
-  #   - Flexible:     P7/V1 has consent bit = 0     -> "flexible purpose 7"
+    # Vendor 99 is out of range for this fixture's bitfields (max=10), so
+    # every rule fails uniformly.  Three rules, three reasons:
+    #   - Consent rule:  P1/V99 -> "(consent)"
+    #   - Consent rule:  P6/V99, via flexible default consent -> "(consent)"
+    #   - LI rule:       P10/V99 -> "(legitimate interest)"
     my $validator = GDPR::IAB::TCFv2::Validator->new(
-        vendor_id                       => 1,
-        consent_purpose_ids             => [1],
-        legitimate_interest_purpose_ids => [1],
-        flexible_purpose_ids => [ { purpose_id => 7, default_is_li => 0 } ],
+        vendor_id                       => 99,
+        consent_purpose_ids             => [ 1, 6 ],
+        legitimate_interest_purpose_ids => [10],
+        flexible_purpose_ids            => [6],
     );
 
     my $result = $validator->validate_all($tc_string);
     ok !$result, 'all-fail validation reports failure';
     is scalar( $result->reasons ), 3,
-      'one reason per rule family (3 total)';
+      'three reasons accumulated across consent + LI rules';
 
     my $joined = join '|', $result->reasons;
     like $joined, qr/\(consent\)/,             'has the consent rule reason';
     like $joined, qr/\(legitimate interest\)/, 'has the LI rule reason';
-    like $joined, qr/flexible purpose 7/,      'has the flexible rule reason';
+    like $joined, qr/purpose 6 \(consent\)/,
+      'flexible P6 with default consent reports as a consent failure';
 };
 
 done_testing;

--- a/t/06-validator.t
+++ b/t/06-validator.t
@@ -298,56 +298,6 @@ subtest "Validator strict mode override" => sub {
       'invalid purpose id with strict=1 propagates the parser croak';
 };
 
-subtest "from_gvl_vendor_entry maps GVL JSON to constructor args" => sub {
-    my $entry = {
-        id               => 284,
-        name             => 'Weborama',    # ignored
-        purposes         => [ 1, 3, 4, 5, 6 ],
-        legIntPurposes   => [ 2, 7, 8, 9, 10, 11 ],
-        flexiblePurposes => [ 2, 7, 8, 9, 10, 11 ],
-    };
-
-    my %args = GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry($entry);
-
-    is $args{vendor_id}, 284, 'vendor_id maps from id';
-    is_deeply $args{consent_purpose_ids},
-      [ 1, 3, 4, 5, 6 ],
-      'consent_purpose_ids maps from purposes';
-    is_deeply $args{legitimate_interest_purpose_ids},
-      [ 2, 7, 8, 9, 10, 11 ],
-      'legitimate_interest_purpose_ids maps from legIntPurposes';
-    is_deeply $args{flexible_purpose_ids},
-      [ 2, 7, 8, 9, 10, 11 ],
-      'flexible_purpose_ids maps from flexiblePurposes';
-
-    # Returned args splat into the constructor cleanly, mixed with extras.
-    my $v = GDPR::IAB::TCFv2::Validator->new( %args, strict => 1 );
-    isa_ok $v, 'GDPR::IAB::TCFv2::Validator';
-
-    # Croak on missing id
-    throws_ok {
-        GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry(
-            {   purposes         => [],
-                legIntPurposes   => [],
-                flexiblePurposes => [],
-            }
-        );
-    }
-    qr/from_gvl_vendor_entry: missing 'id'/,
-      'croaks on a vendor entry missing the id field';
-
-    # Missing list fields default to empty arrayrefs (a vendor with no
-    # legIntPurposes is valid in the GVL schema).
-    my %sparse =
-      GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry( { id => 1 } );
-    is_deeply $sparse{consent_purpose_ids}, [],
-      'missing purposes defaults to empty arrayref';
-    is_deeply $sparse{legitimate_interest_purpose_ids}, [],
-      'missing legIntPurposes defaults to empty arrayref';
-    is_deeply $sparse{flexible_purpose_ids}, [],
-      'missing flexiblePurposes defaults to empty arrayref';
-};
-
 subtest "Validator validate_all accumulates across rule families" => sub {
     my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
 

--- a/t/06-validator.t
+++ b/t/06-validator.t
@@ -137,6 +137,44 @@ subtest "Validator legitimate_interest_purpose_ids" => sub {
       'reason names the LI rule type';
 };
 
+subtest "Validator coherence checks at construction time" => sub {
+
+    # A purpose can't be in both consent_purpose_ids and
+    # legitimate_interest_purpose_ids — the GVL schema treats those as
+    # mutually exclusive declarations.
+    throws_ok {
+        GDPR::IAB::TCFv2::Validator->new(
+            vendor_id                       => 1,
+            consent_purpose_ids             => [3],
+            legitimate_interest_purpose_ids => [3],
+        );
+    }
+    qr/purpose 3 cannot be in both consent_purpose_ids and legitimate_interest_purpose_ids/,
+      'croaks when a purpose is listed under both bases';
+
+    # A flexible purpose must be listed under one of the two bases —
+    # otherwise no default can be derived.
+    throws_ok {
+        GDPR::IAB::TCFv2::Validator->new(
+            vendor_id            => 1,
+            flexible_purpose_ids => [5],
+        );
+    }
+    qr/flexible purpose 5 must also appear in consent_purpose_ids or legitimate_interest_purpose_ids/,
+      'croaks when a flexible purpose has no derivable default basis';
+
+    # Sanity: a properly-coherent config still constructs.
+    lives_ok {
+        GDPR::IAB::TCFv2::Validator->new(
+            vendor_id                       => 1,
+            consent_purpose_ids             => [ 1, 6 ],
+            legitimate_interest_purpose_ids => [ 2, 10 ],
+            flexible_purpose_ids            => [ 6, 2 ],
+        );
+    }
+    'coherent configuration constructs without error';
+};
+
 subtest "flexible_purpose_ids derives default basis from membership" => sub {
     my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
 

--- a/t/06-validator.t
+++ b/t/06-validator.t
@@ -239,6 +239,56 @@ subtest "Validator strict mode override" => sub {
       'invalid purpose id with strict=1 propagates the parser croak';
 };
 
+subtest "from_gvl_vendor_entry maps GVL JSON to constructor args" => sub {
+    my $entry = {
+        id               => 284,
+        name             => 'Weborama',    # ignored
+        purposes         => [ 1, 3, 4, 5, 6 ],
+        legIntPurposes   => [ 2, 7, 8, 9, 10, 11 ],
+        flexiblePurposes => [ 2, 7, 8, 9, 10, 11 ],
+    };
+
+    my %args = GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry($entry);
+
+    is $args{vendor_id}, 284, 'vendor_id maps from id';
+    is_deeply $args{consent_purpose_ids},
+      [ 1, 3, 4, 5, 6 ],
+      'consent_purpose_ids maps from purposes';
+    is_deeply $args{legitimate_interest_purpose_ids},
+      [ 2, 7, 8, 9, 10, 11 ],
+      'legitimate_interest_purpose_ids maps from legIntPurposes';
+    is_deeply $args{flexible_purpose_ids},
+      [ 2, 7, 8, 9, 10, 11 ],
+      'flexible_purpose_ids maps from flexiblePurposes';
+
+    # Returned args splat into the constructor cleanly, mixed with extras.
+    my $v = GDPR::IAB::TCFv2::Validator->new( %args, strict => 1 );
+    isa_ok $v, 'GDPR::IAB::TCFv2::Validator';
+
+    # Croak on missing id
+    throws_ok {
+        GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry(
+            {   purposes         => [],
+                legIntPurposes   => [],
+                flexiblePurposes => [],
+            }
+        );
+    }
+    qr/from_gvl_vendor_entry: missing 'id'/,
+      'croaks on a vendor entry missing the id field';
+
+    # Missing list fields default to empty arrayrefs (a vendor with no
+    # legIntPurposes is valid in the GVL schema).
+    my %sparse =
+      GDPR::IAB::TCFv2::Validator::from_gvl_vendor_entry( { id => 1 } );
+    is_deeply $sparse{consent_purpose_ids}, [],
+      'missing purposes defaults to empty arrayref';
+    is_deeply $sparse{legitimate_interest_purpose_ids}, [],
+      'missing legIntPurposes defaults to empty arrayref';
+    is_deeply $sparse{flexible_purpose_ids}, [],
+      'missing flexiblePurposes defaults to empty arrayref';
+};
+
 subtest "Validator validate_all accumulates across rule families" => sub {
     my $tc_string = 'COwAdDhOwAdDhN4ABAENAPCgAAQAAv___wAAAFP_AAp_4AI6ACACAA';
 

--- a/t/09-predicates.t
+++ b/t/09-predicates.t
@@ -121,10 +121,9 @@ subtest 'CLI --strict option' => sub {
     my $out_lenient = `$perl -Ilib $bin dump $tc_v23_no_dv`;
     like( $out_lenient, qr/"tc_string":/i, 'Lenient mode (default) succeeds' );
 
-    # --quiet suppresses the application-level "Warning: Failed to parse..."
-    # so GitHub Actions doesn't promote it to a workflow annotation.  The
+    # Warnings are off by default (Path D), so no need to silence them.  The
     # error JSON is still emitted to stdout, which is what we assert on.
-    my $out_strict = `$perl -Ilib $bin dump --strict --quiet $tc_v23_no_dv`;
+    my $out_strict = `$perl -Ilib $bin dump --strict $tc_v23_no_dv`;
     like(
         $out_strict,
         qr/Disclosed Vendors segment is mandatory/,

--- a/t/10-cli-iabtcfv2.t
+++ b/t/10-cli-iabtcfv2.t
@@ -96,7 +96,7 @@ ok( $? != 0, "--fail-fast exits with non-zero code" );
 # Use a temporary file to capture stderr safely
 my $stderr_file = File::Spec->catfile( File::Spec->tmpdir(), "tcf_stderr_$$" );
 my $e2s_stdout =
-  `$perl -Ilib $bin dump --quiet --errors-to-stderr $invalid_str 2>$stderr_file`;
+  `$perl -Ilib $bin dump --errors-to-stderr $invalid_str 2>$stderr_file`;
 
 is( $e2s_stdout, "", "--errors-to-stderr stdout is empty for bad string" );
 
@@ -153,15 +153,16 @@ subtest 'Version Option' => sub {
 # Test Short Option Bundling and = syntax
 subtest 'Short option bundling and = value syntax' => sub {
 
-    # Bundled boolean flags: -pq is parsed as --pretty --quiet.
+    # Bundled boolean flags: -pi is parsed as --pretty --ignore-errors.
     # `--pretty` produces multi-line indented JSON, which is the easiest
-    # observable side effect to assert on.
-    my $bundled_flags_out  = `$perl -Ilib $bin dump -pq $tc_string`;
+    # observable side effect to assert on; -i is a no-op for a valid TC
+    # string (no parse error to ignore).
+    my $bundled_flags_out  = `$perl -Ilib $bin dump -pi $tc_string`;
     my $bundled_flags_data = decode_helper($bundled_flags_out);
-    ok( $bundled_flags_data, '-pq produces valid JSON' );
+    ok( $bundled_flags_data, '-pi produces valid JSON' );
     like(
         $bundled_flags_out, qr/\n\s+"/,
-        '-pq enables --pretty (multi-line output)'
+        '-pi enables --pretty (multi-line output)'
     );
 
     # Bundled flag + value-taking short: -pv 1 is --pretty --vendor-id 1.
@@ -203,11 +204,12 @@ subtest 'Short aliases -c (compact) and -s (strict)' => sub {
 
     # -s == --strict: a TCF v2.3 string without Disclosed Vendors segment
     # must be rejected with the standard "Disclosed Vendors segment is
-    # mandatory" message.  --quiet keeps the warn off CI.
+    # mandatory" message.  Warnings are off by default (Path D), so no
+    # extra flag needed to keep CI clean.
     my $tc_v23_no_dv =
       'CP188cAQKFpAAAHABBENBSFsAP_gAEPgAAiQKqNX_H__bW9r8X73aft0eY1P9_j77uQxBhfJE-4FzLvW_JwXx2ExNA36tqIKmRIEu3bBIQNlHJHUTVigaogVryHMak2cpTNKJ6BkiFMRM2dYCF5vm4tj-QKY5_r993dx2D-t_dv83dzyz81Hn3f5_2e0eLCdQ5-tDfv9bROb-9IPd_78v4v8_l_rk2_eT1n_tevr7D_-ft8__XW_9_fff_9Pn_-uB_-_3_vf_EFUwCTDQqIA-wJCQg0DCKBACoKwgIoFAQAAJA0QEAJgwKdgYALrCRACAFAAMEAIAAQZAAgAAAgAQiACQAoEAAEAgUAAYAEAwEABAwAAgAsBAIAAQHQMUwIIFAsIEjMioUwIQoEggJbKhBICgQVwhCLPAIgERMFAAgAAAVgACAsFgcSSAlQkECXUG0AABAAgFEIFQgk9MAAwJmy1B4MG0ZWmAYPmCRDTAMgCIIyEAAAA';
 
-    my $s_out = `$perl -Ilib $bin dump -s --quiet $tc_v23_no_dv`;
+    my $s_out = `$perl -Ilib $bin dump -s $tc_v23_no_dv`;
     like(
         $s_out, qr/Disclosed Vendors segment is mandatory/,
         '-s enables --strict (rejects v2.3 without Disclosed Vendors)'

--- a/t/10-cli-iabtcfv2.t
+++ b/t/10-cli-iabtcfv2.t
@@ -226,4 +226,109 @@ subtest 'Short aliases -c (compact) and -s (strict)' => sub {
     );
 };
 
+subtest 'validate subcommand' => sub {
+
+    # The fixture TC string was produced for vendor 32 (it appears in the
+    # vendor consents).  Asking the validator to OK vendor 32 with no
+    # required purposes should always succeed; asking it to OK an
+    # out-of-range vendor (99999) for any required purpose always fails,
+    # which gives stable assertions independent of the GVL contents.
+
+    my $valid_out = `$perl -Ilib $bin validate -v 32 $tc_string`;
+    my $valid_data = decode_helper($valid_out);
+    ok( $valid_data, 'validate emits JSON' );
+    is( $valid_data->{valid}, JSON->can('true') ? JSON->true() : JSON::PP::true(),
+        'valid case has valid:true'
+    );
+    is( $valid_data->{vendor_id}, 32, 'valid case echoes vendor_id' );
+
+    # Failure (singular reason, fail-fast default).
+    my $fail_out  = `$perl -Ilib $bin validate -v 99999 -C 1,2 $tc_string`;
+    my $fail_code = $? >> 8;
+    my $fail_data = decode_helper($fail_out);
+    ok( $fail_data, 'failing validate emits JSON' );
+    is( $fail_data->{valid}, $json_false, 'failing case has valid:false' );
+    ok( exists $fail_data->{reason}, 'fail-fast uses singular reason' );
+    ok( !exists $fail_data->{reasons}, 'fail-fast does not emit reasons array' );
+    is( $fail_code, 1, 'failing validate exits 1' );
+
+    # --all aggregates reasons.
+    my $all_out  = `$perl -Ilib $bin validate -av 99999 -C 1,2 -L 7,8 $tc_string`;
+    my $all_data = decode_helper($all_out);
+    ok( exists $all_data->{reasons}, '--all uses plural reasons array' );
+    ok( !exists $all_data->{reason}, '--all does not emit singular reason' );
+    is( ref $all_data->{reasons}, 'ARRAY', 'reasons is an array' );
+    cmp_ok( scalar @{ $all_data->{reasons} }, '>=', 2,
+        '--all aggregates multiple failures'
+    );
+
+    # --text output paths (success and failure).
+    my $text_ok = `$perl -Ilib $bin validate -tv 32 $tc_string`;
+    like( $text_ok, qr/^OK\s+\S+\s+vendor 32/, '--text valid line shape' );
+
+    my $text_fail = `$perl -Ilib $bin validate -tv 99999 -C 1 $tc_string`;
+    like(
+        $text_fail, qr/^FAIL\s+\S+\s+vendor 99999:/,
+        '--text fail line shape'
+    );
+
+    my $text_all = `$perl -Ilib $bin validate -atv 99999 -C 1,2 $tc_string`;
+    my @text_lines = split /\n/, $text_all;
+    cmp_ok( scalar @text_lines, '>=', 2,
+        '--text --all spans multiple lines'
+    );
+    like(
+        $text_lines[0], qr/^FAIL\s+\S+\s+vendor 99999:$/,
+        '--text --all first line ends with colon'
+    );
+    like(
+        $text_lines[1], qr/^\s+-\s/,
+        '--text --all subsequent lines are indented bullets'
+    );
+
+    # --quiet preserves exit code, suppresses stdout.
+    my $quiet_ok = `$perl -Ilib $bin validate -qv 32 $tc_string`;
+    is( $quiet_ok, '', '--quiet on success emits nothing' );
+    is( $? >> 8,   0,  '--quiet on success exits 0' );
+
+    my $quiet_fail = `$perl -Ilib $bin validate -qv 99999 -C 1 $tc_string`;
+    is( $quiet_fail, '', '--quiet on failure emits nothing' );
+    is( $? >> 8,     1,  '--quiet on failure still exits 1' );
+
+    # Missing --vendor-id: exit 2 with diagnostic on STDERR.
+    my $missing_v_stderr = File::Spec->catfile( File::Spec->tmpdir(),
+        "tcf_missing_v_$$" );
+    my $missing_v_stdout =
+      `$perl -Ilib $bin validate $tc_string 2>$missing_v_stderr`;
+    is( $? >> 8, 2, 'missing --vendor-id exits 2' );
+    my $missing_v_msg = "";
+    if ( -f $missing_v_stderr ) {
+        open my $fh, '<', $missing_v_stderr;
+        $missing_v_msg = join '', <$fh>;
+        close $fh;
+        unlink $missing_v_stderr;
+    }
+    like(
+        $missing_v_msg, qr/--vendor-id\|-v is required/,
+        'missing --vendor-id explains itself on STDERR'
+    );
+
+    # Parse error path.
+    my $parse_err_out =
+      `$perl -Ilib $bin validate -v 32 INVALID_STRING 2>$devnull`;
+    my $parse_err_code = $? >> 8;
+    my $parse_err_data = decode_helper($parse_err_out);
+    ok( $parse_err_data, 'parse error emits JSON' );
+    is( $parse_err_data->{success}, $json_false,
+        'parse error has success:false'
+    );
+    is( $parse_err_code, 1, 'parse error exits 1' );
+
+    # --ignore-errors silences the parse error JSON but keeps exit code.
+    my $ignore_out =
+      `$perl -Ilib $bin validate -iv 32 INVALID_STRING 2>$devnull`;
+    is( $ignore_out, '', '--ignore-errors silences parse error JSON' );
+    is( $? >> 8,     1,  '--ignore-errors still exits 1' );
+};
+
 done_testing();

--- a/t/10-cli-iabtcfv2.t
+++ b/t/10-cli-iabtcfv2.t
@@ -234,10 +234,11 @@ subtest 'validate subcommand' => sub {
     # out-of-range vendor (99999) for any required purpose always fails,
     # which gives stable assertions independent of the GVL contents.
 
-    my $valid_out = `$perl -Ilib $bin validate -v 32 $tc_string`;
+    my $valid_out  = `$perl -Ilib $bin validate -v 32 $tc_string`;
     my $valid_data = decode_helper($valid_out);
     ok( $valid_data, 'validate emits JSON' );
-    is( $valid_data->{valid}, JSON->can('true') ? JSON->true() : JSON::PP::true(),
+    is( $valid_data->{valid},
+        JSON->can('true') ? JSON->true() : JSON::PP::true(),
         'valid case has valid:true'
     );
     is( $valid_data->{vendor_id}, 32, 'valid case echoes vendor_id' );
@@ -249,16 +250,20 @@ subtest 'validate subcommand' => sub {
     ok( $fail_data, 'failing validate emits JSON' );
     is( $fail_data->{valid}, $json_false, 'failing case has valid:false' );
     ok( exists $fail_data->{reason}, 'fail-fast uses singular reason' );
-    ok( !exists $fail_data->{reasons}, 'fail-fast does not emit reasons array' );
+    ok( !exists $fail_data->{reasons},
+        'fail-fast does not emit reasons array'
+    );
     is( $fail_code, 1, 'failing validate exits 1' );
 
     # --all aggregates reasons.
-    my $all_out  = `$perl -Ilib $bin validate -av 99999 -C 1,2 -L 7,8 $tc_string`;
+    my $all_out =
+      `$perl -Ilib $bin validate -av 99999 -C 1,2 -L 7,8 $tc_string`;
     my $all_data = decode_helper($all_out);
     ok( exists $all_data->{reasons}, '--all uses plural reasons array' );
     ok( !exists $all_data->{reason}, '--all does not emit singular reason' );
     is( ref $all_data->{reasons}, 'ARRAY', 'reasons is an array' );
-    cmp_ok( scalar @{ $all_data->{reasons} }, '>=', 2,
+    cmp_ok(
+        scalar @{ $all_data->{reasons} }, '>=', 2,
         '--all aggregates multiple failures'
     );
 
@@ -272,9 +277,10 @@ subtest 'validate subcommand' => sub {
         '--text fail line shape'
     );
 
-    my $text_all = `$perl -Ilib $bin validate -atv 99999 -C 1,2 $tc_string`;
+    my $text_all   = `$perl -Ilib $bin validate -atv 99999 -C 1,2 $tc_string`;
     my @text_lines = split /\n/, $text_all;
-    cmp_ok( scalar @text_lines, '>=', 2,
+    cmp_ok(
+        scalar @text_lines, '>=', 2,
         '--text --all spans multiple lines'
     );
     like(
@@ -296,8 +302,10 @@ subtest 'validate subcommand' => sub {
     is( $? >> 8,     1,  '--quiet on failure still exits 1' );
 
     # Missing --vendor-id: exit 2 with diagnostic on STDERR.
-    my $missing_v_stderr = File::Spec->catfile( File::Spec->tmpdir(),
-        "tcf_missing_v_$$" );
+    my $missing_v_stderr = File::Spec->catfile(
+        File::Spec->tmpdir(),
+        "tcf_missing_v_$$"
+    );
     my $missing_v_stdout =
       `$perl -Ilib $bin validate $tc_string 2>$missing_v_stderr`;
     is( $? >> 8, 2, 'missing --vendor-id exits 2' );


### PR DESCRIPTION
This PR implements the flexible-purposes redesign for the Validator as outlined in the implementation plan. It includes the structural derivation of default basis, construction-time coherence checks, and the from_gvl_vendor_entry helper.