### PR TITLE
fix: restore PAUSE indexation regressed by #72 (CMPValidator $VERSION)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,14 @@ REGEN_CORPUS=1 prove -lv t/07-golden.t
 
 The corpus lives at `t/corpus/golden.jsonl`; the generator is `t/generate_golden.pl` and reads input strings from `t/corpus/gdpr_subset.txt`.
 
+Bump the dist version with the helper instead of hand-editing every `.pm`:
+
+```sh
+tools/bump-version 0.402     # rewrites `our $VERSION = "..."` across lib/**.pm
+```
+
+The script refuses to downgrade and refuses to run if any `.pm` is missing `$VERSION`.
+
 ## Release flow
 
 Documented in `CONTRIBUTING.pod`. Summary: bump `$VERSION` in `lib/GDPR/IAB/TCFv2.pm`, run `git cliff -o CHANGELOG.md` (config in `cliff.toml` — uses Conventional Commits), regenerate `README.md` from POD with `pod2markdown lib/GDPR/IAB/TCFv2.pm > README.md`. 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ The script refuses to downgrade and refuses to run if any `.pm` is missing `$VER
 
 ## Release flow
 
-Documented in `CONTRIBUTING.pod`. Summary: bump `$VERSION` in `lib/GDPR/IAB/TCFv2.pm`, run `git cliff -o CHANGELOG.md` (config in `cliff.toml` — uses Conventional Commits), regenerate `README.md` from POD with `pod2markdown lib/GDPR/IAB/TCFv2.pm > README.md`. 
+Documented in `CONTRIBUTING.pod`. Summary: bump `$VERSION` across `lib/**.pm` with `tools/bump-version <new-version>`, run `git cliff -o CHANGELOG.md` (config in `cliff.toml` — uses Conventional Commits), regenerate `README.md` from POD with `pod2markdown lib/GDPR/IAB/TCFv2.pm > README.md`. 
 
 The release process is **automated**: once `devel` is merged to `main`, pushing a tag (`v*`) triggers a GitHub Action (`.github/workflows/release.yml`) that builds the distribution, uploads to CPAN (PAUSE), and creates a GitHub Release with the tarball attached.
 

--- a/CONTRIBUTING.pod
+++ b/CONTRIBUTING.pod
@@ -246,17 +246,18 @@ B<vanilla git:>
 
 =item 3. Bump the version in both files
 
-    $EDITOR lib/GDPR/IAB/TCFv2.pm
-    # Edit:  our $VERSION = "0.360";
+    tools/bump-version 0.360         # rewrites $VERSION across lib/**.pm
 
     $EDITOR CITATION.cff
     # Edit:
     #   version: "0.360"
     #   date-released: "YYYY-MM-DD"     # the actual tag/release date
 
-F<Makefile.PL> reads C<$VERSION> from the C<.pm> via C<VERSION_FROM>;
-F<CITATION.cff> is the only other file that has to be hand-bumped, and
-both its C<version> and C<date-released> fields must be updated together.
+See L</Bumping the version> above for what the helper does and the
+sanity checks it enforces. F<Makefile.PL> reads C<$VERSION> from the
+C<.pm> via C<VERSION_FROM>; F<CITATION.cff> is the only other file
+that has to be hand-bumped, and both its C<version> and
+C<date-released> fields must be updated together.
 
 =item 4. Regenerate the changelog
 

--- a/CONTRIBUTING.pod
+++ b/CONTRIBUTING.pod
@@ -182,6 +182,45 @@ in steps of 10 for normal releases (e.g. C<0.350 → 0.360>) and by 1 for
 pure bug-fix follow-ups (e.g. C<0.350 → 0.351>). The git tag prepends
 C<v> (e.g. C<v0.360>); the C<$VERSION> string in the F<.pm> does not.
 
+=head2 Bumping the version
+
+Use the F<tools/bump-version> helper rather than hand-editing the
+fifteen C<our $VERSION = "..."> declarations under F<lib/>. Pass the
+new version as the only argument:
+
+    tools/bump-version 0.402
+
+The script:
+
+=over 4
+
+=item *
+
+Reads the current dist version from F<lib/GDPR/IAB/TCFv2.pm> and
+refuses to run if the new version is not strictly greater (the same
+sanity check PAUSE itself enforces against version regressions).
+
+=item *
+
+Rewrites C<our $VERSION = "..."> in every F<lib/**/*.pm> file in
+place.
+
+=item *
+
+Refuses to run if any F<.pm> under F<lib/> is missing the
+C<$VERSION> declaration entirely. That signals either a new module
+that was added without seeding C<$VERSION>, or a drift caused by
+hand-editing. Investigate and reconcile before bumping.
+
+=back
+
+The script does B<not> touch F<CHANGELOG.md>, run C<git cliff>,
+amend git, or push. Those remain manual steps in the
+L</Step-by-step release> flow below.
+
+After running the bumper, run C<prove -lr xt> to confirm
+F<xt/version.t> stays green.
+
 =head2 Step-by-step release
 
 =over 4

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -24,3 +24,4 @@ tmp/
 t_xs/
 ^xt/
 docs/
+^tools/

--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -22,7 +22,7 @@ use GDPR::IAB::TCFv2::Publisher;
 use GDPR::IAB::TCFv2::RangeSection;
 use GDPR::IAB::TCFv2::Constants::RestrictionType qw<:all>;
 
-our $VERSION = "0.400";
+our $VERSION = "0.401";
 
 use constant {
   CONSENT_STRING_TCF_V2   => {SEPARATOR => quotemeta q<.>, PREFIX => q<C>, MIN_BYTE_SIZE => 29,},

--- a/lib/GDPR/IAB/TCFv2/BitField.pm
+++ b/lib/GDPR/IAB/TCFv2/BitField.pm
@@ -7,6 +7,8 @@ use bytes;
 use GDPR::IAB::TCFv2::BitUtils qw<is_set>;
 use Carp                       qw<croak>;
 
+our $VERSION = "0.401";
+
 sub Parse {
   my ($klass, %args) = @_;
 

--- a/lib/GDPR/IAB/TCFv2/BitUtils.pm
+++ b/lib/GDPR/IAB/TCFv2/BitUtils.pm
@@ -12,6 +12,8 @@ use base qw<Exporter>;
 
 use constant ASCII_OFFSET => ord('A');
 
+our $VERSION = "0.401";
+
 our $CAN_PACK_QUADS;
 our $CAN_FORCE_BIG_ENDIAN;
 

--- a/lib/GDPR/IAB/TCFv2/CMPValidator.pm
+++ b/lib/GDPR/IAB/TCFv2/CMPValidator.pm
@@ -6,6 +6,7 @@ use warnings;
 use Carp         qw<croak carp>;
 use Scalar::Util qw<blessed>;
 
+our $VERSION = "0.401";
 
 # JSON::PP and Time::Piece are loaded lazily (see load_from_data and
 # _parse_date). They are listed under META "recommends" rather than

--- a/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
@@ -5,6 +5,8 @@ use warnings;
 require Exporter;
 use base qw<Exporter>;
 
+our $VERSION = "0.401";
+
 use constant {
 
   # Short, established names -- supported indefinitely.  Used by examples

--- a/lib/GDPR/IAB/TCFv2/Constants/RestrictionType.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/RestrictionType.pm
@@ -5,6 +5,8 @@ use warnings;
 require Exporter;
 use base qw<Exporter>;
 
+our $VERSION = "0.401";
+
 use constant {NotAllowed => 0, RequireConsent => 1, RequireLegitimateInterest => 2,};
 
 use constant RestrictionTypeDescription => {

--- a/lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
@@ -5,6 +5,8 @@ use warnings;
 require Exporter;
 use base qw<Exporter>;
 
+our $VERSION = "0.401";
+
 use constant {
 
   # Short, established names -- supported indefinitely.

--- a/lib/GDPR/IAB/TCFv2/Publisher.pm
+++ b/lib/GDPR/IAB/TCFv2/Publisher.pm
@@ -7,6 +7,7 @@ use Carp qw<croak>;
 use GDPR::IAB::TCFv2::PublisherRestrictions;
 use GDPR::IAB::TCFv2::PublisherTC;
 
+our $VERSION = "0.401";
 
 sub Parse {
   my ($klass, %args) = @_;

--- a/lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm
+++ b/lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm
@@ -10,6 +10,8 @@ use GDPR::IAB::TCFv2::BitUtils qw<
   get_uint12
 >;
 
+our $VERSION = "0.401";
+
 use constant ASSUMED_MAX_VENDOR_ID => 0x7FFF;    # 32767 or (1 << 15) -1
 
 

--- a/lib/GDPR/IAB/TCFv2/PublisherTC.pm
+++ b/lib/GDPR/IAB/TCFv2/PublisherTC.pm
@@ -9,6 +9,8 @@ use GDPR::IAB::TCFv2::BitUtils qw<is_set
   get_uint6
 >;
 
+our $VERSION = "0.401";
+
 use constant {
   SEGMENT_TYPE_PUBLISHER_TC => 3,
   MAX_PURPOSE_ID            => 24,

--- a/lib/GDPR/IAB/TCFv2/RangeSection.pm
+++ b/lib/GDPR/IAB/TCFv2/RangeSection.pm
@@ -7,6 +7,8 @@ use bytes;
 use GDPR::IAB::TCFv2::BitUtils qw<is_set get_uint12 get_uint16>;
 use Carp                       qw<croak>;
 
+our $VERSION = "0.401";
+
 sub Parse {
   my ($klass, %args) = @_;
 

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -11,6 +11,8 @@ use GDPR::IAB::TCFv2::Validator::Failure;
 use GDPR::IAB::TCFv2::Validator::Reason qw<:all>;
 use GDPR::IAB::TCFv2::Validator::Result;
 
+our $VERSION = "0.401";
+
 sub new {
   my ($klass, %args) = @_;
 

--- a/lib/GDPR/IAB/TCFv2/Validator/Failure.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Failure.pm
@@ -7,6 +7,8 @@ use overload
   '""'     => sub { $_[0]->{message} },
   fallback => 1;
 
+our $VERSION = "0.401";
+
 sub new {
   my ($klass, %args) = @_;
 

--- a/lib/GDPR/IAB/TCFv2/Validator/Reason.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Reason.pm
@@ -5,6 +5,8 @@ use warnings;
 require Exporter;
 use base qw<Exporter>;
 
+our $VERSION = "0.401";
+
 use constant {
 
   # Successful validation: no failure to report.

--- a/lib/GDPR/IAB/TCFv2/Validator/Result.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Result.pm
@@ -14,6 +14,8 @@ use overload
   return join($sep, map { $_->message } @{$self->{failures} || []});
   };
 
+our $VERSION = "0.401";
+
 sub new {
   my ($klass, %args) = @_;
 

--- a/tools/bump-version
+++ b/tools/bump-version
@@ -66,6 +66,16 @@ if (@missing) {
         . "Add `our \$VERSION = \"$current_version\";` to each before bumping.\n";
 }
 
+my @unwritable;
+for my $pm (@pms) {
+    push @unwritable, $pm unless -w $pm;
+}
+if (@unwritable) {
+    die "bump-version: the following files are not writable:\n"
+        . join('', map { "  $_\n" } @unwritable)
+        . "Fix permissions before bumping.\n";
+}
+
 print "Bumping " . scalar(@pms) . " files: $current_version -> $new_version\n";
 for my $pm (@pms) {
     rewrite_version($pm, $new_version);

--- a/tools/bump-version
+++ b/tools/bump-version
@@ -1,0 +1,120 @@
+#!/usr/bin/env perl
+# tools/bump-version — release helper for GDPR-IAB-TCFv2
+#
+# Rewrites every `our $VERSION = "..."` declaration under lib/ to
+# the version passed on the command line. Refuses to run if the
+# new version is not strictly greater than the current dist version
+# (PAUSE-style sanity check) or if any .pm under lib/ is missing
+# the `$VERSION` line entirely (means the file drifted out of sync;
+# author should investigate before bumping).
+#
+# Usage:
+#     tools/bump-version 0.402
+#
+# Does NOT touch CHANGELOG, run git-cliff, commit, tag, or push.
+# Those steps remain manual per CONTRIBUTING.pod.
+
+use strict;
+use warnings;
+use File::Find ();
+use version    ();
+
+my $new_version = shift @ARGV;
+die usage() unless defined $new_version && length $new_version;
+
+# Validate the argument parses as a version object.
+my $new_v = eval { version->parse($new_version) };
+die "bump-version: '$new_version' is not a valid version string\n"
+    if !defined $new_v || $@;
+
+# Read current dist version from the canonical source.
+my $dist_pm = 'lib/GDPR/IAB/TCFv2.pm';
+die "bump-version: cannot find $dist_pm (run from the repo root)\n"
+    unless -f $dist_pm;
+
+my $current_version = read_version($dist_pm);
+die "bump-version: $dist_pm has no \$VERSION declaration\n"
+    unless defined $current_version;
+
+my $cur_v = version->parse($current_version);
+die "bump-version: refusing to downgrade ($current_version -> $new_version)\n"
+    if $new_v <= $cur_v;
+
+# Collect every .pm under lib/, verify each declares $VERSION.
+my @pms;
+File::Find::find(
+    {
+        wanted => sub {
+            return unless /\.pm\z/;
+            return if /\.bak\z/;
+            push @pms, $File::Find::name;
+        },
+        no_chdir => 1,
+    },
+    'lib',
+);
+
+@pms = sort @pms;
+
+my @missing;
+for my $pm (@pms) {
+    push @missing, $pm unless defined read_version($pm);
+}
+if (@missing) {
+    die "bump-version: the following files have no \$VERSION line:\n"
+        . join('', map { "  $_\n" } @missing)
+        . "Add `our \$VERSION = \"$current_version\";` to each before bumping.\n";
+}
+
+print "Bumping " . scalar(@pms) . " files: $current_version -> $new_version\n";
+for my $pm (@pms) {
+    rewrite_version($pm, $new_version);
+    print "  $pm\n";
+}
+print "Done. Run `git diff` to review, then `prove -lr xt` to confirm.\n";
+
+exit 0;
+
+sub read_version {
+    my $file = shift;
+    open my $fh, '<', $file or die "open $file: $!\n";
+    while (my $line = <$fh>) {
+        if ($line =~ /^\s*our\s+\$VERSION\s*=\s*(["'])([^"']+)\1\s*;/) {
+            close $fh;
+            return $2;
+        }
+    }
+    close $fh;
+    return undef;
+}
+
+sub rewrite_version {
+    my ($file, $version) = @_;
+    open my $in, '<', $file or die "open $file: $!\n";
+    my @lines = <$in>;
+    close $in;
+
+    my $changed = 0;
+    for my $line (@lines) {
+        if ($line =~ s/^(\s*our\s+\$VERSION\s*=\s*)(["'])[^"']+\2(\s*;)/$1"$version"$3/) {
+            $changed++;
+        }
+    }
+    die "bump-version: failed to rewrite \$VERSION in $file\n" unless $changed;
+
+    open my $out, '>', $file or die "open >$file: $!\n";
+    print {$out} @lines;
+    close $out;
+}
+
+sub usage {
+    return <<'EOF';
+Usage: tools/bump-version <new-version>
+
+Rewrites `our $VERSION = "..."` in every lib/**/*.pm to <new-version>.
+Refuses to downgrade. Refuses to run if any file is missing $VERSION.
+
+Example:
+    tools/bump-version 0.402
+EOF
+}

--- a/xt/version.t
+++ b/xt/version.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+use Test::More;
+
+eval "use Test::Version";
+plan skip_all => "Test::Version required for version coherence checks"
+  if $@;
+
+Test::Version->import(qw<version_all_ok>);
+
+# Enforces:
+#   * has_version => 1: every .pm declares a $VERSION literal.
+#   * consistent  => 1: every $VERSION matches the dist version.
+# Catches the kind of cross-package drift that broke v0.400's PAUSE
+# indexation (CMPValidator regressed from 0.001 to "0" -> PAUSE refused
+# to re-index).
+version_all_ok({ has_version => 1, consistent => 1 });
+done_testing();

--- a/xt/version.t
+++ b/xt/version.t
@@ -2,17 +2,14 @@ use strict;
 use warnings;
 use Test::More;
 
-eval "use Test::Version";
-plan skip_all => "Test::Version required for version coherence checks"
-  if $@;
-
-Test::Version->import(qw<version_all_ok>);
+eval "use Test::Version 1.001001 qw<version_all_ok>, " . "{ has_version => 1, consistent => 1 }";
+plan skip_all => "Test::Version 1.001001+ required for version coherence checks" if $@;
 
 # Enforces:
-#   * has_version => 1: every .pm declares a $VERSION literal.
-#   * consistent  => 1: every $VERSION matches the dist version.
+#   * has_version: every .pm declares a $VERSION literal.
+#   * consistent: every $VERSION matches the dist version.
 # Catches the kind of cross-package drift that broke v0.400's PAUSE
 # indexation (CMPValidator regressed from 0.001 to "0" -> PAUSE refused
 # to re-index).
-version_all_ok({ has_version => 1, consistent => 1 });
+version_all_ok();
 done_testing();


### PR DESCRIPTION
## Summary

**Restores PAUSE indexation regressed by #72.**

v0.400 shipped successfully as a tarball but is **not the version users see** when they run `cpanm GDPR::IAB::TCFv2` or browse MetaCPAN search results. PR #72 dropped `our $VERSION = '0.001'` from `CMPValidator.pm` to silence Kwalitee's `consistent_version` warning. PAUSE then rejected re-indexing because the new "version" of `GDPR::IAB::TCFv2::CMPValidator` (`"0"`, the `MM->parse_version` fallback) is **lower** than the previously-indexed `0.001` — and PAUSE never lets a package version go backward. The whole release got stuck at the previous indexed state.

v0.401 restores indexation by giving every `.pm` a real `$VERSION` matching the dist, which (a) clears `0.001` for `CMPValidator` and (b) makes Kwalitee's `consistent_version` happy at the same time. A new `xt/version.t` (Test::Version) and `tools/bump-version` helper prevent recurrence.

## Changes (5 commits)

- `chore: add tools/bump-version helper` — release helper that rewrites `our $VERSION = "..."` across `lib/**/*.pm` with downgrade and missing-version guards. Excluded from the dist via `MANIFEST.SKIP`. Documented in `CONTRIBUTING.pod` and `AGENTS.md`.
- `chore: harden tools/bump-version + align release docs` — atomic `-w` pre-check (so a mid-batch write failure does not leave a half-bumped tree), plus alignment of `CONTRIBUTING.pod` Step-by-step release and `AGENTS.md` Release flow with the new helper section.
- `test: add xt/version.t consistency guard (Test::Version)` — author-only test that enforces every `.pm` declares the same `$VERSION`. Skips cleanly when `Test::Version` is not installed (matches existing `xt/*.t` convention; no addition to `TEST_REQUIRES`).
- `fix: restore $VERSION on every package, bump to 0.401` — **load-bearing**. One-shot manual bootstrap: bumps `lib/GDPR/IAB/TCFv2.pm` to `0.401` and adds `our $VERSION = "0.401";` to the 14 sub-modules.
- `fix(test): correct Test::Version API in xt/version.t` — corrects the guard's call: options must be passed via the import hashref, not as a positional argument to `version_all_ok`. The original call silently skipped when `Test::Version` was absent and died with a confusing error when present. Pins minimum `Test::Version` to `1.001001` (first release with the `consistent` option).

## Test plan

- [x] `prove -lr t` green — 17548 tests pass (no regression from the `$VERSION` adds; `t/10-cli-iabtcfv2.t` reads the version dynamically and stayed green without modification).
- [x] `prove -lr xt` green — `xt/version.t` reports 16 oks (15 `has_version` + 1 `consistent`); other `xt/*.t` unchanged.
- [x] `make tidy` and `make lint` clean on `lib/`.
- [x] `META.json` `provides:` block reports every `GDPR::IAB::TCFv2::*` package at `0.401` (including `CMPValidator`, the load-bearing one). Verified by dist-build inspection — the most direct check that PAUSE will accept re-indexation.
- [x] Dist tarball does not leak `tools/`, `xt/`, or `docs/`.
- [x] Bumper smoke-tested end-to-end: `tools/bump-version 0.402` produces a uniform diff across all 15 files; `git checkout -- lib/` cleanly reverts. Bumper refuses `0.401 → 0.401` (equal) and `0.401 → 0.300` (downgrade) with non-zero exit.
- [x] `bin/iabtcfv2 --version` prints `iabtcfv2 version 0.401`.

## Out of scope (intentional)

- `CHANGELOG.md` regeneration — `git cliff` will produce the v0.401 entry on the downstream `release/0.401` branch per `CONTRIBUTING.pod`. The Conventional Commit subjects above will surface there.
- Wiring `xt/version.t` into `.github/workflows/release.yml` as a hard pre-upload gate — deferred to a follow-up PR.
- Validator `strict_legal_basis` coupling to `Parse(strict => 1, prefetch => $vendor_id)` — captured as a separate future feature; will land on its own branch after this one.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)