### PR TITLE
refactor!: split parser into GDPR::IAB::TCFv2::Parser + add iabtcfv2 short-alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,56 @@
+## [unreleased]
+
+### Documentation
+
+- *(roadmap)* Add Phase 12 Modernization roadmap 
+- *(todo)* Expand Phase 2 follow-up scope -- narrow validate() overrides 
+- Regenerate README.md from refreshed hub POD
+- *(roadmap)* Add v0.510 Validator->Validate help-wanted item
+- *(roadmap)* Add Phase 11 -- registry freshness policy and CMP-list hot-reload 
+- *(todo)* Add Phase 2 follow-up for Validator strict_legal_basis coupling 
+
+### Features
+
+- *(parser)* Make is_v23 time-aware and support reference_time 
+- Add iabtcfv2 short-alias module for one-liner use
+
+### Other
+
+- Merge remote-tracking branch 'origin/devel' into feat/parser-split-and-shortcut
+
+# Conflicts:
+#	TODO.pod
+#	lib/GDPR/IAB/TCFv2.pm
+- Merge tag 'v0.401' into devel
+
+Tagged for release. v0.401
+
+### Refactor
+
+- Split parser into GDPR::IAB::TCFv2::Parser
+
 ## [0.401] - 2026-05-11
 
 ### Bug Fixes
 
 - Restore PAUSE indexation regressed by #72 (CMPValidator $VERSION) 
+
+### Other
+
+- Merge branch 'release/0.401'
+-   v0.400 -- Phase 5 + Phase 6 (CMP validator + structured failure reporting)
+  Highlights:
+    * Phase 5: CMPValidator + iabtcfv2 CLI integration
+    * Phase 6 (6.1-6.5): structured Validator::Failure objects with
+      machine-readable Reason codes, per-call list overrides
+    * MIN_PERL_VERSION raised to 5.8.9; runtime now Perl 5.8 clean
+    * Performance: vec() + regex optimizations for bitfields
+    * CLI: short-help (-h) and informative unknown-subcommand errors
+    * CMPValidator JSON::PP and Time::Piece are now optional
+      (lazy-required, listed under META `recommends`)
+    * Bug fixes: trailing padding bits in PublisherRestrictions,
+      cleaner CLI error formatting
+  See CHANGELOG.md for the full list.
 
 ## [0.400] - 2026-05-09
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -11,6 +11,7 @@ lib/GDPR/IAB/TCFv2/CMPValidator.pm
 lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
 lib/GDPR/IAB/TCFv2/Constants/RestrictionType.pm
 lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
+lib/GDPR/IAB/TCFv2/Parser.pm
 lib/GDPR/IAB/TCFv2/Publisher.pm
 lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm
 lib/GDPR/IAB/TCFv2/PublisherTC.pm

--- a/MANIFEST
+++ b/MANIFEST
@@ -20,6 +20,7 @@ lib/GDPR/IAB/TCFv2/Validator.pm
 lib/GDPR/IAB/TCFv2/Validator/Failure.pm
 lib/GDPR/IAB/TCFv2/Validator/Reason.pm
 lib/GDPR/IAB/TCFv2/Validator/Result.pm
+lib/iabtcfv2.pm
 LICENSE
 Makefile.PL
 MANIFEST
@@ -36,6 +37,7 @@ t/07-golden.t
 t/08-golden-validator.t
 t/09-predicates.t
 t/10-cli-iabtcfv2.t
+t/11-iabtcfv2-shortcut.t
 t/12-bigint-fallback.t
 t/13-constants-aliases.t
 t/14-cmp-validator.t

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 # NAME
 
-GDPR::IAB::TCFv2 - TCF v2.3 (Transparency & Consent String) parser
+GDPR::IAB::TCFv2 - TCF v2.3 distribution: parser, validator, CMP-validator, and CLI
 
 # PROJECT STATUS
 
@@ -51,74 +51,98 @@ help-wanted list and `CONTRIBUTING.pod` for the patching workflow.
 
 # SYNOPSIS
 
-The purpose of this package is to parse Transparency & Consent String (TC String) as defined by IAB version 2.
+This module is the documentation hub for the `GDPR-IAB-TCFv2`
+distribution. It exposes a thin `Parse` delegate that returns an
+instance of [GDPR::IAB::TCFv2::Parser](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3AParser):
 
-    use strict;
-    use warnings;
-    
+    use feature qw<say>;
     use GDPR::IAB::TCFv2;
-    use GDPR::IAB::TCFv2::Constants::Purpose qw<:all>;
-    use GDPR::IAB::TCFv2::Constants::SpecialFeature qw<:all>;
-    use GDPR::IAB::TCFv2::Constants::RestrictionType qw<:all>;
 
     my $consent = GDPR::IAB::TCFv2->Parse(
         'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA.argAC0gAAAAAAAAAAAA'
     );
 
-    use feature qw<say>;
+    say $consent->cmp_id;             # 21
+    say $consent->consent_language;   # 'EN'
+    say $consent->is_v23 ? 'v2.3' : 'older';
 
-    say $consent->version;             # 2
-    say $consent->created;             # epoch 1228644257 or 07/12/2008
-    say $consent->last_updated;        # epoch 1326215413 or 10/01/2012
-    say $consent->cmp_id;              # 21 - Traffective GmbH 
-    say $consent->cmp_version;         # 7
-    say $consent->consent_screen;      # 2
-    say $consent->consent_language;    # "EN"
-    say $consent->vendor_list_version; # 23
+For declarative compliance checks, see [GDPR::IAB::TCFv2::Validator](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3AValidator).
+For one-liner / shell-use shortcuts, see ["ONE-LINER USAGE"](#one-liner-usage) below.
 
-    say "find consent for purpose ids 1, 3, 9 and 10" if 4 == grep {
-        $consent->is_purpose_consent_allowed($_)
-    } ( # constants exported by GDPR::IAB::TCFv2::Constants::Purpose
-        InfoStorageAccess,       #  1
-        PersonalizationProfile,  #  3
-        MarketResearch,          #  9
-        DevelopImprove,          # 10
-    );
+# COMPONENTS
 
-    say "find consent for vendor id 284 (Weborama)" if $consent->vendor_consent(284);
+The distribution ships several pieces. Each link below jumps to the
+relevant module or section.
 
-    # Geolocation exported by GDPR::IAB::TCFv2::Constants::SpecialFeature
-    say "user is opt in for special feature 'Geolocation (id 1)'" 
-        if $consent->is_special_feature_opt_in(Geolocation);
+## [GDPR::IAB::TCFv2::Parser](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3AParser)
 
-    # NotAllowed exported by GDPR::IAB::TCFv2::Constants::RestrictionType
-    say "publisher restriction for purpose Info Storage Access (1), restriction type NotAllowed (0) for weborama (284)"
-        if $consent->check_publisher_restriction(InfoStorageAccess, NotAllowed, 284);
+The bit-stream parser. `Parse` returns an instance whose accessors,
+predicates, and JSON serializer answer every question about a TC
+string.
 
-For policy-driven checks against an entire vendor profile (required purposes,
-legal basis, GVL flexibility, optional Disclosed Vendors enforcement),
-use the [GDPR::IAB::TCFv2::Validator](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3AValidator) companion class instead of stringing
-the predicates above together by hand:
+## [GDPR::IAB::TCFv2::Validator](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3AValidator)
 
-    use GDPR::IAB::TCFv2::Validator;
+Declarative compliance checks. `$validator->validate($tc_string)`
+asserts a vendor's presence in the string for a given purpose set on a
+given legal basis.
 
-    my $validator = GDPR::IAB::TCFv2::Validator->new(
-        vendor_id                       => 284,
-        consent_purpose_ids             => [ 1, 3 ],
-        legitimate_interest_purpose_ids => [ 7 ],
-    );
+## [GDPR::IAB::TCFv2::CMPValidator](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3ACMPValidator)
 
-    my $tc_string = '...';
-    my $result = $validator->validate($tc_string);   # fail-fast
-    # ...or $validator->validate_all($tc_string) to accumulate every reason
+Validates that a TC string's `cmp_id` is registered in the IAB's
+public CMP list (file, JSON, or URL-loaded snapshot).
 
-    if ($result) {
-        # vendor 284 has every required permission
-    }
-    else {
-        warn "compliance failed: $result\n";   # stringifies to the reasons
-        warn $_ for $result->reasons;
-    }
+## [iabtcfv2](https://metacpan.org/pod/iabtcfv2) (Perl module)
+
+A pure-exporter short alias for one-liner and shell use. Provides
+`tcf($s)` and `validator(%opts)` as importable functions. See
+["ONE-LINER USAGE"](#one-liner-usage).
+
+## `bin/iabtcfv2` (CLI)
+
+Subcommand-style command-line utility. `iabtcfv2 dump` emits parsed
+JSON; `iabtcfv2 validate` runs declarative compliance checks against
+a vendor identity and a purpose set. See ["COMMAND LINE TOOLS"](#command-line-tools).
+
+## Docker image
+
+Pre-built Docker Hub image `peczenyj/gdpr-iab-tcfv2` wraps the CLI
+for portable use. See ["DOCKER USAGE"](#docker-usage).
+
+# INCOMPATIBLE CHANGES
+
+## v0.500
+
+The parser implementation moved from `GDPR::IAB::TCFv2` to a new
+subpackage [GDPR::IAB::TCFv2::Parser](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3AParser). The class-method delegate
+remains: `GDPR::IAB::TCFv2->Parse(...)` still works and is the
+recommended entry point. However, the returned object is now blessed
+into `GDPR::IAB::TCFv2::Parser` rather than `GDPR::IAB::TCFv2`:
+
+    my $c = GDPR::IAB::TCFv2->Parse($s);
+
+    # Before v0.500:
+    ref($c) eq 'GDPR::IAB::TCFv2'             # true
+    $c->isa('GDPR::IAB::TCFv2')               # true
+
+    # v0.500 and later:
+    ref($c) eq 'GDPR::IAB::TCFv2::Parser'     # true
+    $c->isa('GDPR::IAB::TCFv2::Parser')       # true
+    $c->isa('GDPR::IAB::TCFv2')               # false
+
+Every method call, every JSON output byte, and every CLI behavior is
+unchanged. The break only affects code that asserts the exact class
+name via `ref`, `isa`, `blessed`, `Storable::thaw`, or similar.
+
+# CONSTRUCTOR
+
+## Parse
+
+`GDPR::IAB::TCFv2->Parse($tc_string, %opts)` is the entry point
+for parsing TCF v2.3 consent strings. It delegates to
+[GDPR::IAB::TCFv2::Parser->Parse](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3AParser#Parse)
+and returns a `GDPR::IAB::TCFv2::Parser` object; see that page for
+the full constructor contract (`strict`, `prefetch`, `json`
+options).
 
 # COMMAND LINE TOOLS
 
@@ -189,6 +213,55 @@ valid, `1` on any parse or validation failure, `2` on bad CLI usage.
 
 See `iabtcfv2 --help` or `perldoc iabtcfv2` for more details.
 
+For script-free invocation without `bin/iabtcfv2`, see
+["ONE-LINER USAGE"](#one-liner-usage).
+
+# ONE-LINER USAGE
+
+The distribution supports `perl -M...` one-liners directly. The
+[iabtcfv2](https://metacpan.org/pod/iabtcfv2) module exports `tcf($s)` (which returns a
+`GDPR::IAB::TCFv2::Parser`) and `validator(%opts)` (which returns a
+`GDPR::IAB::TCFv2::Validator`), making short scripts even shorter.
+
+## Print one field
+
+    perl -Miabtcfv2 -E 'say tcf(shift)->cmp_id' "$tc"
+
+Equivalent long form (no shortcut module):
+
+    perl -MGDPR::IAB::TCFv2 -E 'say GDPR::IAB::TCFv2->Parse(shift)->cmp_id' "$tc"
+
+## Multi-field TSV
+
+    perl -Miabtcfv2 -E '
+        my $c = tcf(shift);
+        say join("\t", $c->cmp_id, $c->cmp_version, $c->consent_language,
+                       $c->vendor_list_version, $c->policy_version)
+    ' "$tc"
+
+## Emulate \`iabtcfv2 dump --pretty\` via core JSON::PP
+
+    perl -Miabtcfv2 -MJSON::PP -E '
+        say JSON::PP->new->convert_blessed->canonical->pretty
+                    ->encode(tcf(shift))
+    ' "$tc"
+
+## Stream multiple strings on STDIN
+
+    perl -Miabtcfv2 -nE '
+        chomp;
+        my $c = eval { tcf($_) } or next;
+        say join("\t", $_, $c->cmp_id)
+    ' < strings.txt
+
+## Validate
+
+    perl -Miabtcfv2 -E '
+        my $r = validator(vendor_id => 284, consent_purpose_ids => [1,3])
+                ->validate(shift);
+        say $r ? "ok" : "fail: $r"
+    ' "$tc"
+
 # DOCKER USAGE
 
 This tool is also available as a Docker image on Docker Hub.
@@ -211,421 +284,9 @@ To type strings manually:
 
 [GDPR](https://gdpr-info.eu/): General Data Protection Regulation
 
-[IAB](https://iabeurope.eu/about-us/): Interactive Advertising Bureau 
+[IAB](https://iabeurope.eu/about-us/): Interactive Advertising Bureau
 
 [TCF](https://iabeurope.eu/transparency-consent-framework/): The Transparency & Consent Framework
-
-# CONSTRUCTOR
-
-## Parse
-
-The Parse method will decode and validate a base64 encoded version of the tcf v2 string.
-
-Will return a `GDPR::IAB::TCFv2` immutable object that allow easy access to different properties.
-
-Will die if can't decode the string.
-
-    use GDPR::IAB::TCFv2;
-
-    my $consent = GDPR::IAB::TCFv2->Parse(
-        'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA.argAC0gAAAAAAAAAAAA'
-    );
-
-or
-
-    use GDPR::IAB::TCFv2;
-
-    my $consent = GDPR::IAB::TCFv2->Parse(
-        'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA.argAC0gAAAAAAAAAAAA',
-        json => {
-            verbose        => 0,
-            compact        => 1,
-            use_epoch      => 0,
-            boolean_values => [ 0, 1 ],
-            date_format    => '%Y%m%d',    # yyymmdd
-        },
-        strict => 1,
-        prefetch => 284,
-    );
-
-Parse may receive an optional hash with the following parameters:
-
-- On `strict` mode we will validate if the version of the consent string is the version 2 (or die with an exception).
-
-    Additionally, for TCF v2.3 strings (Policy Version 5+), `strict` mode will enforce that the **Disclosed Vendors** segment is present.
-
-    The `strict` mode is disabled by default.
-
-- The `prefetch` option receives one (as scalar) or more (as arrayref) vendor ids. 
-
-    This is useful when parsing a range based consent string, since we need to visit all ranges to find a particular id.
-
-- `json` is hashref with the following properties used to customize the json format:
-    - `verbose` changes the json encoding. By default we omit some false values such as `vendor_consents` to create 
-    a compact json representation. With `verbose` we will present everything. See ["TO\_JSON"](#to_json) for more details.
-    - `compact` changes the json encoding. All fields that are a mapping of something to a boolean will be changed to an array
-    of all elements keys where the value is true. This affects the following fields:  `special_features_opt_in`,
-    `purpose/consents`, `purpose/legitimate_interests`, `vendor/consents` and `vendor/legitimate_interests`. See ["TO\_JSON"](#to_json) for more details.
-    - `use_epoch` changes the json encode. By default we format the `created` and `last_updated` are converted to string using 
-    [ISO\_8601](https://en.wikipedia.org/wiki/ISO_8601). With `use_epoch` we will return the unix epoch in seconds.
-    See ["TO\_JSON"](#to_json) for more details.
-    - `boolean_values` if present, expects an arrayref if two elements: the `false` and the `true` values to be used in json encoding.
-    If omit, we will try to use `JSON::false` and `JSON::true` if the package [JSON](https://metacpan.org/pod/JSON) is available, else we will fallback to `0` and `1`.
-    - `date_format` if present accepts two kinds of value: an `string` (to be used on `POSIX::strftime`) or a code reference to a subroutine that
-    will be called with two arguments: epoch in seconds and nanoseconds. If omitted the format [ISO\_8601](https://en.wikipedia.org/wiki/ISO_8601) will be used
-    except if the option `use_epoch` is true.
-    - `vendor_id` if present, filters the JSON output to only include data for the specific vendor ID. This affects the `vendor` and `publisher/restrictions` sections, drastically reducing the size of the output.
-
-# METHODS
-
-## tc\_string
-
-Returns the original consent string.
-
-The consent object [GDPR::IAB::TCFv2](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2) will call this method on string interpolations.
-
-## version
-
-Version number of the encoding format. The value is 2 for this format.
-
-## created
-
-Epoch time format when TC String was created in numeric format. You can easily parse with [DateTime](https://metacpan.org/pod/DateTime) if needed.
-
-On scalar context it returns epoch in seconds. On list context it returns epoch in seconds and nanoseconds.
-
-    use GDPR::IAB::TCFv2;
-    use Test::More tests => 3;
-
-    my $consent = GDPR::IAB::TCFv2->Parse(
-        'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA.argAC0gAAAAAAAAAAAA'
-    );
-
-    is $consent->created, 1228644257,
-      'should return the creation epoch 07/12/2008';
-
-    my ( $seconds, $nanoseconds ) = $consent->created;
-    is $seconds, 1228644257,
-        'should return the creation epoch 07/12/2008 on list context';
-    is $nanoseconds, 700000000,
-        'should return the 700000000 nanoseconds of epoch on list context';
-    
-
-## last\_updated
-
-Epoch time format when TC String was last updated in numeric format. You can easily parse with [DateTime](https://metacpan.org/pod/DateTime) if needed.
-
-On scalar context it returns epoch in seconds. On list context it returns epoch in seconds and nanoseconds, like the `created`
-
-## cmp\_id
-
-Consent Management Platform ID that last updated the TC String. Is a unique ID will be assigned to each Consent Management Platform.
-
-## cmp\_version
-
-Consent Management Platform version of the CMP that last updated this TC String.
-Each change to a CMP should increment their internally assigned version number as a record of which version the user gave consent and transparency was established.
-
-## consent\_screen
-
-CMP Screen number at which consent was given for a user with the CMP that last updated this TC String.
-The number is a CMP internal designation and is CmpVersion specific. The number is used for identifying on which screen a user gave consent as a record.
-
-## consent\_language
-
-Two-letter [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) language code in which the CMP UI was presented.
-
-## vendor\_list\_version
-
-Number corresponds to [GVL](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list) vendorListVersion.
-Version of the GVL used to create this TC String.
-
-## policy\_version
-
-Version of policy used within [GVL](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list).
-
-From the corresponding field in the GVL that was used for obtaining consent.
-
-## is\_v22\_plus
-
-Returns true if the TC string uses Policy Version 4 or higher (TCF v2.2+).
-
-## is\_v23
-
-Returns true if the TC string uses Policy Version 5 or higher (TCF v2.3).
-
-## is\_service\_specific
-
-This field must always have the value of 1. When a Vendor encounters a TC String with `is_service_specific=0` then it is considered invalid.
-
-## use\_non\_standard\_stacks
-
-If true, CMP used non-IAB standard texts during consent gathering.
-
-Setting this to 1 signals to Vendors that a private CMP has modified standard Stack descriptions and/or their translations and/or that a CMP has modified or supplemented standard Illustrations and/or their translations as allowed by the policy..
-
-## is\_special\_feature\_opt\_in
-
-If true means Opt in.
-
-The TCF [Policies](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/) designates certain Features as "special" which means a CMP must afford the user a means to opt in to their use. These "Special Features" are published and numerically identified in the [Global Vendor List separately](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list) from normal Features.
-
-See also: [GDPR::IAB::TCFv2::Constants::SpecialFeature](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3AConstants%3A%3ASpecialFeature).
-
-## is\_purpose\_consent\_allowed
-
-If true means Consent.
-
-The user's consent value for each Purpose established on the legal basis of consent.
-Accepts one or more Purpose IDs. Returns true if all Purposes have consent.
-
-    my $ok = $instance->is_purpose_consent_allowed(1);
-    my $all_ok = $instance->is_purpose_consent_allowed(1, 2, 3);
-
-Throws an exception if no arguments are provided or if an ID is invalid.
-
-See also: [GDPR::IAB::TCFv2::Constants::Purpose](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3AConstants%3A%3APurpose).
-
-## is\_purpose\_legitimate\_interest\_allowed
-
-The user's consent value for each Purpose established on the legal basis of legitimate interest.
-Accepts one or more Purpose IDs. Returns true if all Purposes have legitimate interest.
-
-    my $ok = $instance->is_purpose_legitimate_interest_allowed(1);
-    my $all_ok = $instance->is_purpose_legitimate_interest_allowed(1, 2, 3);
-
-Throws an exception if no arguments are provided or if an ID is invalid.
-
-See also: [GDPR::IAB::TCFv2::Constants::Purpose](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3AConstants%3A%3APurpose).
-
-## purpose\_one\_treatment
-
-CMPs can use the `publisher_country_code` field to indicate the legal jurisdiction the publisher is under to help vendors determine whether the vendor needs consent for Purpose 1.
-
-Returns true if Purpose 1 was NOT disclosed at all.
-
-Returns false if Purpose 1 was disclosed commonly as consent as expected by the [Policies](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/).
-
-## publisher\_country\_code
-
-Two-letter [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) language code of the country that determines legislation of reference. 
-Commonly, this corresponds to the country in which the publisher's business entity is established.
-
-## max\_vendor\_id\_consent
-
-The maximum Vendor ID that is represented in the following bit field or range encoding.
-
-Because this section can be a variable length, this indicates the last ID of the section so that a decoder will know when it has reached the end.
-
-## vendor\_consent
-
-If true, vendor has consent.
-
-The consent value for each Vendor ID.
-
-    my $ok = $instance->vendor_consent(284); # if true, consent ok for Weborama (vendor id 284).
-
-## max\_vendor\_id\_legitimate\_interest
-
-The maximum Vendor ID that is represented in the following bit field or range encoding.
-
-Because this section can be a variable length, this indicates the last ID of the section so that a decoder will know when it has reached the end.
-
-## vendor\_legitimate\_interest
-
-If true, legitimate interest established.
-
-The legitimate interest value for each Vendor ID
-
-    my $ok = $instance->vendor_legitimate_interest(284); # if true, legitimate interest established for Weborama (vendor id 284).
-
-## disclosed\_vendor
-
-If true, the vendor was disclosed to the user (Segment 1 or 5).
-
-    say "Vendor 284 was disclosed" if $consent->disclosed_vendor(284);
-
-## has\_vendor\_disclosure
-
-Returns true (1) if the TC string contains a "Disclosed Vendors" segment (ID 1 or 5), and false (0) otherwise.
-
-## allowed\_vendor
-
-If true, the vendor is in the "Allowed Vendors" segment (Segment 2). This is typically used for service-specific TC strings.
-
-    say "Vendor 284 is allowed" if $consent->allowed_vendor(284);
-
-## is\_vendor\_consent\_allowed
-
-Check if a vendor has consent for a list of purposes, respecting publisher restrictions.
-
-    if ($consent->is_vendor_consent_allowed(284, 1, 2, 3)) {
-        # ...
-    }
-
-## is\_vendor\_legitimate\_interest\_allowed
-
-Check if a vendor has legitimate interest for a list of purposes, respecting publisher restrictions.
-
-    if ($consent->is_vendor_legitimate_interest_allowed(284, 2, 4)) {
-        # ...
-    }
-
-## is\_vendor\_allowed\_for\_any\_basis
-
-Check if a vendor has either consent or legitimate interest for a list of purposes, respecting publisher restrictions.
-
-    if ($consent->is_vendor_allowed_for_any_basis(284, 1, 2)) {
-        # ...
-    }
-
-## has\_publisher\_restrictions
-
-Returns true (1) if the TC string contains a "Publisher Restrictions" section, and false (0) otherwise.
-
-## check\_publisher\_restriction
-
-It true, there is a publisher restriction of certain type, for a given purpose id, for a given vendor id:
-
-    # return true if there is publisher restriction to vendor 284 regarding purpose id 1 
-    # with restriction type 0 'Purpose Flatly Not Allowed by Publisher'
-    my $ok = $instance->check_publisher_restriction(1, 0, 284);
-
-or
-
-    my $ok = $instance->check_publisher_restriction(
-        purpose_id       => 1, 
-        restriction_type => 0,  
-        vendor_id        => 284);
-
-Version 2.0 of the Framework introduced the ability for publishers to signal restrictions on how vendors may process personal data. Restrictions can be of two types:
-
-- Purposes. Restrict the purposes for which personal data is processed by a vendor.
-- Legal basis. Specify the legal basis upon which a publisher requires a vendor to operate where a vendor has signaled flexibility on legal basis in the GVL.
-
-Publisher restrictions are custom requirements specified by a publisher. In order for vendors to determine if processing is permissible at all for a specific purpose or which legal basis is applicable (in case they signaled flexibility in the GVL) restrictions must be respected.
-
-1. Vendors must always respect a restriction signal that disallows them the processing for a specific purpose regardless of whether or not they have declared that purpose to be "flexible".
-2. Vendors that declared a purpose with a default legal basis (consent or legitimate interest respectively) but also declared this purpose as flexible must respect a legal basis restriction if present. That means for example in case they declared a purpose as legitimate interest but also declared that purpose as flexible and there is a legal basis restriction to require consent, they must then check for the consent signal and must not apply the legitimate interest signal.
-
-For the avoidance of doubt:
-
-In case a vendor has declared flexibility for a purpose and there is no legal basis restriction signal it must always apply the default legal basis under which the purpose was registered aside from being registered as flexible. That means if a vendor declared a purpose as legitimate interest and also declared that purpose as flexible it may not apply a "consent" signal without a legal basis restriction signal to require consent.
-
-## is\_vendor\_allowed\_for\_flexible\_purpose
-
-Check if a vendor is allowed for a flexible purpose, given a default legal basis (true if Legitimate Interest, false if Consent).
-
-    if ($consent->is_vendor_allowed_for_flexible_purpose(284, 2, 1)) {
-        # vendor 284, purpose 2, default is LI
-    }
-
-## publisher\_restrictions
-
-Similar to ["check\_publisher\_restriction"](#check_publisher_restriction) but return an hashref of purpose => { restriction type => bool } for a given vendor.
-
-## publisher\_tc
-
-If the consent string has a `Publisher TC` section, we will decode this section as an instance of [GDPR::IAB::TCFv2::PublisherTC](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3APublisherTC).
-
-Will return undefined if there is no `Publisher TC` section.
-
-## TO\_JSON
-
-Will serialize the consent object into a hash reference. The objective is to be used by [JSON](https://metacpan.org/pod/JSON) package.
-
-With option `convert_blessed`, the encoder will call this method.
-
-    use strict;
-    use warnings;
-    use feature qw<say>;
-
-    use JSON;
-    use DateTime;
-    use DateTimeX::TO_JSON formatter => 'DateTime::Format::RFC3339';
-    use GDPR::IAB::TCFv2;
-
-    my $consent = GDPR::IAB::TCFv2->Parse(
-        'COyiILmOyiILmADACHENAPCAAAAAAAAAAAAAE5QBgALgAqgD8AQACSwEygJyAAAAAA.argAC0gAAAAAAAAAAAA',
-        json => {
-            compact     => 1,
-            date_format => sub { # can be omitted, with DateTimeX::TO_JSON
-                my ( $epoch, $ns ) = @_;
-
-                return DateTime->from_epoch( epoch => $epoch )
-                ->set_nanosecond($ns);
-            },
-        },
-    );
-
-    my $json    = JSON->new->convert_blessed;
-    my $encoded = $json->pretty->encode($consent);
-
-    say $encoded;
-
-Outputs:
-
-    {
-        "tc_string" : "COyiILmOyiILmADACHENAPCAAAAAAAAAAAAAE5QBgALgAqgD8AQACSwEygJyAAAAAA",
-        "consent_language" : "EN",
-        "purpose" : {
-            "consents" : [],
-            "legitimate_interests" : []
-        },
-        "cmp_id" : 3,
-        "purpose_one_treatment" : false,
-        "publisher" : {
-            "consents" : [
-                2,
-                4,
-                6,
-                8,
-                9,
-                10
-            ],
-            "legitimate_interests" : [
-                2,
-                4,
-                5,
-                7,
-                10
-            ],
-            "custom_purposes" : {
-                "consents" : [],
-                "legitimate_interests" : []
-            },
-            "restrictions" : {}
-        },
-        "special_features_opt_in" : [],
-        "last_updated" : "2020-04-27T20:27:54.200000000Z",
-        "use_non_standard_stacks" : false,
-        "policy_version" : 2,
-        "version" : 2,
-        "is_service_specific" : false,
-        "created" : "2020-04-27T20:27:54.200000000Z",
-        "consent_screen" : 7,
-        "vendor_list_version" : 15,
-        "cmp_version" : 2,
-        "publisher_country_code" : "AA",
-        "vendor" : {
-            "consents" : [
-                23,
-                42,
-                126,
-                127,
-                128,
-                587,
-                613,
-                626
-            ],
-            "legitimate_interests" : []
-        }
-    }
-
-If [JSON](https://metacpan.org/pod/JSON) is installed, the ["TO\_JSON"](#to_json) method will use `JSON::true` and `JSON::false` as boolean value.
-
-By default it returns a compacted format where we omit the `false` on fields like `vendor_consents` and we convert the dates 
-using [ISO\_8601](https://en.wikipedia.org/wiki/ISO_8601). This behaviour can be changed by extra option in the [Parse](https://metacpan.org/pod/Parse) constructor.
 
 # FUNCTIONS
 
@@ -673,11 +334,15 @@ and `TODO.pod` for context.
 
 # SEE ALSO
 
-[GDPR::IAB::TCFv2::Validator](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3AValidator) for declarative compliance checks against a
-parsed TC string -- a higher-level API for the per-vendor / per-purpose
-permission combinations that this module's predicates expose.
+[GDPR::IAB::TCFv2::Parser](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3AParser) for the parser API.
 
-The original documentation of the [TCF v2 from IAB documentation](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md).
+[GDPR::IAB::TCFv2::Validator](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3AValidator) for declarative compliance checks.
+
+[GDPR::IAB::TCFv2::CMPValidator](https://metacpan.org/pod/GDPR%3A%3AIAB%3A%3ATCFv2%3A%3ACMPValidator) for CMP-list validation.
+
+[iabtcfv2](https://metacpan.org/pod/iabtcfv2) for one-liner / shell-use shortcuts.
+
+The original IAB documentation of [TCF v2](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md).
 
 # AUTHOR
 

--- a/TODO.pod
+++ b/TODO.pod
@@ -434,6 +434,40 @@ the caller-owned case for pre-parsed objects.
 
 =back
 
+=head2 v0.510 follow-up -- C<< Validator->Validate >> class-method shortcut
+
+Additive (no BC concerns), tiny: ~5 LOC plus one test subtest.
+
+Add a class-method front door C<< Validator->Validate($tc_string, %opts) >>
+that is shorthand for C<< Validator->new(%opts)->validate($tc_string) >>.
+Mirrors the existing C<< GDPR::IAB::TCFv2::Parser->Parse($s, %opts) >>
+shape and prepares the symmetry that the v0.600 Parser/VendorConsent
+refactor will complete.
+
+Scope:
+
+=over 4
+
+=item *
+
+In F<lib/GDPR/IAB/TCFv2/Validator.pm>, add C<sub Validate> that
+detects class vs instance invocation, builds a transient C<$self>
+on class invocation, and calls C<< $self->validate($tc_string) >>.
+
+=item *
+
+Extend F<t/06-validator.t> with a subtest that exercises both
+C<< Validator->new(%opts)->validate($s) >> and
+C<< Validator->Validate($s, %opts) >> against the same fixture and
+asserts identical C<Validator::Result> output.
+
+=item *
+
+Update C<Validator.pm> POD to document both invocation forms and
+note they are equivalent.
+
+=back
+
 =head2 Phase 6 follow-up -- CMPValidator structured failures (non-blocking)
 
 Round out Phase 6 by migrating C<GDPR::IAB::TCFv2::CMPValidator>

--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -2,897 +2,24 @@ package GDPR::IAB::TCFv2;
 
 use strict;
 use warnings;
-use integer;
-use bytes;
 
-use Carp         qw<carp croak>;
-use MIME::Base64 qw<decode_base64>;
-use POSIX        qw<strftime>;
-
-use GDPR::IAB::TCFv2::BitField;
-use GDPR::IAB::TCFv2::BitUtils qw<is_set
-  get_uint3
-  get_uint6
-  get_uint12
-  get_uint16
-  get_uint36
-  get_char6_pair
->;
-use GDPR::IAB::TCFv2::Publisher;
-use GDPR::IAB::TCFv2::RangeSection;
-use GDPR::IAB::TCFv2::Constants::RestrictionType qw<:all>;
+use GDPR::IAB::TCFv2::Parser;
 
 our $VERSION = "0.401";
 
-use constant {
-  CONSENT_STRING_TCF_V2   => {SEPARATOR => quotemeta q<.>, PREFIX => q<C>, MIN_BYTE_SIZE => 29,},
-  EXPECTED_TCF_V2_VERSION => 2,
-  MAX_SPECIAL_FEATURE_ID  => 12,
-  MAX_PURPOSE_ID          => 24,
-  DATE_FORMAT_ISO_8601    => '%Y-%m-%dT%H:%M:%SZ',
-  TCF_V23_DEADLINE        => 1772236800,                                                          # 2026-02-28T00:00:00Z
-  SEGMENT_TYPES           => {CORE => 0, DISCLOSED_VENDORS => 1, ALLOWED_VENDORS => 2, PUBLISHER_TC => 3,},
-  OFFSETS                 => {
-    SEGMENT_TYPE            => 0,
-    VERSION                 => 0,
-    CREATED                 => 6,
-    LAST_UPDATED            => 42,
-    CMP_ID                  => 78,
-    CMP_VERSION             => 90,
-    CONSENT_SCREEN          => 102,
-    CONSENT_LANGUAGE        => 108,
-    VENDOR_LIST_VERSION     => 120,
-    POLICY_VERSION          => 132,
-    SERVICE_SPECIFIC        => 138,
-    USE_NON_STANDARD_STACKS => 139,
-    SPECIAL_FEATURE_OPT_IN  => 140,
-    PURPOSE_CONSENT_ALLOWED => 152,
-    PURPOSE_LIT_ALLOWED     => 176,
-    PURPOSE_ONE_TREATMENT   => 200,
-    PUBLISHER_COUNTRY_CODE  => 201,
-    VENDOR_CONSENT          => 213,
-  },
-};
-
-use overload q<""> => \&tc_string;
-
-# ABSTRACT: gdpr iab tcf v2.3 consent string parser
-
 sub Parse {
-  my ($klass, $tc_string, %opts) = @_;
-
-  croak 'missing gdpr consent string' unless defined $tc_string && length $tc_string;
-
-  my $segments = _decode_tc_string_segments($tc_string);
-
-  my $strict = !!$opts{strict};
-
-  my %options = (json => $opts{json} || {}, strict => $strict,);
-
-  $options{json}->{date_format}    ||= DATE_FORMAT_ISO_8601;
-  $options{json}->{boolean_values} ||= [_json_false(), _json_true()];
-
-  if (exists $opts{prefetch}) {
-    my $prefetch = $opts{prefetch};
-
-    $prefetch = [$prefetch] if ref($prefetch) ne ref([]);
-
-    $options{prefetch} = $prefetch;
-  }
-
-  my $self = {
-    core_data              => $segments->{core_data},
-    disclosed_vendors_data => $segments->{disclosed_vendors},
-    allowed_vendors_data   => $segments->{allowed_vendors},
-    publisher_tc_data      => $segments->{publisher_tc},
-    options                => \%options,
-    tc_string              => $tc_string,
-
-    vendor_consents             => undef,
-    vendor_legitimate_interests => undef,
-    publisher                   => undef,
-    disclosed_vendors           => undef,
-    allowed_vendors             => undef,
-  };
-
-  bless $self, $klass;
-
-  croak "consent string is not tcf version @{[ EXPECTED_TCF_V2_VERSION ]}"
-    if $strict && $self->version != EXPECTED_TCF_V2_VERSION;
-
-  croak 'invalid vendor list version' if $self->vendor_list_version == 0;
-
-  # TCF v2.3: Mandatory Disclosed Vendors segment check
-  if ($strict && $self->is_v23) {
-    croak "TCF v2.3: Disclosed Vendors segment is mandatory" unless $self->has_vendor_disclosure;
-  }
-
-  my $next_offset = $self->_parse_vendor_section();
-
-  $self->_parse_publisher_section($next_offset);
-
-  $self->_parse_disclosed_vendors();
-  $self->_parse_allowed_vendors();
-
-  return $self;
-}
-
-sub tc_string {
-  my $self = shift;
-
-  return $self->{tc_string};
-}
-
-sub version {
-  my $self = shift;
-
-  return scalar(get_uint6($self->{core_data}, OFFSETS->{VERSION}));
-}
-
-sub created {
-  my $self = shift;
-
-  my ($seconds, $nanoseconds) = $self->_get_epoch(OFFSETS->{CREATED});
-
-  return wantarray ? ($seconds, $nanoseconds) : $seconds;
-}
-
-sub last_updated {
-  my $self = shift;
-
-  my ($seconds, $nanoseconds) = $self->_get_epoch(OFFSETS->{LAST_UPDATED});
-
-  return wantarray ? ($seconds, $nanoseconds) : $seconds;
-}
-
-sub _get_epoch {
-  my ($self, $offset) = @_;
-
-  # Drop the file-level `use integer` for this scope. TCF v2 stores
-  # Created and LastUpdated as a 36-bit deciseconds-since-epoch field,
-  # which exceeds a 32-bit signed IV. On a Perl built without 64-bit
-  # ints (e.g. the armv6l smokers), `get_uint36` returns the value as
-  # an NV via Math::BigInt->numify; the C-integer `/` and `%` of
-  # `use integer` would then coerce that NV back into an overflowing
-  # 32-bit IV. NV float math keeps full precision (36 bits fits in
-  # the 53-bit mantissa) and lands a correct integer result via int().
-  no integer;
-
-  my $deciseconds = scalar(get_uint36($self->{core_data}, $offset));
-
-  my $seconds     = int($deciseconds / 10);
-  my $nanoseconds = int(($deciseconds - $seconds * 10) * 100_000_000);
-
-  return ($seconds, $nanoseconds);
-}
-
-sub cmp_id {
-  my $self = shift;
-
-  return scalar(get_uint12($self->{core_data}, OFFSETS->{CMP_ID}));
-}
-
-sub cmp_version {
-  my $self = shift;
-
-  return scalar(get_uint12($self->{core_data}, OFFSETS->{CMP_VERSION}));
-}
-
-sub consent_screen {
-  my $self = shift;
-
-  return scalar(get_uint6($self->{core_data}, OFFSETS->{CONSENT_SCREEN}));
-}
-
-sub consent_language {
-  my $self = shift;
-
-  return scalar(get_char6_pair($self->{core_data}, OFFSETS->{CONSENT_LANGUAGE}));
-}
-
-sub vendor_list_version {
-  my $self = shift;
-
-  return scalar(get_uint12($self->{core_data}, OFFSETS->{VENDOR_LIST_VERSION}));
-}
-
-sub policy_version {
-  my $self = shift;
-
-  return scalar(get_uint6($self->{core_data}, OFFSETS->{POLICY_VERSION}));
-}
-
-sub is_v22_plus {
-  my $self = shift;
-  return $self->policy_version >= 4 ? 1 : 0;
-}
-
-sub is_v23 {
-  my $self = shift;
-  return $self->policy_version >= 5 ? 1 : 0;
-}
-
-sub is_service_specific {
-  my $self = shift;
-
-  return scalar(is_set($self->{core_data}, OFFSETS->{SERVICE_SPECIFIC}));
-}
-
-sub use_non_standard_stacks {
-  my $self = shift;
-
-  return scalar(is_set($self->{core_data}, OFFSETS->{USE_NON_STANDARD_STACKS}));
-}
-
-sub is_special_feature_opt_in {
-  my ($self, $id) = @_;
-
-  croak "invalid special feature id $id: must be between 1 and @{[ MAX_SPECIAL_FEATURE_ID ]}"
-    if $id < 1 || $id > MAX_SPECIAL_FEATURE_ID;
-
-  return $self->_safe_is_special_feature_opt_in($id);
-}
-
-sub _safe_is_special_feature_opt_in {
-  my ($self, $id) = @_;
-
-  return scalar(is_set($self->{core_data}, OFFSETS->{SPECIAL_FEATURE_OPT_IN} + $id - 1));
-}
-
-sub is_purpose_consent_allowed {
-  my ($self, @ids) = @_;
-
-  $self->_validate_purpose_ids('is_purpose_consent_allowed', @ids);
-
-  foreach my $id (@ids) {
-    return 0 unless $self->_safe_is_purpose_consent_allowed($id);
-  }
-
-  return 1;
-}
-
-sub _safe_is_purpose_consent_allowed {
-  my ($self, $id) = @_;
-  return scalar(is_set($self->{core_data}, OFFSETS->{PURPOSE_CONSENT_ALLOWED} + $id - 1));
-}
-
-sub is_purpose_legitimate_interest_allowed {
-  my ($self, @ids) = @_;
-
-  $self->_validate_purpose_ids('is_purpose_legitimate_interest_allowed', @ids);
-
-  foreach my $id (@ids) {
-
-    # SPEC: Purpose 1 never allows Legitimate Interest
-    return 0 if $id == 1;
-
-    # SPEC: TCF v2.2+ (Policy >= 4) prohibits LI for Purposes 3, 4, 5, and 6
-    if ($self->is_v22_plus) {
-      return 0 if $id >= 3 && $id <= 6;
-    }
-
-    return 0 unless $self->_safe_is_purpose_legitimate_interest_allowed($id);
-  }
-
-  return 1;
-}
-
-sub _validate_purpose_ids {
-  my ($self, $method_name, @ids) = @_;
-
-  croak "method $method_name requires at least one argument" unless @ids;
-
-  foreach my $id (@ids) {
-    croak "invalid purpose id $id: must be between 1 and @{[ MAX_PURPOSE_ID ]}" if $id < 1 || $id > MAX_PURPOSE_ID;
-  }
-}
-
-sub _safe_is_purpose_legitimate_interest_allowed {
-  my ($self, $id) = @_;
-
-  return scalar(is_set($self->{core_data}, OFFSETS->{PURPOSE_LIT_ALLOWED} + $id - 1));
-}
-
-sub purpose_one_treatment {
-  my $self = shift;
-
-  return scalar(is_set($self->{core_data}, OFFSETS->{PURPOSE_ONE_TREATMENT}));
-}
-
-sub publisher_country_code {
-  my $self = shift;
-
-  return scalar(get_char6_pair($self->{core_data}, OFFSETS->{PUBLISHER_COUNTRY_CODE}));
-}
-
-sub max_vendor_id_consent {
-  my $self = shift;
-
-  return $self->{vendor_consents}->max_id;
-}
-
-sub max_vendor_id_legitimate_interest {
-  my $self = shift;
-
-  return $self->{vendor_legitimate_interests}->max_id;
-}
-
-sub vendor_consent {
-  my ($self, $id) = @_;
-
-  return $self->{vendor_consents}->contains($id);
-}
-
-sub vendor_legitimate_interest {
-  my ($self, $id) = @_;
-
-  return $self->{vendor_legitimate_interests}->contains($id);
-}
-
-sub disclosed_vendor {
-  my ($self, $id) = @_;
-
-  return 0 unless defined $self->{disclosed_vendors};
-
-  return $self->{disclosed_vendors}->contains($id);
-}
-
-sub has_vendor_disclosure {
-  my $self = shift;
-  return defined $self->{disclosed_vendors} ? 1 : 0;
-}
-
-sub allowed_vendor {
-  my ($self, $id) = @_;
-
-  return 0 unless defined $self->{allowed_vendors};
-
-  return $self->{allowed_vendors}->contains($id);
-}
-
-sub check_publisher_restriction {
-  my $self = shift;
-
-  my ($purpose_id, $restriction_type, $vendor_id);
-
-  if (scalar(@_) == 6) {
-    my (%opts) = @_;
-
-    $purpose_id       = $opts{purpose_id};
-    $restriction_type = $opts{restriction_type};
-    $vendor_id        = $opts{vendor_id};
-  }
-  else {
-    ($purpose_id, $restriction_type, $vendor_id) = @_;
-  }
-
-  return $self->{publisher}->check_restriction($purpose_id, $restriction_type, $vendor_id);
-}
-
-sub has_publisher_restrictions {
-  my $self = shift;
-  return $self->{publisher} ? $self->{publisher}->has_restrictions : 0;
-}
-
-sub publisher_restrictions {
-  my ($self, $vendor_id) = @_;
-
-  return $self->{publisher}->restrictions($vendor_id);
-}
-
-sub publisher_tc {
-  my $self = shift;
-
-  return $self->{publisher}->publisher_tc;
-}
-
-sub is_vendor_consent_allowed {
-  my ($self, $vendor_id, @args) = @_;
-
-  my ($purpose_ids, $opts) = $self->_parse_vendor_args(@args);
-
-  foreach my $purpose_id (@$purpose_ids) {
-    return 0 unless $self->_check_purpose_id($purpose_id, %$opts);
-  }
-
-  return 0 unless $self->vendor_consent($vendor_id);
-
-  foreach my $purpose_id (@$purpose_ids) {
-    return 0 if $self->check_publisher_restriction($purpose_id, NotAllowed,                $vendor_id);
-    return 0 if $self->check_publisher_restriction($purpose_id, RequireLegitimateInterest, $vendor_id);
-
-    return 0 unless $self->_safe_is_purpose_consent_allowed($purpose_id);
-  }
-
-  return 1;
-}
-
-sub is_vendor_legitimate_interest_allowed {
-  my ($self, $vendor_id, @args) = @_;
-
-  my ($purpose_ids, $opts) = $self->_parse_vendor_args(@args);
-
-  foreach my $purpose_id (@$purpose_ids) {
-    return 0 unless $self->_check_purpose_id($purpose_id, %$opts);
-  }
-
-  return 0 unless $self->vendor_legitimate_interest($vendor_id);
-
-  foreach my $purpose_id (@$purpose_ids) {
-
-    # SPEC: Purpose 1 never allows Legitimate Interest
-    return 0 if $purpose_id == 1;
-
-    # SPEC: TCF v2.2+ (Policy >= 4) prohibits LI for Purposes 3, 4, 5, and 6
-    if ($self->is_v22_plus) {
-      return 0 if $purpose_id >= 3 && $purpose_id <= 6;
-    }
-
-    return 0 if $self->check_publisher_restriction($purpose_id, NotAllowed,     $vendor_id);
-    return 0 if $self->check_publisher_restriction($purpose_id, RequireConsent, $vendor_id);
-
-    return 0 unless $self->_safe_is_purpose_legitimate_interest_allowed($purpose_id);
-  }
-
-  return 1;
-}
-
-sub _parse_vendor_args {
-  my ($self, @args) = @_;
-
-  if (@args && ref $args[-1] eq 'HASH') {
-    my $opts = pop @args;
-    return (\@args, $opts);
-  }
-
-  my @purposes;
-  my %opts;
-  while (@args) {
-    if ($args[0] =~ /^\d+$/) {
-      push @purposes, shift @args;
-    }
-    else {
-      %opts = @args;
-      last;
-    }
-  }
-
-  return (\@purposes, \%opts);
-}
-
-sub is_vendor_allowed_for_any_basis {
-  my ($self, $vendor_id, @args) = @_;
-
-  return 1 if $self->is_vendor_consent_allowed($vendor_id, @args);
-  return 1 if $self->is_vendor_legitimate_interest_allowed($vendor_id, @args);
-
-  return 0;
-}
-
-sub is_vendor_allowed_for_flexible_purpose {
-  my ($self, $vendor_id, $purpose_id, $default_is_li, %opts) = @_;
-
-  return 0 unless $self->_check_purpose_id($purpose_id, %opts);
-
-  # SPEC: TCF v2.2+ (Policy >= 4) prohibits LI for Purposes 3, 4, 5, and 6
-  if ($self->is_v22_plus && $purpose_id >= 3 && $purpose_id <= 6) {
-    $default_is_li = 0;
-  }
-
-  # SPEC: Purpose 1 never allows Legitimate Interest
-  if ($purpose_id == 1) {
-    $default_is_li = 0;
-  }
-
-  if ($self->check_publisher_restriction($purpose_id, RequireConsent, $vendor_id)) {
-    return $self->is_vendor_consent_allowed($vendor_id, $purpose_id, %opts);
-  }
-
-  if ($self->check_publisher_restriction($purpose_id, RequireLegitimateInterest, $vendor_id)) {
-    return $self->is_vendor_legitimate_interest_allowed($vendor_id, $purpose_id, %opts);
-  }
-
-  if ($self->check_publisher_restriction($purpose_id, NotAllowed, $vendor_id)) {
-    return 0;
-  }
-
-  if ($default_is_li) {
-    return $self->is_vendor_legitimate_interest_allowed($vendor_id, $purpose_id, %opts);
-  }
-
-  return $self->is_vendor_consent_allowed($vendor_id, $purpose_id, %opts);
-}
-
-sub _check_purpose_id {
-  my ($self, $id, %opts) = @_;
-
-  my $strict = exists $opts{strict} ? $opts{strict} : $self->{options}->{strict};
-
-  if ($id < 1 || $id > MAX_PURPOSE_ID) {
-    if ($strict) {
-      croak "invalid purpose id $id: must be between 1 and @{[ MAX_PURPOSE_ID ]}";
-    }
-    else {
-      carp "invalid purpose id $id: must be between 1 and @{[ MAX_PURPOSE_ID ]}";
-      return 0;
-    }
-  }
-
-  return 1;
-}
-
-sub _format_date {
-  my ($self, $epoch, $nanoseconds) = @_;
-
-  return $epoch if !!$self->{options}->{json}->{use_epoch};
-
-  my $format = $self->{options}->{json}->{date_format};
-
-  return $format->($epoch, $nanoseconds) if ref($format) eq ref(sub { });
-
-  return strftime($format, gmtime($epoch));
-}
-
-sub _json_true { 1 == 1 }
-
-sub _json_false { 1 == 0 }
-
-sub _format_json_subsection {
-  my ($self, @data) = @_;
-
-  if (!!$self->{options}->{json}->{compact}) {
-    return [map { $_->[0] } grep { $_->[1] } @data];
-  }
-
-  my $verbose = !!$self->{options}->{json}->{verbose};
-
-  return {map { @{$_} } grep { $verbose || $_->[1] } @data};
-}
-
-sub TO_JSON {
-  my $self = shift;
-
-  my %args      = (@_ && ref $_[-1] eq 'HASH') ? %{pop @_} : @_;
-  my $filter_id = $args{vendor_id} || $self->{options}->{json}->{vendor_id};
-
-  my ($false, $true) = @{$self->{options}->{json}->{boolean_values}};
-
-  my $created      = $self->_format_date($self->created);
-  my $last_updated = $self->_format_date($self->last_updated);
-
-  my $purpose_consents = $self->_format_json_subsection(
-    map { [
-      $_ => (
-          $filter_id
-        ? $self->is_vendor_allowed_for_any_basis($filter_id, $_)
-        : $self->_safe_is_purpose_consent_allowed($_)
-      ) ? $true : $false
-    ] } 1 .. MAX_PURPOSE_ID,
-  );
-
-  my $purpose_li = $self->_format_json_subsection(
-    map { [
-      $_ => (
-          $filter_id
-        ? $self->is_vendor_legitimate_interest_allowed($filter_id, $_)
-        : $self->_safe_is_purpose_legitimate_interest_allowed($_)
-      ) ? $true : $false
-    ] } 1 .. MAX_PURPOSE_ID,
-  );
-
-  return {
-    tc_string               => $self->tc_string,
-    version                 => $self->version,
-    created                 => $created,
-    last_updated            => $last_updated,
-    cmp_id                  => $self->cmp_id,
-    cmp_version             => $self->cmp_version,
-    consent_screen          => $self->consent_screen,
-    consent_language        => $self->consent_language,
-    vendor_list_version     => $self->vendor_list_version,
-    policy_version          => $self->policy_version,
-    is_service_specific     => $self->is_service_specific     ? $true : $false,
-    use_non_standard_stacks => $self->use_non_standard_stacks ? $true : $false,
-    purpose_one_treatment   => $self->purpose_one_treatment   ? $true : $false,
-    publisher_country_code  => $self->publisher_country_code,
-    special_features_opt_in => $self->_format_json_subsection(
-      map { [$_ => $self->_safe_is_special_feature_opt_in($_) ? $true : $false] } 1 .. MAX_SPECIAL_FEATURE_ID
-    ),
-    purpose => {consents => $purpose_consents, legitimate_interests => $purpose_li,},
-    vendor  => {
-      consents             => $self->{vendor_consents}->TO_JSON($filter_id),
-      legitimate_interests => $self->{vendor_legitimate_interests}->TO_JSON($filter_id),
-      ($self->{disclosed_vendors} ? (disclosed => $self->{disclosed_vendors}->TO_JSON($filter_id)) : ()),
-      ($self->{allowed_vendors}   ? (allowed   => $self->{allowed_vendors}->TO_JSON($filter_id))   : ()),
-    },
-    publisher => $self->{publisher}->TO_JSON($filter_id),
-  };
-}
-
-sub _decode_tc_string_segments {
-  my $tc_string = shift;
-
-  my ($core, @parts) = split CONSENT_STRING_TCF_V2->{SEPARATOR}, $tc_string;
-
-  my $core_data      = _validate_and_decode_base64($core);
-  my $core_data_size = length($core_data);
-
-  croak
-    "vendor consent strings are at least @{[ CONSENT_STRING_TCF_V2->{MIN_BYTE_SIZE} ]} bytes long (got ${core_data_size} bytes)"
-    if $core_data_size < CONSENT_STRING_TCF_V2->{MIN_BYTE_SIZE};
-
-  my %segments;
-
-  foreach my $part (@parts) {
-    my $decoded = _validate_and_decode_base64($part);
-
-    my $segment_type = get_uint3($decoded, OFFSETS->{SEGMENT_TYPE});
-
-    croak "duplicate segment type $segment_type" if exists $segments{$segment_type};
-
-    $segments{$segment_type} = $decoded;
-  }
-
-  return {
-    core_data         => $core_data,
-    disclosed_vendors => $segments{SEGMENT_TYPES->{DISCLOSED_VENDORS}},
-    allowed_vendors   => $segments{SEGMENT_TYPES->{ALLOWED_VENDORS}},
-    publisher_tc      => $segments{SEGMENT_TYPES->{PUBLISHER_TC}},
-  };
-}
-
-sub _validate_and_decode_base64 {
-  my $s = shift;
-
-  # see: https://www.perlmonks.org/?node_id=775820
-  croak "invalid base64 format" unless $s =~ m{
-        ^
-        (?:[-A-Za-z0-9_]{4})*
-        (?:
-            [-A-Za-z0-9_]{2}[AEIMQUYcgkosw048]
-        |
-            [-A-Za-z0-9_][AQgw]
-        )?
-        \z
-    }x;
-
-  return _decode_base64url($s);
-}
-
-sub _decode_base64url {
-  my $s = shift;
-  $s =~ tr/-_/+\//;
-  $s .= '=' while length($s) % 4;
-  return decode_base64($s);
-}
-
-sub _parse_vendor_section {
-  my $self = shift;
-
-  # parse vendor consent
-
-  my $legitimate_interest_offset = $self->_parse_vendor_consents(OFFSETS->{VENDOR_CONSENT});
-
-  # parse vendor legitimate interest
-
-  my $pub_restriction_offset = $self->_parse_vendor_legitimate_interests($legitimate_interest_offset);
-
-  return $pub_restriction_offset;
-}
-
-sub _parse_vendor_consents {
-  my ($self, $vendor_consent_offset) = @_;
-
-  my ($vendor_consents, $legitimate_interest_offset) = $self->_parse_bitfield_or_range($vendor_consent_offset,);
-
-  $self->{vendor_consents} = $vendor_consents;
-
-  return $legitimate_interest_offset;
-}
-
-sub _parse_vendor_legitimate_interests {
-  my ($self, $legitimate_interest_offset) = @_;
-
-  my $data_size_bits = length($self->{core_data}) << 3;
-
-  my ($vendor_legitimate_interests, $pub_restriction_offset) = $self->_parse_bitfield_or_range(
-    $legitimate_interest_offset,
-    sub {
-      my $legitimate_interest_start = shift;
-
-      croak "invalid consent data: no legitimate interest start position"
-        if $legitimate_interest_start >= $data_size_bits;
-    }
-  );
-
-  $self->{vendor_legitimate_interests} = $vendor_legitimate_interests;
-
-  return $pub_restriction_offset;
-}
-
-sub _parse_publisher_section {
-  my ($self, $pub_restriction_offset) = @_;
-
-  # parse public restrictions
-
-  my $publisher = GDPR::IAB::TCFv2::Publisher->Parse(
-    core_data         => $self->{core_data},
-    core_data_size    => length($self->{core_data}),
-    offset            => $pub_restriction_offset,
-    publisher_tc_data => $self->{publisher_tc_data},
-    options           => $self->{options},
-  );
-
-  $self->{publisher} = $publisher;
-}
-
-sub _parse_disclosed_vendors {
-  my $self = shift;
-
-  return unless defined $self->{disclosed_vendors_data};
-
-  $self->{disclosed_vendors}
-    = $self->_parse_vendor_bitfield_or_range($self->{disclosed_vendors_data}, SEGMENT_TYPES->{DISCLOSED_VENDORS},);
-}
-
-sub _parse_allowed_vendors {
-  my $self = shift;
-
-  return unless defined $self->{allowed_vendors_data};
-
-  $self->{allowed_vendors}
-    = $self->_parse_vendor_bitfield_or_range($self->{allowed_vendors_data}, SEGMENT_TYPES->{ALLOWED_VENDORS},);
-}
-
-# Returns only $vendors_section -- unlike _parse_bitfield_or_range, which
-# yields ($section, $next_offset) so the caller can keep parsing the core
-# segment.  Disclosed/Allowed Vendors live in their own base64 segment
-# with nothing trailing the bitfield/range, so there is no offset to chain.
-sub _parse_vendor_bitfield_or_range {
-  my ($self, $data, $expected_segment_type) = @_;
-
-  # If data looks like a string of 0/1 (from legacy tests), pack it.
-  if ($data =~ /^[01]+$/) {
-    $data = pack("B*", $data);
-  }
-
-  my ($segment_type, $offset) = get_uint3($data, 0);
-
-  croak "invalid segment type $segment_type: expected $expected_segment_type"
-    if defined $expected_segment_type && $segment_type != $expected_segment_type;
-
-  my ($max_id, $next_offset) = get_uint16($data, $offset);
-
-  # Spec: MaxVendorId == 0 means "field unused".  Skip the IsRange flag
-  # and any trailing payload entirely; return an empty BitField so that
-  # has_vendor_disclosure() still reports the segment as present while
-  # contains() always returns false for any vendor id.
-  if ($max_id == 0) {
-    my ($empty_section) = GDPR::IAB::TCFv2::BitField->Parse(
-      data      => $data,
-      data_size => length($data),
-      max_id    => 0,
-      offset    => $next_offset,
-      options   => $self->{options},
-    );
-    return $empty_section;
-  }
-
-  my ($is_range, $bf_offset) = is_set($data, $next_offset);
-
-  my $vendors_section;
-  if ($is_range) {
-    ($vendors_section,) = GDPR::IAB::TCFv2::RangeSection->Parse(
-      data      => $data,
-      data_size => length($data),
-      offset    => $bf_offset,
-      max_id    => $max_id,
-      options   => $self->{options},
-    );
-  }
-  else {
-    ($vendors_section,) = GDPR::IAB::TCFv2::BitField->Parse(
-      data      => $data,
-      data_size => length($data),
-      offset    => $bf_offset,
-      max_id    => $max_id,
-      options   => $self->{options},
-    );
-  }
-
-  return $vendors_section;
-}
-
-sub _parse_bitfield_or_range {
-  my ($self, $offset, $validate_next_offset) = @_;
-
-  my $vendors_section;
-
-  my ($max_id, $next_offset) = get_uint16($self->{core_data}, $offset);
-
-  $validate_next_offset->($next_offset) if defined $validate_next_offset;
-
-  my $is_range;
-
-  ($is_range, $next_offset) = is_set($self->{core_data}, $next_offset,);
-
-  if ($is_range) {
-    ($vendors_section, $next_offset) = $self->_parse_range_section($max_id, $next_offset,);
-  }
-  else {
-    ($vendors_section, $next_offset) = $self->_parse_bitfield($max_id, $next_offset,);
-  }
-
-  return wantarray ? ($vendors_section, $next_offset) : $vendors_section;
-}
-
-sub _parse_range_section {
-  my ($self, $max_id, $range_section_start_offset) = @_;
-
-  my ($range_section, $next_offset) = GDPR::IAB::TCFv2::RangeSection->Parse(
-    data      => $self->{core_data},
-    data_size => length($self->{core_data}),
-    offset    => $range_section_start_offset,
-    max_id    => $max_id,
-    options   => $self->{options},
-  );
-
-  return wantarray ? ($range_section, $next_offset) : $range_section;
-}
-
-sub _parse_bitfield {
-  my ($self, $max_id, $bitfield_start_offset) = @_;
-
-  my ($bitfield, $next_offset) = GDPR::IAB::TCFv2::BitField->Parse(
-    data      => $self->{core_data},
-    data_size => length($self->{core_data}),
-    offset    => $bitfield_start_offset,
-    max_id    => $max_id,
-    options   => $self->{options},
-  );
-
-  return wantarray ? ($bitfield, $next_offset) : $bitfield;
+  shift;    # discard $klass — force GDPR::IAB::TCFv2::Parser as leaf class
+  return GDPR::IAB::TCFv2::Parser->Parse(@_);
 }
 
 sub looksLikeIsConsentVersion2 {
-  my ($gdpr_consent_string) = @_;
-
-  return unless defined $gdpr_consent_string;
-
-  return rindex($gdpr_consent_string, CONSENT_STRING_TCF_V2->{PREFIX}, 0) == 0;
+  my $s = shift;
+  return unless defined $s;
+  return rindex($s, 'C', 0) == 0;
 }
-
-BEGIN {
-  if (my $native_decode_base64url = MIME::Base64->can("decode_base64url")) {
-    no warnings q<redefine>;
-
-    *_decode_base64url = $native_decode_base64url;
-  }
-
-  eval {
-    require JSON;
-
-    if (my $native_json_true = JSON->can("true")) {
-      no warnings q<redefine>;
-
-      *_json_true = $native_json_true;
-    }
-
-    if (my $native_json_false = JSON->can("false")) {
-      no warnings q<redefine>;
-
-      *_json_false = $native_json_false;
-    }
-  };
-}
-
 
 1;
 __END__
-
-=pod
-
-=encoding utf8
 
 =for html <a href="https://cpants.cpanauthors.org/dist/GDPR-IAB-TCFv2"><img src="https://cpants.cpanauthors.org/dist/GDPR-IAB-TCFv2.svg" alt='Kwalitee'/></a>
 
@@ -908,9 +35,13 @@ __END__
 
 =for html <a href="https://metacpan.org/dist/GDPR-IAB-TCFv2"><img src="https://img.shields.io/cpan/v/GDPR-IAB-TCFv2.svg" alt='cpan'/></a>
 
+=pod
+
+=encoding utf8
+
 =head1 NAME
 
-GDPR::IAB::TCFv2 - TCF v2.3 (Transparency & Consent String) parser
+GDPR::IAB::TCFv2 - TCF v2.3 distribution: parser, validator, CMP-validator, and CLI
 
 =head1 PROJECT STATUS
 
@@ -933,75 +64,98 @@ help-wanted list and F<CONTRIBUTING.pod> for the patching workflow.
 
 =head1 SYNOPSIS
 
-The purpose of this package is to parse Transparency & Consent String (TC String) as defined by IAB version 2.
+This module is the documentation hub for the C<GDPR-IAB-TCFv2>
+distribution. It exposes a thin C<Parse> delegate that returns an
+instance of L<GDPR::IAB::TCFv2::Parser>:
 
-    use strict;
-    use warnings;
-    
+    use feature qw<say>;
     use GDPR::IAB::TCFv2;
-    use GDPR::IAB::TCFv2::Constants::Purpose qw<:all>;
-    use GDPR::IAB::TCFv2::Constants::SpecialFeature qw<:all>;
-    use GDPR::IAB::TCFv2::Constants::RestrictionType qw<:all>;
 
     my $consent = GDPR::IAB::TCFv2->Parse(
         'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA.argAC0gAAAAAAAAAAAA'
     );
 
-    use feature qw<say>;
+    say $consent->cmp_id;             # 21
+    say $consent->consent_language;   # 'EN'
+    say $consent->is_v23 ? 'v2.3' : 'older';
 
-    say $consent->version;             # 2
-    say $consent->created;             # epoch 1228644257 or 07/12/2008
-    say $consent->last_updated;        # epoch 1326215413 or 10/01/2012
-    say $consent->cmp_id;              # 21 - Traffective GmbH 
-    say $consent->cmp_version;         # 7
-    say $consent->consent_screen;      # 2
-    say $consent->consent_language;    # "EN"
-    say $consent->vendor_list_version; # 23
+For declarative compliance checks, see L<GDPR::IAB::TCFv2::Validator>.
+For one-liner / shell-use shortcuts, see L</ONE-LINER USAGE> below.
 
-    say "find consent for purpose ids 1, 3, 9 and 10" if 4 == grep {
-        $consent->is_purpose_consent_allowed($_)
-    } ( # constants exported by GDPR::IAB::TCFv2::Constants::Purpose
-        InfoStorageAccess,       #  1
-        PersonalizationProfile,  #  3
-        MarketResearch,          #  9
-        DevelopImprove,          # 10
-    );
+=head1 COMPONENTS
 
-    say "find consent for vendor id 284 (Weborama)" if $consent->vendor_consent(284);
+The distribution ships several pieces. Each link below jumps to the
+relevant module or section.
 
-    # Geolocation exported by GDPR::IAB::TCFv2::Constants::SpecialFeature
-    say "user is opt in for special feature 'Geolocation (id 1)'" 
-        if $consent->is_special_feature_opt_in(Geolocation);
+=head2 L<GDPR::IAB::TCFv2::Parser>
 
-    # NotAllowed exported by GDPR::IAB::TCFv2::Constants::RestrictionType
-    say "publisher restriction for purpose Info Storage Access (1), restriction type NotAllowed (0) for weborama (284)"
-        if $consent->check_publisher_restriction(InfoStorageAccess, NotAllowed, 284);
+The bit-stream parser. C<Parse> returns an instance whose accessors,
+predicates, and JSON serializer answer every question about a TC
+string.
 
-For policy-driven checks against an entire vendor profile (required purposes,
-legal basis, GVL flexibility, optional Disclosed Vendors enforcement),
-use the L<GDPR::IAB::TCFv2::Validator> companion class instead of stringing
-the predicates above together by hand:
+=head2 L<GDPR::IAB::TCFv2::Validator>
 
-    use GDPR::IAB::TCFv2::Validator;
+Declarative compliance checks. C<< $validator->validate($tc_string) >>
+asserts a vendor's presence in the string for a given purpose set on a
+given legal basis.
 
-    my $validator = GDPR::IAB::TCFv2::Validator->new(
-        vendor_id                       => 284,
-        consent_purpose_ids             => [ 1, 3 ],
-        legitimate_interest_purpose_ids => [ 7 ],
-    );
+=head2 L<GDPR::IAB::TCFv2::CMPValidator>
 
-    my $tc_string = '...';
-    my $result = $validator->validate($tc_string);   # fail-fast
-    # ...or $validator->validate_all($tc_string) to accumulate every reason
+Validates that a TC string's C<cmp_id> is registered in the IAB's
+public CMP list (file, JSON, or URL-loaded snapshot).
 
-    if ($result) {
-        # vendor 284 has every required permission
-    }
-    else {
-        warn "compliance failed: $result\n";   # stringifies to the reasons
-        warn $_ for $result->reasons;
-    }
+=head2 L<iabtcfv2> (Perl module)
 
+A pure-exporter short alias for one-liner and shell use. Provides
+C<tcf($s)> and C<validator(%opts)> as importable functions. See
+L</ONE-LINER USAGE>.
+
+=head2 C<bin/iabtcfv2> (CLI)
+
+Subcommand-style command-line utility. C<iabtcfv2 dump> emits parsed
+JSON; C<iabtcfv2 validate> runs declarative compliance checks against
+a vendor identity and a purpose set. See L</COMMAND LINE TOOLS>.
+
+=head2 Docker image
+
+Pre-built Docker Hub image C<peczenyj/gdpr-iab-tcfv2> wraps the CLI
+for portable use. See L</DOCKER USAGE>.
+
+=head1 INCOMPATIBLE CHANGES
+
+=head2 v0.500
+
+The parser implementation moved from C<GDPR::IAB::TCFv2> to a new
+subpackage L<GDPR::IAB::TCFv2::Parser>. The class-method delegate
+remains: C<< GDPR::IAB::TCFv2->Parse(...) >> still works and is the
+recommended entry point. However, the returned object is now blessed
+into C<GDPR::IAB::TCFv2::Parser> rather than C<GDPR::IAB::TCFv2>:
+
+    my $c = GDPR::IAB::TCFv2->Parse($s);
+
+    # Before v0.500:
+    ref($c) eq 'GDPR::IAB::TCFv2'             # true
+    $c->isa('GDPR::IAB::TCFv2')               # true
+
+    # v0.500 and later:
+    ref($c) eq 'GDPR::IAB::TCFv2::Parser'     # true
+    $c->isa('GDPR::IAB::TCFv2::Parser')       # true
+    $c->isa('GDPR::IAB::TCFv2')               # false
+
+Every method call, every JSON output byte, and every CLI behavior is
+unchanged. The break only affects code that asserts the exact class
+name via C<ref>, C<isa>, C<blessed>, C<Storable::thaw>, or similar.
+
+=head1 CONSTRUCTOR
+
+=head2 Parse
+
+C<< GDPR::IAB::TCFv2->Parse($tc_string, %opts) >> is the entry point
+for parsing TCF v2.3 consent strings. It delegates to
+L<< GDPR::IAB::TCFv2::Parser->Parse|GDPR::IAB::TCFv2::Parser/Parse >>
+and returns a C<GDPR::IAB::TCFv2::Parser> object; see that page for
+the full constructor contract (C<strict>, C<prefetch>, C<json>
+options).
 
 =head1 COMMAND LINE TOOLS
 
@@ -1072,6 +226,55 @@ valid, C<1> on any parse or validation failure, C<2> on bad CLI usage.
 
 See C<iabtcfv2 --help> or C<perldoc iabtcfv2> for more details.
 
+For script-free invocation without C<bin/iabtcfv2>, see
+L</ONE-LINER USAGE>.
+
+=head1 ONE-LINER USAGE
+
+The distribution supports C<perl -M...> one-liners directly. The
+L<iabtcfv2> module exports C<tcf($s)> (which returns a
+C<GDPR::IAB::TCFv2::Parser>) and C<validator(%opts)> (which returns a
+C<GDPR::IAB::TCFv2::Validator>), making short scripts even shorter.
+
+=head2 Print one field
+
+    perl -Miabtcfv2 -E 'say tcf(shift)->cmp_id' "$tc"
+
+Equivalent long form (no shortcut module):
+
+    perl -MGDPR::IAB::TCFv2 -E 'say GDPR::IAB::TCFv2->Parse(shift)->cmp_id' "$tc"
+
+=head2 Multi-field TSV
+
+    perl -Miabtcfv2 -E '
+        my $c = tcf(shift);
+        say join("\t", $c->cmp_id, $c->cmp_version, $c->consent_language,
+                       $c->vendor_list_version, $c->policy_version)
+    ' "$tc"
+
+=head2 Emulate `iabtcfv2 dump --pretty` via core JSON::PP
+
+    perl -Miabtcfv2 -MJSON::PP -E '
+        say JSON::PP->new->convert_blessed->canonical->pretty
+                    ->encode(tcf(shift))
+    ' "$tc"
+
+=head2 Stream multiple strings on STDIN
+
+    perl -Miabtcfv2 -nE '
+        chomp;
+        my $c = eval { tcf($_) } or next;
+        say join("\t", $_, $c->cmp_id)
+    ' < strings.txt
+
+=head2 Validate
+
+    perl -Miabtcfv2 -E '
+        my $r = validator(vendor_id => 284, consent_purpose_ids => [1,3])
+                ->validate(shift);
+        say $r ? "ok" : "fail: $r"
+    ' "$tc"
+
 =head1 DOCKER USAGE
 
 This tool is also available as a Docker image on Docker Hub.
@@ -1094,471 +297,9 @@ To type strings manually:
 
 L<GDPR|https://gdpr-info.eu/>: General Data Protection Regulation
 
-L<IAB|https://iabeurope.eu/about-us/>: Interactive Advertising Bureau 
+L<IAB|https://iabeurope.eu/about-us/>: Interactive Advertising Bureau
 
 L<TCF|https://iabeurope.eu/transparency-consent-framework/>: The Transparency & Consent Framework
-
-=head1 CONSTRUCTOR
-
-=head2 Parse
-
-The Parse method will decode and validate a base64 encoded version of the tcf v2 string.
-
-Will return a C<GDPR::IAB::TCFv2> immutable object that allow easy access to different properties.
-
-Will die if can't decode the string.
-
-    use GDPR::IAB::TCFv2;
-
-    my $consent = GDPR::IAB::TCFv2->Parse(
-        'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA.argAC0gAAAAAAAAAAAA'
-    );
-
-or
-
-    use GDPR::IAB::TCFv2;
-
-    my $consent = GDPR::IAB::TCFv2->Parse(
-        'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA.argAC0gAAAAAAAAAAAA',
-        json => {
-            verbose        => 0,
-            compact        => 1,
-            use_epoch      => 0,
-            boolean_values => [ 0, 1 ],
-            date_format    => '%Y%m%d',    # yyymmdd
-        },
-        strict => 1,
-        prefetch => 284,
-    );
-
-Parse may receive an optional hash with the following parameters:
-
-=over
-
-=item *
-
-On C<strict> mode we will validate if the version of the consent string is the version 2 (or die with an exception).
-
-Additionally, for TCF v2.3 strings (Policy Version 5+), C<strict> mode will enforce that the B<Disclosed Vendors> segment is present.
-
-The C<strict> mode is disabled by default.
-
-=item *
-
-The C<prefetch> option receives one (as scalar) or more (as arrayref) vendor ids. 
-
-This is useful when parsing a range based consent string, since we need to visit all ranges to find a particular id.
-
-=item *
-
-C<json> is hashref with the following properties used to customize the json format:
-
-=over 
-
-=item *
-
-C<verbose> changes the json encoding. By default we omit some false values such as C<vendor_consents> to create 
-a compact json representation. With C<verbose> we will present everything. See L</TO_JSON> for more details.
-
-=item *
-
-C<compact> changes the json encoding. All fields that are a mapping of something to a boolean will be changed to an array
-of all elements keys where the value is true. This affects the following fields:  C<special_features_opt_in>,
-C<purpose/consents>, C<purpose/legitimate_interests>, C<vendor/consents> and C<vendor/legitimate_interests>. See L</TO_JSON> for more details.
-
-=item *
-
-C<use_epoch> changes the json encode. By default we format the C<created> and C<last_updated> are converted to string using 
-L<ISO_8601|https://en.wikipedia.org/wiki/ISO_8601>. With C<use_epoch> we will return the unix epoch in seconds.
-See L</TO_JSON> for more details.
-
-=item *
-
-C<boolean_values> if present, expects an arrayref if two elements: the C<false> and the C<true> values to be used in json encoding.
-If omit, we will try to use C<JSON::false> and C<JSON::true> if the package L<JSON> is available, else we will fallback to C<0> and C<1>.
-
-=item *
-
-C<date_format> if present accepts two kinds of value: an C<string> (to be used on C<POSIX::strftime>) or a code reference to a subroutine that
-will be called with two arguments: epoch in seconds and nanoseconds. If omitted the format L<ISO_8601|https://en.wikipedia.org/wiki/ISO_8601> will be used
-except if the option C<use_epoch> is true.
-
-=item *
-
-C<vendor_id> if present, filters the JSON output to only include data for the specific vendor ID. This affects the C<vendor> and C<publisher/restrictions> sections, drastically reducing the size of the output.
-
-=back
-
-=back
-
-=head1 METHODS
-
-=head2 tc_string
-
-Returns the original consent string.
-
-The consent object L<GDPR::IAB::TCFv2> will call this method on string interpolations.
-
-=head2 version
-
-Version number of the encoding format. The value is 2 for this format.
-
-=head2 created
-
-Epoch time format when TC String was created in numeric format. You can easily parse with L<DateTime> if needed.
-
-On scalar context it returns epoch in seconds. On list context it returns epoch in seconds and nanoseconds.
-
-    use GDPR::IAB::TCFv2;
-    use Test::More tests => 3;
-
-    my $consent = GDPR::IAB::TCFv2->Parse(
-        'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA.argAC0gAAAAAAAAAAAA'
-    );
-
-    is $consent->created, 1228644257,
-      'should return the creation epoch 07/12/2008';
-
-    my ( $seconds, $nanoseconds ) = $consent->created;
-    is $seconds, 1228644257,
-        'should return the creation epoch 07/12/2008 on list context';
-    is $nanoseconds, 700000000,
-        'should return the 700000000 nanoseconds of epoch on list context';
-    
-=head2 last_updated
-
-Epoch time format when TC String was last updated in numeric format. You can easily parse with L<DateTime> if needed.
-
-On scalar context it returns epoch in seconds. On list context it returns epoch in seconds and nanoseconds, like the C<created>
-
-=head2 cmp_id
-
-Consent Management Platform ID that last updated the TC String. Is a unique ID will be assigned to each Consent Management Platform.
-
-=head2 cmp_version
-
-Consent Management Platform version of the CMP that last updated this TC String.
-Each change to a CMP should increment their internally assigned version number as a record of which version the user gave consent and transparency was established.
-
-=head2 consent_screen
-
-CMP Screen number at which consent was given for a user with the CMP that last updated this TC String.
-The number is a CMP internal designation and is CmpVersion specific. The number is used for identifying on which screen a user gave consent as a record.
-
-=head2 consent_language
-
-Two-letter L<ISO 639-1|https://en.wikipedia.org/wiki/ISO_639-1> language code in which the CMP UI was presented.
-
-=head2 vendor_list_version
-
-Number corresponds to L<GVL|https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list> vendorListVersion.
-Version of the GVL used to create this TC String.
-
-=head2 policy_version
-
-Version of policy used within L<GVL|https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list>.
-
-From the corresponding field in the GVL that was used for obtaining consent.
-
-=head2 is_v22_plus
-
-Returns true if the TC string uses Policy Version 4 or higher (TCF v2.2+).
-
-=head2 is_v23
-
-Returns true if the TC string uses Policy Version 5 or higher (TCF v2.3).
-
-=head2 is_service_specific
-
-This field must always have the value of 1. When a Vendor encounters a TC String with C<is_service_specific=0> then it is considered invalid.
-
-=head2 use_non_standard_stacks
-
-If true, CMP used non-IAB standard texts during consent gathering.
-
-Setting this to 1 signals to Vendors that a private CMP has modified standard Stack descriptions and/or their translations and/or that a CMP has modified or supplemented standard Illustrations and/or their translations as allowed by the policy..
-
-=head2 is_special_feature_opt_in
-
-If true means Opt in.
-
-The TCF L<Policies|https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/> designates certain Features as "special" which means a CMP must afford the user a means to opt in to their use. These "Special Features" are published and numerically identified in the L<Global Vendor List separately|https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list> from normal Features.
-
-See also: L<GDPR::IAB::TCFv2::Constants::SpecialFeature>.
-
-=head2 is_purpose_consent_allowed
-
-If true means Consent.
-
-The user's consent value for each Purpose established on the legal basis of consent.
-Accepts one or more Purpose IDs. Returns true if all Purposes have consent.
-
-    my $ok = $instance->is_purpose_consent_allowed(1);
-    my $all_ok = $instance->is_purpose_consent_allowed(1, 2, 3);
-
-Throws an exception if no arguments are provided or if an ID is invalid.
-
-See also: L<GDPR::IAB::TCFv2::Constants::Purpose>.
-
-=head2 is_purpose_legitimate_interest_allowed
-
-The user's consent value for each Purpose established on the legal basis of legitimate interest.
-Accepts one or more Purpose IDs. Returns true if all Purposes have legitimate interest.
-
-    my $ok = $instance->is_purpose_legitimate_interest_allowed(1);
-    my $all_ok = $instance->is_purpose_legitimate_interest_allowed(1, 2, 3);
-
-Throws an exception if no arguments are provided or if an ID is invalid.
-
-See also: L<GDPR::IAB::TCFv2::Constants::Purpose>.
-
-=head2 purpose_one_treatment
-
-CMPs can use the C<publisher_country_code> field to indicate the legal jurisdiction the publisher is under to help vendors determine whether the vendor needs consent for Purpose 1.
-
-Returns true if Purpose 1 was NOT disclosed at all.
-
-Returns false if Purpose 1 was disclosed commonly as consent as expected by the L<Policies|https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/>.
-
-=head2 publisher_country_code
-
-Two-letter L<ISO 639-1|https://en.wikipedia.org/wiki/ISO_639-1> language code of the country that determines legislation of reference. 
-Commonly, this corresponds to the country in which the publisher's business entity is established.
-
-=head2 max_vendor_id_consent
-
-The maximum Vendor ID that is represented in the following bit field or range encoding.
-
-Because this section can be a variable length, this indicates the last ID of the section so that a decoder will know when it has reached the end.
-
-=head2 vendor_consent
-
-If true, vendor has consent.
-
-The consent value for each Vendor ID.
-
-    my $ok = $instance->vendor_consent(284); # if true, consent ok for Weborama (vendor id 284).
-
-=head2 max_vendor_id_legitimate_interest
-
-The maximum Vendor ID that is represented in the following bit field or range encoding.
-
-Because this section can be a variable length, this indicates the last ID of the section so that a decoder will know when it has reached the end.
-
-=head2 vendor_legitimate_interest
-
-If true, legitimate interest established.
-
-The legitimate interest value for each Vendor ID
-
-    my $ok = $instance->vendor_legitimate_interest(284); # if true, legitimate interest established for Weborama (vendor id 284).
-
-=head2 disclosed_vendor
-
-If true, the vendor was disclosed to the user (Segment 1 or 5).
-
-    say "Vendor 284 was disclosed" if $consent->disclosed_vendor(284);
-
-=head2 has_vendor_disclosure
-
-Returns true (1) if the TC string contains a "Disclosed Vendors" segment (ID 1 or 5), and false (0) otherwise.
-
-=head2 allowed_vendor
-
-If true, the vendor is in the "Allowed Vendors" segment (Segment 2). This is typically used for service-specific TC strings.
-
-    say "Vendor 284 is allowed" if $consent->allowed_vendor(284);
-
-=head2 is_vendor_consent_allowed
-
-Check if a vendor has consent for a list of purposes, respecting publisher restrictions.
-
-    if ($consent->is_vendor_consent_allowed(284, 1, 2, 3)) {
-        # ...
-    }
-
-=head2 is_vendor_legitimate_interest_allowed
-
-Check if a vendor has legitimate interest for a list of purposes, respecting publisher restrictions.
-
-    if ($consent->is_vendor_legitimate_interest_allowed(284, 2, 4)) {
-        # ...
-    }
-
-=head2 is_vendor_allowed_for_any_basis
-
-Check if a vendor has either consent or legitimate interest for a list of purposes, respecting publisher restrictions.
-
-    if ($consent->is_vendor_allowed_for_any_basis(284, 1, 2)) {
-        # ...
-    }
-
-=head2 has_publisher_restrictions
-
-Returns true (1) if the TC string contains a "Publisher Restrictions" section, and false (0) otherwise.
-
-=head2 check_publisher_restriction
-
-It true, there is a publisher restriction of certain type, for a given purpose id, for a given vendor id:
-
-    # return true if there is publisher restriction to vendor 284 regarding purpose id 1 
-    # with restriction type 0 'Purpose Flatly Not Allowed by Publisher'
-    my $ok = $instance->check_publisher_restriction(1, 0, 284);
-
-or
-
-    my $ok = $instance->check_publisher_restriction(
-        purpose_id       => 1, 
-        restriction_type => 0,  
-        vendor_id        => 284);
-
-Version 2.0 of the Framework introduced the ability for publishers to signal restrictions on how vendors may process personal data. Restrictions can be of two types:
-
-=over
-
-=item *
-
-Purposes. Restrict the purposes for which personal data is processed by a vendor.
-
-=item *
-
-Legal basis. Specify the legal basis upon which a publisher requires a vendor to operate where a vendor has signaled flexibility on legal basis in the GVL.
-
-=back
-
-Publisher restrictions are custom requirements specified by a publisher. In order for vendors to determine if processing is permissible at all for a specific purpose or which legal basis is applicable (in case they signaled flexibility in the GVL) restrictions must be respected.
-
-=over
-
-=item 1
-
-Vendors must always respect a restriction signal that disallows them the processing for a specific purpose regardless of whether or not they have declared that purpose to be "flexible".
-
-=item 2
-
-Vendors that declared a purpose with a default legal basis (consent or legitimate interest respectively) but also declared this purpose as flexible must respect a legal basis restriction if present. That means for example in case they declared a purpose as legitimate interest but also declared that purpose as flexible and there is a legal basis restriction to require consent, they must then check for the consent signal and must not apply the legitimate interest signal.
-
-=back
-
-For the avoidance of doubt:
-
-In case a vendor has declared flexibility for a purpose and there is no legal basis restriction signal it must always apply the default legal basis under which the purpose was registered aside from being registered as flexible. That means if a vendor declared a purpose as legitimate interest and also declared that purpose as flexible it may not apply a "consent" signal without a legal basis restriction signal to require consent.
-
-=head2 is_vendor_allowed_for_flexible_purpose
-
-Check if a vendor is allowed for a flexible purpose, given a default legal basis (true if Legitimate Interest, false if Consent).
-
-    if ($consent->is_vendor_allowed_for_flexible_purpose(284, 2, 1)) {
-        # vendor 284, purpose 2, default is LI
-    }
-
-=head2 publisher_restrictions
-
-Similar to L</check_publisher_restriction> but return an hashref of purpose => { restriction type => bool } for a given vendor.
-
-=head2 publisher_tc
-
-If the consent string has a C<Publisher TC> section, we will decode this section as an instance of L<GDPR::IAB::TCFv2::PublisherTC>.
-
-Will return undefined if there is no C<Publisher TC> section.
-
-=head2 TO_JSON
-
-Will serialize the consent object into a hash reference. The objective is to be used by L<JSON> package.
-
-With option C<convert_blessed>, the encoder will call this method.
-
-    use strict;
-    use warnings;
-    use feature qw<say>;
-
-    use JSON;
-    use DateTime;
-    use DateTimeX::TO_JSON formatter => 'DateTime::Format::RFC3339';
-    use GDPR::IAB::TCFv2;
-
-    my $consent = GDPR::IAB::TCFv2->Parse(
-        'COyiILmOyiILmADACHENAPCAAAAAAAAAAAAAE5QBgALgAqgD8AQACSwEygJyAAAAAA.argAC0gAAAAAAAAAAAA',
-        json => {
-            compact     => 1,
-            date_format => sub { # can be omitted, with DateTimeX::TO_JSON
-                my ( $epoch, $ns ) = @_;
-
-                return DateTime->from_epoch( epoch => $epoch )
-                ->set_nanosecond($ns);
-            },
-        },
-    );
-
-    my $json    = JSON->new->convert_blessed;
-    my $encoded = $json->pretty->encode($consent);
-
-    say $encoded;
-
-Outputs:
-
-    {
-        "tc_string" : "COyiILmOyiILmADACHENAPCAAAAAAAAAAAAAE5QBgALgAqgD8AQACSwEygJyAAAAAA",
-        "consent_language" : "EN",
-        "purpose" : {
-            "consents" : [],
-            "legitimate_interests" : []
-        },
-        "cmp_id" : 3,
-        "purpose_one_treatment" : false,
-        "publisher" : {
-            "consents" : [
-                2,
-                4,
-                6,
-                8,
-                9,
-                10
-            ],
-            "legitimate_interests" : [
-                2,
-                4,
-                5,
-                7,
-                10
-            ],
-            "custom_purposes" : {
-                "consents" : [],
-                "legitimate_interests" : []
-            },
-            "restrictions" : {}
-        },
-        "special_features_opt_in" : [],
-        "last_updated" : "2020-04-27T20:27:54.200000000Z",
-        "use_non_standard_stacks" : false,
-        "policy_version" : 2,
-        "version" : 2,
-        "is_service_specific" : false,
-        "created" : "2020-04-27T20:27:54.200000000Z",
-        "consent_screen" : 7,
-        "vendor_list_version" : 15,
-        "cmp_version" : 2,
-        "publisher_country_code" : "AA",
-        "vendor" : {
-            "consents" : [
-                23,
-                42,
-                126,
-                127,
-                128,
-                587,
-                613,
-                626
-            ],
-            "legitimate_interests" : []
-        }
-    }
-
-
-If L<JSON> is installed, the L</TO_JSON> method will use C<JSON::true> and C<JSON::false> as boolean value.
-
-By default it returns a compacted format where we omit the C<false> on fields like C<vendor_consents> and we convert the dates 
-using L<ISO_8601|https://en.wikipedia.org/wiki/ISO_8601>. This behaviour can be changed by extra option in the L<Parse> constructor.
 
 =head1 FUNCTIONS
 
@@ -1620,11 +361,15 @@ and F<TODO.pod> for context.
 
 =head1 SEE ALSO
 
-L<GDPR::IAB::TCFv2::Validator> for declarative compliance checks against a
-parsed TC string -- a higher-level API for the per-vendor / per-purpose
-permission combinations that this module's predicates expose.
+L<GDPR::IAB::TCFv2::Parser> for the parser API.
 
-The original documentation of the L<TCF v2 from IAB documentation|https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md>.
+L<GDPR::IAB::TCFv2::Validator> for declarative compliance checks.
+
+L<GDPR::IAB::TCFv2::CMPValidator> for CMP-list validation.
+
+L<iabtcfv2> for one-liner / shell-use shortcuts.
+
+The original IAB documentation of L<TCF v2|https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md>.
 
 =head1 AUTHOR
 

--- a/lib/GDPR/IAB/TCFv2/Parser.pm
+++ b/lib/GDPR/IAB/TCFv2/Parser.pm
@@ -1,0 +1,1449 @@
+package GDPR::IAB::TCFv2::Parser;
+
+use strict;
+use warnings;
+use integer;
+use bytes;
+
+use Carp         qw<carp croak>;
+use MIME::Base64 qw<decode_base64>;
+use POSIX        qw<strftime>;
+
+use GDPR::IAB::TCFv2::BitField;
+use GDPR::IAB::TCFv2::BitUtils qw<is_set
+  get_uint3
+  get_uint6
+  get_uint12
+  get_uint16
+  get_uint36
+  get_char6_pair
+>;
+use GDPR::IAB::TCFv2::Publisher;
+use GDPR::IAB::TCFv2::RangeSection;
+use GDPR::IAB::TCFv2::Constants::RestrictionType qw<:all>;
+
+our $VERSION = "0.401";
+
+use constant {
+  CONSENT_STRING_TCF_V2   => {SEPARATOR => quotemeta q<.>, PREFIX => q<C>, MIN_BYTE_SIZE => 29,},
+  EXPECTED_TCF_V2_VERSION => 2,
+  MAX_SPECIAL_FEATURE_ID  => 12,
+  MAX_PURPOSE_ID          => 24,
+  DATE_FORMAT_ISO_8601    => '%Y-%m-%dT%H:%M:%SZ',
+  TCF_V23_DEADLINE        => 1772236800,                                                          # 2026-02-28T00:00:00Z
+  SEGMENT_TYPES           => {CORE => 0, DISCLOSED_VENDORS => 1, ALLOWED_VENDORS => 2, PUBLISHER_TC => 3,},
+  OFFSETS                 => {
+    SEGMENT_TYPE            => 0,
+    VERSION                 => 0,
+    CREATED                 => 6,
+    LAST_UPDATED            => 42,
+    CMP_ID                  => 78,
+    CMP_VERSION             => 90,
+    CONSENT_SCREEN          => 102,
+    CONSENT_LANGUAGE        => 108,
+    VENDOR_LIST_VERSION     => 120,
+    POLICY_VERSION          => 132,
+    SERVICE_SPECIFIC        => 138,
+    USE_NON_STANDARD_STACKS => 139,
+    SPECIAL_FEATURE_OPT_IN  => 140,
+    PURPOSE_CONSENT_ALLOWED => 152,
+    PURPOSE_LIT_ALLOWED     => 176,
+    PURPOSE_ONE_TREATMENT   => 200,
+    PUBLISHER_COUNTRY_CODE  => 201,
+    VENDOR_CONSENT          => 213,
+  },
+};
+
+use overload q<""> => \&tc_string;
+
+# ABSTRACT: gdpr iab tcf v2.3 consent string parser
+
+sub Parse {
+  my ($klass, $tc_string, %opts) = @_;
+
+  croak 'missing gdpr consent string' unless defined $tc_string && length $tc_string;
+
+  my $segments = _decode_tc_string_segments($tc_string);
+
+  my $strict = !!$opts{strict};
+
+  my %options = (json => $opts{json} || {}, strict => $strict,);
+
+  $options{json}->{date_format}    ||= DATE_FORMAT_ISO_8601;
+  $options{json}->{boolean_values} ||= [_json_false(), _json_true()];
+
+  if (exists $opts{prefetch}) {
+    my $prefetch = $opts{prefetch};
+
+    $prefetch = [$prefetch] if ref($prefetch) ne ref([]);
+
+    $options{prefetch} = $prefetch;
+  }
+
+  my $self = {
+    core_data              => $segments->{core_data},
+    disclosed_vendors_data => $segments->{disclosed_vendors},
+    allowed_vendors_data   => $segments->{allowed_vendors},
+    publisher_tc_data      => $segments->{publisher_tc},
+    options                => \%options,
+    tc_string              => $tc_string,
+
+    vendor_consents             => undef,
+    vendor_legitimate_interests => undef,
+    publisher                   => undef,
+    disclosed_vendors           => undef,
+    allowed_vendors             => undef,
+  };
+
+  bless $self, $klass;
+
+  croak "consent string is not tcf version @{[ EXPECTED_TCF_V2_VERSION ]}"
+    if $strict && $self->version != EXPECTED_TCF_V2_VERSION;
+
+  croak 'invalid vendor list version' if $self->vendor_list_version == 0;
+
+  # TCF v2.3: Mandatory Disclosed Vendors segment check
+  if ($strict && $self->is_v23) {
+    croak "TCF v2.3: Disclosed Vendors segment is mandatory" unless $self->has_vendor_disclosure;
+  }
+
+  my $next_offset = $self->_parse_vendor_section();
+
+  $self->_parse_publisher_section($next_offset);
+
+  $self->_parse_disclosed_vendors();
+  $self->_parse_allowed_vendors();
+
+  return $self;
+}
+
+sub tc_string {
+  my $self = shift;
+
+  return $self->{tc_string};
+}
+
+sub version {
+  my $self = shift;
+
+  return scalar(get_uint6($self->{core_data}, OFFSETS->{VERSION}));
+}
+
+sub created {
+  my $self = shift;
+
+  my ($seconds, $nanoseconds) = $self->_get_epoch(OFFSETS->{CREATED});
+
+  return wantarray ? ($seconds, $nanoseconds) : $seconds;
+}
+
+sub last_updated {
+  my $self = shift;
+
+  my ($seconds, $nanoseconds) = $self->_get_epoch(OFFSETS->{LAST_UPDATED});
+
+  return wantarray ? ($seconds, $nanoseconds) : $seconds;
+}
+
+sub _get_epoch {
+  my ($self, $offset) = @_;
+
+  # Drop the file-level `use integer` for this scope. TCF v2 stores
+  # Created and LastUpdated as a 36-bit deciseconds-since-epoch field,
+  # which exceeds a 32-bit signed IV. On a Perl built without 64-bit
+  # ints (e.g. the armv6l smokers), `get_uint36` returns the value as
+  # an NV via Math::BigInt->numify; the C-integer `/` and `%` of
+  # `use integer` would then coerce that NV back into an overflowing
+  # 32-bit IV. NV float math keeps full precision (36 bits fits in
+  # the 53-bit mantissa) and lands a correct integer result via int().
+  no integer;
+
+  my $deciseconds = scalar(get_uint36($self->{core_data}, $offset));
+
+  my $seconds     = int($deciseconds / 10);
+  my $nanoseconds = int(($deciseconds - $seconds * 10) * 100_000_000);
+
+  return ($seconds, $nanoseconds);
+}
+
+sub cmp_id {
+  my $self = shift;
+
+  return scalar(get_uint12($self->{core_data}, OFFSETS->{CMP_ID}));
+}
+
+sub cmp_version {
+  my $self = shift;
+
+  return scalar(get_uint12($self->{core_data}, OFFSETS->{CMP_VERSION}));
+}
+
+sub consent_screen {
+  my $self = shift;
+
+  return scalar(get_uint6($self->{core_data}, OFFSETS->{CONSENT_SCREEN}));
+}
+
+sub consent_language {
+  my $self = shift;
+
+  return scalar(get_char6_pair($self->{core_data}, OFFSETS->{CONSENT_LANGUAGE}));
+}
+
+sub vendor_list_version {
+  my $self = shift;
+
+  return scalar(get_uint12($self->{core_data}, OFFSETS->{VENDOR_LIST_VERSION}));
+}
+
+sub policy_version {
+  my $self = shift;
+
+  return scalar(get_uint6($self->{core_data}, OFFSETS->{POLICY_VERSION}));
+}
+
+sub is_v22_plus {
+  my $self = shift;
+  return $self->policy_version >= 4 ? 1 : 0;
+}
+
+sub is_v23 {
+  my $self = shift;
+  return $self->policy_version >= 5 ? 1 : 0;
+}
+
+sub is_service_specific {
+  my $self = shift;
+
+  return scalar(is_set($self->{core_data}, OFFSETS->{SERVICE_SPECIFIC}));
+}
+
+sub use_non_standard_stacks {
+  my $self = shift;
+
+  return scalar(is_set($self->{core_data}, OFFSETS->{USE_NON_STANDARD_STACKS}));
+}
+
+sub is_special_feature_opt_in {
+  my ($self, $id) = @_;
+
+  croak "invalid special feature id $id: must be between 1 and @{[ MAX_SPECIAL_FEATURE_ID ]}"
+    if $id < 1 || $id > MAX_SPECIAL_FEATURE_ID;
+
+  return $self->_safe_is_special_feature_opt_in($id);
+}
+
+sub _safe_is_special_feature_opt_in {
+  my ($self, $id) = @_;
+
+  return scalar(is_set($self->{core_data}, OFFSETS->{SPECIAL_FEATURE_OPT_IN} + $id - 1));
+}
+
+sub is_purpose_consent_allowed {
+  my ($self, @ids) = @_;
+
+  $self->_validate_purpose_ids('is_purpose_consent_allowed', @ids);
+
+  foreach my $id (@ids) {
+    return 0 unless $self->_safe_is_purpose_consent_allowed($id);
+  }
+
+  return 1;
+}
+
+sub _safe_is_purpose_consent_allowed {
+  my ($self, $id) = @_;
+  return scalar(is_set($self->{core_data}, OFFSETS->{PURPOSE_CONSENT_ALLOWED} + $id - 1));
+}
+
+sub is_purpose_legitimate_interest_allowed {
+  my ($self, @ids) = @_;
+
+  $self->_validate_purpose_ids('is_purpose_legitimate_interest_allowed', @ids);
+
+  foreach my $id (@ids) {
+
+    # SPEC: Purpose 1 never allows Legitimate Interest
+    return 0 if $id == 1;
+
+    # SPEC: TCF v2.2+ (Policy >= 4) prohibits LI for Purposes 3, 4, 5, and 6
+    if ($self->is_v22_plus) {
+      return 0 if $id >= 3 && $id <= 6;
+    }
+
+    return 0 unless $self->_safe_is_purpose_legitimate_interest_allowed($id);
+  }
+
+  return 1;
+}
+
+sub _validate_purpose_ids {
+  my ($self, $method_name, @ids) = @_;
+
+  croak "method $method_name requires at least one argument" unless @ids;
+
+  foreach my $id (@ids) {
+    croak "invalid purpose id $id: must be between 1 and @{[ MAX_PURPOSE_ID ]}" if $id < 1 || $id > MAX_PURPOSE_ID;
+  }
+}
+
+sub _safe_is_purpose_legitimate_interest_allowed {
+  my ($self, $id) = @_;
+
+  return scalar(is_set($self->{core_data}, OFFSETS->{PURPOSE_LIT_ALLOWED} + $id - 1));
+}
+
+sub purpose_one_treatment {
+  my $self = shift;
+
+  return scalar(is_set($self->{core_data}, OFFSETS->{PURPOSE_ONE_TREATMENT}));
+}
+
+sub publisher_country_code {
+  my $self = shift;
+
+  return scalar(get_char6_pair($self->{core_data}, OFFSETS->{PUBLISHER_COUNTRY_CODE}));
+}
+
+sub max_vendor_id_consent {
+  my $self = shift;
+
+  return $self->{vendor_consents}->max_id;
+}
+
+sub max_vendor_id_legitimate_interest {
+  my $self = shift;
+
+  return $self->{vendor_legitimate_interests}->max_id;
+}
+
+sub vendor_consent {
+  my ($self, $id) = @_;
+
+  return $self->{vendor_consents}->contains($id);
+}
+
+sub vendor_legitimate_interest {
+  my ($self, $id) = @_;
+
+  return $self->{vendor_legitimate_interests}->contains($id);
+}
+
+sub disclosed_vendor {
+  my ($self, $id) = @_;
+
+  return 0 unless defined $self->{disclosed_vendors};
+
+  return $self->{disclosed_vendors}->contains($id);
+}
+
+sub has_vendor_disclosure {
+  my $self = shift;
+  return defined $self->{disclosed_vendors} ? 1 : 0;
+}
+
+sub allowed_vendor {
+  my ($self, $id) = @_;
+
+  return 0 unless defined $self->{allowed_vendors};
+
+  return $self->{allowed_vendors}->contains($id);
+}
+
+sub check_publisher_restriction {
+  my $self = shift;
+
+  my ($purpose_id, $restriction_type, $vendor_id);
+
+  if (scalar(@_) == 6) {
+    my (%opts) = @_;
+
+    $purpose_id       = $opts{purpose_id};
+    $restriction_type = $opts{restriction_type};
+    $vendor_id        = $opts{vendor_id};
+  }
+  else {
+    ($purpose_id, $restriction_type, $vendor_id) = @_;
+  }
+
+  return $self->{publisher}->check_restriction($purpose_id, $restriction_type, $vendor_id);
+}
+
+sub has_publisher_restrictions {
+  my $self = shift;
+  return $self->{publisher} ? $self->{publisher}->has_restrictions : 0;
+}
+
+sub publisher_restrictions {
+  my ($self, $vendor_id) = @_;
+
+  return $self->{publisher}->restrictions($vendor_id);
+}
+
+sub publisher_tc {
+  my $self = shift;
+
+  return $self->{publisher}->publisher_tc;
+}
+
+sub is_vendor_consent_allowed {
+  my ($self, $vendor_id, @args) = @_;
+
+  my ($purpose_ids, $opts) = $self->_parse_vendor_args(@args);
+
+  foreach my $purpose_id (@$purpose_ids) {
+    return 0 unless $self->_check_purpose_id($purpose_id, %$opts);
+  }
+
+  return 0 unless $self->vendor_consent($vendor_id);
+
+  foreach my $purpose_id (@$purpose_ids) {
+    return 0 if $self->check_publisher_restriction($purpose_id, NotAllowed,                $vendor_id);
+    return 0 if $self->check_publisher_restriction($purpose_id, RequireLegitimateInterest, $vendor_id);
+
+    return 0 unless $self->_safe_is_purpose_consent_allowed($purpose_id);
+  }
+
+  return 1;
+}
+
+sub is_vendor_legitimate_interest_allowed {
+  my ($self, $vendor_id, @args) = @_;
+
+  my ($purpose_ids, $opts) = $self->_parse_vendor_args(@args);
+
+  foreach my $purpose_id (@$purpose_ids) {
+    return 0 unless $self->_check_purpose_id($purpose_id, %$opts);
+  }
+
+  return 0 unless $self->vendor_legitimate_interest($vendor_id);
+
+  foreach my $purpose_id (@$purpose_ids) {
+
+    # SPEC: Purpose 1 never allows Legitimate Interest
+    return 0 if $purpose_id == 1;
+
+    # SPEC: TCF v2.2+ (Policy >= 4) prohibits LI for Purposes 3, 4, 5, and 6
+    if ($self->is_v22_plus) {
+      return 0 if $purpose_id >= 3 && $purpose_id <= 6;
+    }
+
+    return 0 if $self->check_publisher_restriction($purpose_id, NotAllowed,     $vendor_id);
+    return 0 if $self->check_publisher_restriction($purpose_id, RequireConsent, $vendor_id);
+
+    return 0 unless $self->_safe_is_purpose_legitimate_interest_allowed($purpose_id);
+  }
+
+  return 1;
+}
+
+sub _parse_vendor_args {
+  my ($self, @args) = @_;
+
+  if (@args && ref $args[-1] eq 'HASH') {
+    my $opts = pop @args;
+    return (\@args, $opts);
+  }
+
+  my @purposes;
+  my %opts;
+  while (@args) {
+    if ($args[0] =~ /^\d+$/) {
+      push @purposes, shift @args;
+    }
+    else {
+      %opts = @args;
+      last;
+    }
+  }
+
+  return (\@purposes, \%opts);
+}
+
+sub is_vendor_allowed_for_any_basis {
+  my ($self, $vendor_id, @args) = @_;
+
+  return 1 if $self->is_vendor_consent_allowed($vendor_id, @args);
+  return 1 if $self->is_vendor_legitimate_interest_allowed($vendor_id, @args);
+
+  return 0;
+}
+
+sub is_vendor_allowed_for_flexible_purpose {
+  my ($self, $vendor_id, $purpose_id, $default_is_li, %opts) = @_;
+
+  return 0 unless $self->_check_purpose_id($purpose_id, %opts);
+
+  # SPEC: TCF v2.2+ (Policy >= 4) prohibits LI for Purposes 3, 4, 5, and 6
+  if ($self->is_v22_plus && $purpose_id >= 3 && $purpose_id <= 6) {
+    $default_is_li = 0;
+  }
+
+  # SPEC: Purpose 1 never allows Legitimate Interest
+  if ($purpose_id == 1) {
+    $default_is_li = 0;
+  }
+
+  if ($self->check_publisher_restriction($purpose_id, RequireConsent, $vendor_id)) {
+    return $self->is_vendor_consent_allowed($vendor_id, $purpose_id, %opts);
+  }
+
+  if ($self->check_publisher_restriction($purpose_id, RequireLegitimateInterest, $vendor_id)) {
+    return $self->is_vendor_legitimate_interest_allowed($vendor_id, $purpose_id, %opts);
+  }
+
+  if ($self->check_publisher_restriction($purpose_id, NotAllowed, $vendor_id)) {
+    return 0;
+  }
+
+  if ($default_is_li) {
+    return $self->is_vendor_legitimate_interest_allowed($vendor_id, $purpose_id, %opts);
+  }
+
+  return $self->is_vendor_consent_allowed($vendor_id, $purpose_id, %opts);
+}
+
+sub _check_purpose_id {
+  my ($self, $id, %opts) = @_;
+
+  my $strict = exists $opts{strict} ? $opts{strict} : $self->{options}->{strict};
+
+  if ($id < 1 || $id > MAX_PURPOSE_ID) {
+    if ($strict) {
+      croak "invalid purpose id $id: must be between 1 and @{[ MAX_PURPOSE_ID ]}";
+    }
+    else {
+      carp "invalid purpose id $id: must be between 1 and @{[ MAX_PURPOSE_ID ]}";
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+sub _format_date {
+  my ($self, $epoch, $nanoseconds) = @_;
+
+  return $epoch if !!$self->{options}->{json}->{use_epoch};
+
+  my $format = $self->{options}->{json}->{date_format};
+
+  return $format->($epoch, $nanoseconds) if ref($format) eq ref(sub { });
+
+  return strftime($format, gmtime($epoch));
+}
+
+sub _json_true { 1 == 1 }
+
+sub _json_false { 1 == 0 }
+
+sub _format_json_subsection {
+  my ($self, @data) = @_;
+
+  if (!!$self->{options}->{json}->{compact}) {
+    return [map { $_->[0] } grep { $_->[1] } @data];
+  }
+
+  my $verbose = !!$self->{options}->{json}->{verbose};
+
+  return {map { @{$_} } grep { $verbose || $_->[1] } @data};
+}
+
+sub TO_JSON {
+  my $self = shift;
+
+  my %args      = (@_ && ref $_[-1] eq 'HASH') ? %{pop @_} : @_;
+  my $filter_id = $args{vendor_id} || $self->{options}->{json}->{vendor_id};
+
+  my ($false, $true) = @{$self->{options}->{json}->{boolean_values}};
+
+  my $created      = $self->_format_date($self->created);
+  my $last_updated = $self->_format_date($self->last_updated);
+
+  my $purpose_consents = $self->_format_json_subsection(
+    map { [
+      $_ => (
+          $filter_id
+        ? $self->is_vendor_allowed_for_any_basis($filter_id, $_)
+        : $self->_safe_is_purpose_consent_allowed($_)
+      ) ? $true : $false
+    ] } 1 .. MAX_PURPOSE_ID,
+  );
+
+  my $purpose_li = $self->_format_json_subsection(
+    map { [
+      $_ => (
+          $filter_id
+        ? $self->is_vendor_legitimate_interest_allowed($filter_id, $_)
+        : $self->_safe_is_purpose_legitimate_interest_allowed($_)
+      ) ? $true : $false
+    ] } 1 .. MAX_PURPOSE_ID,
+  );
+
+  return {
+    tc_string               => $self->tc_string,
+    version                 => $self->version,
+    created                 => $created,
+    last_updated            => $last_updated,
+    cmp_id                  => $self->cmp_id,
+    cmp_version             => $self->cmp_version,
+    consent_screen          => $self->consent_screen,
+    consent_language        => $self->consent_language,
+    vendor_list_version     => $self->vendor_list_version,
+    policy_version          => $self->policy_version,
+    is_service_specific     => $self->is_service_specific     ? $true : $false,
+    use_non_standard_stacks => $self->use_non_standard_stacks ? $true : $false,
+    purpose_one_treatment   => $self->purpose_one_treatment   ? $true : $false,
+    publisher_country_code  => $self->publisher_country_code,
+    special_features_opt_in => $self->_format_json_subsection(
+      map { [$_ => $self->_safe_is_special_feature_opt_in($_) ? $true : $false] } 1 .. MAX_SPECIAL_FEATURE_ID
+    ),
+    purpose => {consents => $purpose_consents, legitimate_interests => $purpose_li,},
+    vendor  => {
+      consents             => $self->{vendor_consents}->TO_JSON($filter_id),
+      legitimate_interests => $self->{vendor_legitimate_interests}->TO_JSON($filter_id),
+      ($self->{disclosed_vendors} ? (disclosed => $self->{disclosed_vendors}->TO_JSON($filter_id)) : ()),
+      ($self->{allowed_vendors}   ? (allowed   => $self->{allowed_vendors}->TO_JSON($filter_id))   : ()),
+    },
+    publisher => $self->{publisher}->TO_JSON($filter_id),
+  };
+}
+
+sub _decode_tc_string_segments {
+  my $tc_string = shift;
+
+  my ($core, @parts) = split CONSENT_STRING_TCF_V2->{SEPARATOR}, $tc_string;
+
+  my $core_data      = _validate_and_decode_base64($core);
+  my $core_data_size = length($core_data);
+
+  croak
+    "vendor consent strings are at least @{[ CONSENT_STRING_TCF_V2->{MIN_BYTE_SIZE} ]} bytes long (got ${core_data_size} bytes)"
+    if $core_data_size < CONSENT_STRING_TCF_V2->{MIN_BYTE_SIZE};
+
+  my %segments;
+
+  foreach my $part (@parts) {
+    my $decoded = _validate_and_decode_base64($part);
+
+    my $segment_type = get_uint3($decoded, OFFSETS->{SEGMENT_TYPE});
+
+    croak "duplicate segment type $segment_type" if exists $segments{$segment_type};
+
+    $segments{$segment_type} = $decoded;
+  }
+
+  return {
+    core_data         => $core_data,
+    disclosed_vendors => $segments{SEGMENT_TYPES->{DISCLOSED_VENDORS}},
+    allowed_vendors   => $segments{SEGMENT_TYPES->{ALLOWED_VENDORS}},
+    publisher_tc      => $segments{SEGMENT_TYPES->{PUBLISHER_TC}},
+  };
+}
+
+sub _validate_and_decode_base64 {
+  my $s = shift;
+
+  # see: https://www.perlmonks.org/?node_id=775820
+  croak "invalid base64 format" unless $s =~ m{
+        ^
+        (?:[-A-Za-z0-9_]{4})*
+        (?:
+            [-A-Za-z0-9_]{2}[AEIMQUYcgkosw048]
+        |
+            [-A-Za-z0-9_][AQgw]
+        )?
+        \z
+    }x;
+
+  return _decode_base64url($s);
+}
+
+sub _decode_base64url {
+  my $s = shift;
+  $s =~ tr/-_/+\//;
+  $s .= '=' while length($s) % 4;
+  return decode_base64($s);
+}
+
+sub _parse_vendor_section {
+  my $self = shift;
+
+  # parse vendor consent
+
+  my $legitimate_interest_offset = $self->_parse_vendor_consents(OFFSETS->{VENDOR_CONSENT});
+
+  # parse vendor legitimate interest
+
+  my $pub_restriction_offset = $self->_parse_vendor_legitimate_interests($legitimate_interest_offset);
+
+  return $pub_restriction_offset;
+}
+
+sub _parse_vendor_consents {
+  my ($self, $vendor_consent_offset) = @_;
+
+  my ($vendor_consents, $legitimate_interest_offset) = $self->_parse_bitfield_or_range($vendor_consent_offset,);
+
+  $self->{vendor_consents} = $vendor_consents;
+
+  return $legitimate_interest_offset;
+}
+
+sub _parse_vendor_legitimate_interests {
+  my ($self, $legitimate_interest_offset) = @_;
+
+  my $data_size_bits = length($self->{core_data}) << 3;
+
+  my ($vendor_legitimate_interests, $pub_restriction_offset) = $self->_parse_bitfield_or_range(
+    $legitimate_interest_offset,
+    sub {
+      my $legitimate_interest_start = shift;
+
+      croak "invalid consent data: no legitimate interest start position"
+        if $legitimate_interest_start >= $data_size_bits;
+    }
+  );
+
+  $self->{vendor_legitimate_interests} = $vendor_legitimate_interests;
+
+  return $pub_restriction_offset;
+}
+
+sub _parse_publisher_section {
+  my ($self, $pub_restriction_offset) = @_;
+
+  # parse public restrictions
+
+  my $publisher = GDPR::IAB::TCFv2::Publisher->Parse(
+    core_data         => $self->{core_data},
+    core_data_size    => length($self->{core_data}),
+    offset            => $pub_restriction_offset,
+    publisher_tc_data => $self->{publisher_tc_data},
+    options           => $self->{options},
+  );
+
+  $self->{publisher} = $publisher;
+}
+
+sub _parse_disclosed_vendors {
+  my $self = shift;
+
+  return unless defined $self->{disclosed_vendors_data};
+
+  $self->{disclosed_vendors}
+    = $self->_parse_vendor_bitfield_or_range($self->{disclosed_vendors_data}, SEGMENT_TYPES->{DISCLOSED_VENDORS},);
+}
+
+sub _parse_allowed_vendors {
+  my $self = shift;
+
+  return unless defined $self->{allowed_vendors_data};
+
+  $self->{allowed_vendors}
+    = $self->_parse_vendor_bitfield_or_range($self->{allowed_vendors_data}, SEGMENT_TYPES->{ALLOWED_VENDORS},);
+}
+
+# Returns only $vendors_section -- unlike _parse_bitfield_or_range, which
+# yields ($section, $next_offset) so the caller can keep parsing the core
+# segment.  Disclosed/Allowed Vendors live in their own base64 segment
+# with nothing trailing the bitfield/range, so there is no offset to chain.
+sub _parse_vendor_bitfield_or_range {
+  my ($self, $data, $expected_segment_type) = @_;
+
+  # If data looks like a string of 0/1 (from legacy tests), pack it.
+  if ($data =~ /^[01]+$/) {
+    $data = pack("B*", $data);
+  }
+
+  my ($segment_type, $offset) = get_uint3($data, 0);
+
+  croak "invalid segment type $segment_type: expected $expected_segment_type"
+    if defined $expected_segment_type && $segment_type != $expected_segment_type;
+
+  my ($max_id, $next_offset) = get_uint16($data, $offset);
+
+  # Spec: MaxVendorId == 0 means "field unused".  Skip the IsRange flag
+  # and any trailing payload entirely; return an empty BitField so that
+  # has_vendor_disclosure() still reports the segment as present while
+  # contains() always returns false for any vendor id.
+  if ($max_id == 0) {
+    my ($empty_section) = GDPR::IAB::TCFv2::BitField->Parse(
+      data      => $data,
+      data_size => length($data),
+      max_id    => 0,
+      offset    => $next_offset,
+      options   => $self->{options},
+    );
+    return $empty_section;
+  }
+
+  my ($is_range, $bf_offset) = is_set($data, $next_offset);
+
+  my $vendors_section;
+  if ($is_range) {
+    ($vendors_section,) = GDPR::IAB::TCFv2::RangeSection->Parse(
+      data      => $data,
+      data_size => length($data),
+      offset    => $bf_offset,
+      max_id    => $max_id,
+      options   => $self->{options},
+    );
+  }
+  else {
+    ($vendors_section,) = GDPR::IAB::TCFv2::BitField->Parse(
+      data      => $data,
+      data_size => length($data),
+      offset    => $bf_offset,
+      max_id    => $max_id,
+      options   => $self->{options},
+    );
+  }
+
+  return $vendors_section;
+}
+
+sub _parse_bitfield_or_range {
+  my ($self, $offset, $validate_next_offset) = @_;
+
+  my $vendors_section;
+
+  my ($max_id, $next_offset) = get_uint16($self->{core_data}, $offset);
+
+  $validate_next_offset->($next_offset) if defined $validate_next_offset;
+
+  my $is_range;
+
+  ($is_range, $next_offset) = is_set($self->{core_data}, $next_offset,);
+
+  if ($is_range) {
+    ($vendors_section, $next_offset) = $self->_parse_range_section($max_id, $next_offset,);
+  }
+  else {
+    ($vendors_section, $next_offset) = $self->_parse_bitfield($max_id, $next_offset,);
+  }
+
+  return wantarray ? ($vendors_section, $next_offset) : $vendors_section;
+}
+
+sub _parse_range_section {
+  my ($self, $max_id, $range_section_start_offset) = @_;
+
+  my ($range_section, $next_offset) = GDPR::IAB::TCFv2::RangeSection->Parse(
+    data      => $self->{core_data},
+    data_size => length($self->{core_data}),
+    offset    => $range_section_start_offset,
+    max_id    => $max_id,
+    options   => $self->{options},
+  );
+
+  return wantarray ? ($range_section, $next_offset) : $range_section;
+}
+
+sub _parse_bitfield {
+  my ($self, $max_id, $bitfield_start_offset) = @_;
+
+  my ($bitfield, $next_offset) = GDPR::IAB::TCFv2::BitField->Parse(
+    data      => $self->{core_data},
+    data_size => length($self->{core_data}),
+    offset    => $bitfield_start_offset,
+    max_id    => $max_id,
+    options   => $self->{options},
+  );
+
+  return wantarray ? ($bitfield, $next_offset) : $bitfield;
+}
+
+BEGIN {
+  if (my $native_decode_base64url = MIME::Base64->can("decode_base64url")) {
+    no warnings q<redefine>;
+
+    *_decode_base64url = $native_decode_base64url;
+  }
+
+  eval {
+    require JSON;
+
+    if (my $native_json_true = JSON->can("true")) {
+      no warnings q<redefine>;
+
+      *_json_true = $native_json_true;
+    }
+
+    if (my $native_json_false = JSON->can("false")) {
+      no warnings q<redefine>;
+
+      *_json_false = $native_json_false;
+    }
+  };
+}
+
+
+1;
+__END__
+
+=pod
+
+=encoding utf8
+
+=head1 NAME
+
+GDPR::IAB::TCFv2::Parser - bit-stream parser for TCF v2.3 consent strings
+
+=head1 SYNOPSIS
+
+The purpose of this package is to parse Transparency & Consent String (TC String) as defined by IAB version 2.
+
+    use strict;
+    use warnings;
+
+    use GDPR::IAB::TCFv2::Parser;
+    use GDPR::IAB::TCFv2::Constants::Purpose qw<:all>;
+    use GDPR::IAB::TCFv2::Constants::SpecialFeature qw<:all>;
+    use GDPR::IAB::TCFv2::Constants::RestrictionType qw<:all>;
+
+    my $consent = GDPR::IAB::TCFv2::Parser->Parse(
+        'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA.argAC0gAAAAAAAAAAAA'
+    );
+
+    use feature qw<say>;
+
+    say $consent->version;             # 2
+    say $consent->created;             # epoch 1228644257 or 07/12/2008
+    say $consent->last_updated;        # epoch 1326215413 or 10/01/2012
+    say $consent->cmp_id;              # 21 - Traffective GmbH
+    say $consent->cmp_version;         # 7
+    say $consent->consent_screen;      # 2
+    say $consent->consent_language;    # "EN"
+    say $consent->vendor_list_version; # 23
+
+    say "find consent for purpose ids 1, 3, 9 and 10" if 4 == grep {
+        $consent->is_purpose_consent_allowed($_)
+    } ( # constants exported by GDPR::IAB::TCFv2::Constants::Purpose
+        InfoStorageAccess,       #  1
+        PersonalizationProfile,  #  3
+        MarketResearch,          #  9
+        DevelopImprove,          # 10
+    );
+
+    say "find consent for vendor id 284 (Weborama)" if $consent->vendor_consent(284);
+
+    # Geolocation exported by GDPR::IAB::TCFv2::Constants::SpecialFeature
+    say "user is opt in for special feature 'Geolocation (id 1)'"
+        if $consent->is_special_feature_opt_in(Geolocation);
+
+    # NotAllowed exported by GDPR::IAB::TCFv2::Constants::RestrictionType
+    say "publisher restriction for purpose Info Storage Access (1), restriction type NotAllowed (0) for weborama (284)"
+        if $consent->check_publisher_restriction(InfoStorageAccess, NotAllowed, 284);
+
+For policy-driven checks against an entire vendor profile (required purposes,
+legal basis, GVL flexibility, optional Disclosed Vendors enforcement),
+use the L<GDPR::IAB::TCFv2::Validator> companion class instead of stringing
+the predicates above together by hand:
+
+    use GDPR::IAB::TCFv2::Validator;
+
+    my $validator = GDPR::IAB::TCFv2::Validator->new(
+        vendor_id                       => 284,
+        consent_purpose_ids             => [ 1, 3 ],
+        legitimate_interest_purpose_ids => [ 7 ],
+    );
+
+    my $tc_string = '...';
+    my $result = $validator->validate($tc_string);   # fail-fast
+    # ...or $validator->validate_all($tc_string) to accumulate every reason
+
+    if ($result) {
+        # vendor 284 has every required permission
+    }
+    else {
+        warn "compliance failed: $result\n";   # stringifies to the reasons
+        warn $_ for $result->reasons;
+    }
+
+=head1 DESCRIPTION
+
+C<GDPR::IAB::TCFv2::Parser> is the single-pass bit-stream decoder for
+TCF v2.3 (and v2.0/v2.2) consent strings, as specified by the IAB. It
+is normally constructed via the L<GDPR::IAB::TCFv2> hub
+(C<< GDPR::IAB::TCFv2->Parse(...) >>) but can be called directly when
+you want to bypass the hub's facade.
+
+The returned object exposes every accessor, predicate, and JSON
+serializer documented below.
+
+=head1 CONSTRUCTOR
+
+=head2 Parse
+
+The Parse method will decode and validate a base64 encoded version of the tcf v2 string.
+
+Will return a C<GDPR::IAB::TCFv2::Parser> immutable object that allow easy access to different properties.
+
+Will die if can't decode the string.
+
+    use GDPR::IAB::TCFv2::Parser;
+
+    my $consent = GDPR::IAB::TCFv2::Parser->Parse(
+        'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA.argAC0gAAAAAAAAAAAA'
+    );
+
+or
+
+    use GDPR::IAB::TCFv2::Parser;
+
+    my $consent = GDPR::IAB::TCFv2::Parser->Parse(
+        'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA.argAC0gAAAAAAAAAAAA',
+        json => {
+            verbose        => 0,
+            compact        => 1,
+            use_epoch      => 0,
+            boolean_values => [ 0, 1 ],
+            date_format    => '%Y%m%d',    # yyymmdd
+        },
+        strict => 1,
+        prefetch => 284,
+    );
+
+Parse may receive an optional hash with the following parameters:
+
+=over
+
+=item *
+
+On C<strict> mode we will validate if the version of the consent string is the version 2 (or die with an exception).
+
+Additionally, for TCF v2.3 strings (Policy Version 5+), C<strict> mode will enforce that the B<Disclosed Vendors> segment is present.
+
+The C<strict> mode is disabled by default.
+
+=item *
+
+The C<prefetch> option receives one (as scalar) or more (as arrayref) vendor ids.
+
+This is useful when parsing a range based consent string, since we need to visit all ranges to find a particular id.
+
+=item *
+
+C<json> is hashref with the following properties used to customize the json format:
+
+=over
+
+=item *
+
+C<verbose> changes the json encoding. By default we omit some false values such as C<vendor_consents> to create
+a compact json representation. With C<verbose> we will present everything. See L</TO_JSON> for more details.
+
+=item *
+
+C<compact> changes the json encoding. All fields that are a mapping of something to a boolean will be changed to an array
+of all elements keys where the value is true. This affects the following fields:  C<special_features_opt_in>,
+C<purpose/consents>, C<purpose/legitimate_interests>, C<vendor/consents> and C<vendor/legitimate_interests>. See L</TO_JSON> for more details.
+
+=item *
+
+C<use_epoch> changes the json encode. By default we format the C<created> and C<last_updated> are converted to string using
+L<ISO_8601|https://en.wikipedia.org/wiki/ISO_8601>. With C<use_epoch> we will return the unix epoch in seconds.
+See L</TO_JSON> for more details.
+
+=item *
+
+C<boolean_values> if present, expects an arrayref if two elements: the C<false> and the C<true> values to be used in json encoding.
+If omit, we will try to use C<JSON::false> and C<JSON::true> if the package L<JSON> is available, else we will fallback to C<0> and C<1>.
+
+=item *
+
+C<date_format> if present accepts two kinds of value: an C<string> (to be used on C<POSIX::strftime>) or a code reference to a subroutine that
+will be called with two arguments: epoch in seconds and nanoseconds. If omitted the format L<ISO_8601|https://en.wikipedia.org/wiki/ISO_8601> will be used
+except if the option C<use_epoch> is true.
+
+=item *
+
+C<vendor_id> if present, filters the JSON output to only include data for the specific vendor ID. This affects the C<vendor> and C<publisher/restrictions> sections, drastically reducing the size of the output.
+
+=back
+
+=back
+
+=head1 METHODS
+
+=head2 tc_string
+
+Returns the original consent string.
+
+The consent object L<GDPR::IAB::TCFv2::Parser> will call this method on string interpolations.
+
+=head2 version
+
+Version number of the encoding format. The value is 2 for this format.
+
+=head2 created
+
+Epoch time format when TC String was created in numeric format. You can easily parse with L<DateTime> if needed.
+
+On scalar context it returns epoch in seconds. On list context it returns epoch in seconds and nanoseconds.
+
+    use GDPR::IAB::TCFv2::Parser;
+    use Test::More tests => 3;
+
+    my $consent = GDPR::IAB::TCFv2::Parser->Parse(
+        'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA.argAC0gAAAAAAAAAAAA'
+    );
+
+    is $consent->created, 1228644257,
+      'should return the creation epoch 07/12/2008';
+
+    my ( $seconds, $nanoseconds ) = $consent->created;
+    is $seconds, 1228644257,
+        'should return the creation epoch 07/12/2008 on list context';
+    is $nanoseconds, 700000000,
+        'should return the 700000000 nanoseconds of epoch on list context';
+
+=head2 last_updated
+
+Epoch time format when TC String was last updated in numeric format. You can easily parse with L<DateTime> if needed.
+
+On scalar context it returns epoch in seconds. On list context it returns epoch in seconds and nanoseconds, like the C<created>
+
+=head2 cmp_id
+
+Consent Management Platform ID that last updated the TC String. Is a unique ID will be assigned to each Consent Management Platform.
+
+=head2 cmp_version
+
+Consent Management Platform version of the CMP that last updated this TC String.
+Each change to a CMP should increment their internally assigned version number as a record of which version the user gave consent and transparency was established.
+
+=head2 consent_screen
+
+CMP Screen number at which consent was given for a user with the CMP that last updated this TC String.
+The number is a CMP internal designation and is CmpVersion specific. The number is used for identifying on which screen a user gave consent as a record.
+
+=head2 consent_language
+
+Two-letter L<ISO 639-1|https://en.wikipedia.org/wiki/ISO_639-1> language code in which the CMP UI was presented.
+
+=head2 vendor_list_version
+
+Number corresponds to L<GVL|https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list> vendorListVersion.
+Version of the GVL used to create this TC String.
+
+=head2 policy_version
+
+Version of policy used within L<GVL|https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list>.
+
+From the corresponding field in the GVL that was used for obtaining consent.
+
+=head2 is_v22_plus
+
+Returns true if the TC string uses Policy Version 4 or higher (TCF v2.2+).
+
+=head2 is_v23
+
+Returns true if the TC string uses Policy Version 5 or higher (TCF v2.3).
+
+=head2 is_service_specific
+
+This field must always have the value of 1. When a Vendor encounters a TC String with C<is_service_specific=0> then it is considered invalid.
+
+=head2 use_non_standard_stacks
+
+If true, CMP used non-IAB standard texts during consent gathering.
+
+Setting this to 1 signals to Vendors that a private CMP has modified standard Stack descriptions and/or their translations and/or that a CMP has modified or supplemented standard Illustrations and/or their translations as allowed by the policy..
+
+=head2 is_special_feature_opt_in
+
+If true means Opt in.
+
+The TCF L<Policies|https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/> designates certain Features as "special" which means a CMP must afford the user a means to opt in to their use. These "Special Features" are published and numerically identified in the L<Global Vendor List separately|https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list> from normal Features.
+
+See also: L<GDPR::IAB::TCFv2::Constants::SpecialFeature>.
+
+=head2 is_purpose_consent_allowed
+
+If true means Consent.
+
+The user's consent value for each Purpose established on the legal basis of consent.
+Accepts one or more Purpose IDs. Returns true if all Purposes have consent.
+
+    my $ok = $instance->is_purpose_consent_allowed(1);
+    my $all_ok = $instance->is_purpose_consent_allowed(1, 2, 3);
+
+Throws an exception if no arguments are provided or if an ID is invalid.
+
+See also: L<GDPR::IAB::TCFv2::Constants::Purpose>.
+
+=head2 is_purpose_legitimate_interest_allowed
+
+The user's consent value for each Purpose established on the legal basis of legitimate interest.
+Accepts one or more Purpose IDs. Returns true if all Purposes have legitimate interest.
+
+    my $ok = $instance->is_purpose_legitimate_interest_allowed(1);
+    my $all_ok = $instance->is_purpose_legitimate_interest_allowed(1, 2, 3);
+
+Throws an exception if no arguments are provided or if an ID is invalid.
+
+See also: L<GDPR::IAB::TCFv2::Constants::Purpose>.
+
+=head2 purpose_one_treatment
+
+CMPs can use the C<publisher_country_code> field to indicate the legal jurisdiction the publisher is under to help vendors determine whether the vendor needs consent for Purpose 1.
+
+Returns true if Purpose 1 was NOT disclosed at all.
+
+Returns false if Purpose 1 was disclosed commonly as consent as expected by the L<Policies|https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/>.
+
+=head2 publisher_country_code
+
+Two-letter L<ISO 639-1|https://en.wikipedia.org/wiki/ISO_639-1> language code of the country that determines legislation of reference.
+Commonly, this corresponds to the country in which the publisher's business entity is established.
+
+=head2 max_vendor_id_consent
+
+The maximum Vendor ID that is represented in the following bit field or range encoding.
+
+Because this section can be a variable length, this indicates the last ID of the section so that a decoder will know when it has reached the end.
+
+=head2 vendor_consent
+
+If true, vendor has consent.
+
+The consent value for each Vendor ID.
+
+    my $ok = $instance->vendor_consent(284); # if true, consent ok for Weborama (vendor id 284).
+
+=head2 max_vendor_id_legitimate_interest
+
+The maximum Vendor ID that is represented in the following bit field or range encoding.
+
+Because this section can be a variable length, this indicates the last ID of the section so that a decoder will know when it has reached the end.
+
+=head2 vendor_legitimate_interest
+
+If true, legitimate interest established.
+
+The legitimate interest value for each Vendor ID
+
+    my $ok = $instance->vendor_legitimate_interest(284); # if true, legitimate interest established for Weborama (vendor id 284).
+
+=head2 disclosed_vendor
+
+If true, the vendor was disclosed to the user (Segment 1 or 5).
+
+    say "Vendor 284 was disclosed" if $consent->disclosed_vendor(284);
+
+=head2 has_vendor_disclosure
+
+Returns true (1) if the TC string contains a "Disclosed Vendors" segment (ID 1 or 5), and false (0) otherwise.
+
+=head2 allowed_vendor
+
+If true, the vendor is in the "Allowed Vendors" segment (Segment 2). This is typically used for service-specific TC strings.
+
+    say "Vendor 284 is allowed" if $consent->allowed_vendor(284);
+
+=head2 is_vendor_consent_allowed
+
+Check if a vendor has consent for a list of purposes, respecting publisher restrictions.
+
+    if ($consent->is_vendor_consent_allowed(284, 1, 2, 3)) {
+        # ...
+    }
+
+=head2 is_vendor_legitimate_interest_allowed
+
+Check if a vendor has legitimate interest for a list of purposes, respecting publisher restrictions.
+
+    if ($consent->is_vendor_legitimate_interest_allowed(284, 2, 4)) {
+        # ...
+    }
+
+=head2 is_vendor_allowed_for_any_basis
+
+Check if a vendor has either consent or legitimate interest for a list of purposes, respecting publisher restrictions.
+
+    if ($consent->is_vendor_allowed_for_any_basis(284, 1, 2)) {
+        # ...
+    }
+
+=head2 has_publisher_restrictions
+
+Returns true (1) if the TC string contains a "Publisher Restrictions" section, and false (0) otherwise.
+
+=head2 check_publisher_restriction
+
+It true, there is a publisher restriction of certain type, for a given purpose id, for a given vendor id:
+
+    # return true if there is publisher restriction to vendor 284 regarding purpose id 1
+    # with restriction type 0 'Purpose Flatly Not Allowed by Publisher'
+    my $ok = $instance->check_publisher_restriction(1, 0, 284);
+
+or
+
+    my $ok = $instance->check_publisher_restriction(
+        purpose_id       => 1,
+        restriction_type => 0,
+        vendor_id        => 284);
+
+Version 2.0 of the Framework introduced the ability for publishers to signal restrictions on how vendors may process personal data. Restrictions can be of two types:
+
+=over
+
+=item *
+
+Purposes. Restrict the purposes for which personal data is processed by a vendor.
+
+=item *
+
+Legal basis. Specify the legal basis upon which a publisher requires a vendor to operate where a vendor has signaled flexibility on legal basis in the GVL.
+
+=back
+
+Publisher restrictions are custom requirements specified by a publisher. In order for vendors to determine if processing is permissible at all for a specific purpose or which legal basis is applicable (in case they signaled flexibility in the GVL) restrictions must be respected.
+
+=over
+
+=item 1
+
+Vendors must always respect a restriction signal that disallows them the processing for a specific purpose regardless of whether or not they have declared that purpose to be "flexible".
+
+=item 2
+
+Vendors that declared a purpose with a default legal basis (consent or legitimate interest respectively) but also declared this purpose as flexible must respect a legal basis restriction if present. That means for example in case they declared a purpose as legitimate interest but also declared that purpose as flexible and there is a legal basis restriction to require consent, they must then check for the consent signal and must not apply the legitimate interest signal.
+
+=back
+
+For the avoidance of doubt:
+
+In case a vendor has declared flexibility for a purpose and there is no legal basis restriction signal it must always apply the default legal basis under which the purpose was registered aside from being registered as flexible. That means if a vendor declared a purpose as legitimate interest and also declared that purpose as flexible it may not apply a "consent" signal without a legal basis restriction signal to require consent.
+
+=head2 is_vendor_allowed_for_flexible_purpose
+
+Check if a vendor is allowed for a flexible purpose, given a default legal basis (true if Legitimate Interest, false if Consent).
+
+    if ($consent->is_vendor_allowed_for_flexible_purpose(284, 2, 1)) {
+        # vendor 284, purpose 2, default is LI
+    }
+
+=head2 publisher_restrictions
+
+Similar to L</check_publisher_restriction> but return an hashref of purpose => { restriction type => bool } for a given vendor.
+
+=head2 publisher_tc
+
+If the consent string has a C<Publisher TC> section, we will decode this section as an instance of L<GDPR::IAB::TCFv2::PublisherTC>.
+
+Will return undefined if there is no C<Publisher TC> section.
+
+=head2 TO_JSON
+
+Will serialize the consent object into a hash reference. The objective is to be used by L<JSON> package.
+
+With option C<convert_blessed>, the encoder will call this method.
+
+    use strict;
+    use warnings;
+    use feature qw<say>;
+
+    use JSON;
+    use DateTime;
+    use DateTimeX::TO_JSON formatter => 'DateTime::Format::RFC3339';
+    use GDPR::IAB::TCFv2::Parser;
+
+    my $consent = GDPR::IAB::TCFv2::Parser->Parse(
+        'COyiILmOyiILmADACHENAPCAAAAAAAAAAAAAE5QBgALgAqgD8AQACSwEygJyAAAAAA.argAC0gAAAAAAAAAAAA',
+        json => {
+            compact     => 1,
+            date_format => sub { # can be omitted, with DateTimeX::TO_JSON
+                my ( $epoch, $ns ) = @_;
+
+                return DateTime->from_epoch( epoch => $epoch )
+                ->set_nanosecond($ns);
+            },
+        },
+    );
+
+    my $json    = JSON->new->convert_blessed;
+    my $encoded = $json->pretty->encode($consent);
+
+    say $encoded;
+
+Outputs:
+
+    {
+        "tc_string" : "COyiILmOyiILmADACHENAPCAAAAAAAAAAAAAE5QBgALgAqgD8AQACSwEygJyAAAAAA",
+        "consent_language" : "EN",
+        "purpose" : {
+            "consents" : [],
+            "legitimate_interests" : []
+        },
+        "cmp_id" : 3,
+        "purpose_one_treatment" : false,
+        "publisher" : {
+            "consents" : [
+                2,
+                4,
+                6,
+                8,
+                9,
+                10
+            ],
+            "legitimate_interests" : [
+                2,
+                4,
+                5,
+                7,
+                10
+            ],
+            "custom_purposes" : {
+                "consents" : [],
+                "legitimate_interests" : []
+            },
+            "restrictions" : {}
+        },
+        "special_features_opt_in" : [],
+        "last_updated" : "2020-04-27T20:27:54.200000000Z",
+        "use_non_standard_stacks" : false,
+        "policy_version" : 2,
+        "version" : 2,
+        "is_service_specific" : false,
+        "created" : "2020-04-27T20:27:54.200000000Z",
+        "consent_screen" : 7,
+        "vendor_list_version" : 15,
+        "cmp_version" : 2,
+        "publisher_country_code" : "AA",
+        "vendor" : {
+            "consents" : [
+                23,
+                42,
+                126,
+                127,
+                128,
+                587,
+                613,
+                626
+            ],
+            "legitimate_interests" : []
+        }
+    }
+
+
+If L<JSON> is installed, the L</TO_JSON> method will use C<JSON::true> and C<JSON::false> as boolean value.
+
+By default it returns a compacted format where we omit the C<false> on fields like C<vendor_consents> and we convert the dates
+using L<ISO_8601|https://en.wikipedia.org/wiki/ISO_8601>. This behaviour can be changed by extra option in the L<Parse> constructor.
+
+=head1 SEE ALSO
+
+L<GDPR::IAB::TCFv2> for the documentation hub and project overview.
+
+L<GDPR::IAB::TCFv2::Validator> for declarative compliance checks.
+
+L<GDPR::IAB::TCFv2::CMPValidator> for CMP-list validation.
+
+L<iabtcfv2> for one-liner / shell-use shortcuts.
+
+The original IAB documentation of L<TCF v2|https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md>.
+
+=cut

--- a/lib/iabtcfv2.pm
+++ b/lib/iabtcfv2.pm
@@ -1,0 +1,110 @@
+package iabtcfv2;
+
+use strict;
+use warnings;
+
+use GDPR::IAB::TCFv2::Parser;
+use GDPR::IAB::TCFv2::Validator;
+
+use Exporter qw(import);
+
+our @EXPORT  = qw(tcf validator);
+our $VERSION = '0.401';
+
+sub tcf       { GDPR::IAB::TCFv2::Parser->Parse(@_) }
+sub validator { GDPR::IAB::TCFv2::Validator->new(@_) }
+
+1;
+__END__
+
+=pod
+
+=encoding utf8
+
+=head1 NAME
+
+iabtcfv2 - shortcut module for one-liner and shell use of GDPR::IAB::TCFv2
+
+=head1 SYNOPSIS
+
+    use feature qw<say>;
+    use iabtcfv2;
+
+    my $tc_string = 'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA';
+
+    # Parse a TC string and inspect:
+    my $c = tcf($tc_string);
+    say $c->cmp_id;
+    say $c->consent_language;
+
+    # Validate:
+    my $r = validator(
+        vendor_id           => 284,
+        consent_purpose_ids => [ 1, 3 ],
+    )->validate($tc_string);
+    say $r ? "ok" : "fail: $r";
+
+    # One-liner from the shell:
+    #   perl -Miabtcfv2 -E 'say tcf(shift)->cmp_id' "$tc"
+
+=head1 DESCRIPTION
+
+C<iabtcfv2> is a pure-exporter shortcut module for one-liner and
+shell use of the C<GDPR-IAB-TCFv2> distribution. It exports two
+constructor shortcuts so that C<perl -Miabtcfv2 -E '...'> can write
+C<tcf($s)> and C<validator(%opts)> instead of the full-namespace
+forms.
+
+C<iabtcfv2> is intentionally B<not> an inheritance hub: there is no
+C<@ISA>, and class-method calls like C<< iabtcfv2->Parse(...) >> are
+deliberately not supported. Use C<tcf()> for one-liners, or call
+C<< GDPR::IAB::TCFv2->Parse(...) >> on the hub for OO invocation in
+full scripts.
+
+For the full parser API see L<GDPR::IAB::TCFv2::Parser>. For
+declarative validation see L<GDPR::IAB::TCFv2::Validator>. For
+project overview see L<GDPR::IAB::TCFv2>.
+
+=head1 EXPORTS
+
+Both functions are exported automatically on C<use iabtcfv2;>.
+
+=head2 tcf
+
+    my $consent = tcf($tc_string);
+
+Shortcut for C<< GDPR::IAB::TCFv2::Parser->Parse($tc_string) >>.
+Returns a C<GDPR::IAB::TCFv2::Parser> instance.
+
+=head2 validator
+
+    my $v = validator(
+        vendor_id           => 284,
+        consent_purpose_ids => [ 1, 3 ],
+    );
+
+Shortcut for C<< GDPR::IAB::TCFv2::Validator->new(%opts) >>. Returns
+a C<GDPR::IAB::TCFv2::Validator> instance. Pass to
+C<< $v->validate($tc_string) >> for a fail-fast check.
+
+=head1 SEE ALSO
+
+L<GDPR::IAB::TCFv2>, L<GDPR::IAB::TCFv2::Parser>,
+L<GDPR::IAB::TCFv2::Validator>.
+
+The IAB TCF v2 specification:
+L<https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md>.
+
+=head1 AUTHOR
+
+Tiago Peczenyj L<mailto:tiago.peczenyj+cpan@gmail.com>
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright 2023-2026 Tiago Peczenyj.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of either: the GNU General Public License as
+published by the Free Software Foundation; or the Artistic License.
+
+=cut

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -13,6 +13,8 @@ BEGIN {
   use_ok('GDPR::IAB::TCFv2::PublisherTC');
   use_ok('GDPR::IAB::TCFv2::RangeSection');
   use_ok('GDPR::IAB::TCFv2');
+  use_ok('GDPR::IAB::TCFv2::Parser');
+  use_ok('iabtcfv2');
 }
 
 require_ok('GDPR::IAB::TCFv2::Constants::Purpose');
@@ -25,6 +27,8 @@ require_ok('GDPR::IAB::TCFv2::PublisherRestrictions');
 require_ok('GDPR::IAB::TCFv2::PublisherTC');
 require_ok 'GDPR::IAB::TCFv2::RangeSection';
 require_ok 'GDPR::IAB::TCFv2';
+require_ok 'GDPR::IAB::TCFv2::Parser';
+require_ok 'iabtcfv2';
 
 subtest "check interfaces" => sub {
   isa_ok 'GDPR::IAB::TCFv2::BitUtils',                   'Exporter';
@@ -46,6 +50,27 @@ subtest "check interfaces" => sub {
     is_purpose_legitimate_interest_allowed
     is_custom_purpose_consent_allowed
     is_custom_purpose_legitimate_interest_allowed>;
+
+  done_testing;
+};
+
+subtest 'parser-split BC contract' => sub {
+  my $tc_string
+    = 'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA.argAC0gAAAAAAAAAAAA';
+
+  my $c = GDPR::IAB::TCFv2->Parse($tc_string);
+  is(ref($c), 'GDPR::IAB::TCFv2::Parser', 'hub Parse returns a GDPR::IAB::TCFv2::Parser instance');
+
+  isa_ok(GDPR::IAB::TCFv2::Parser->Parse($tc_string),
+    'GDPR::IAB::TCFv2::Parser', 'direct Parser->Parse returns a ::Parser instance');
+
+  done_testing;
+};
+
+subtest 'looksLikeIsConsentVersion2 placement' => sub {
+  ok(GDPR::IAB::TCFv2->can('looksLikeIsConsentVersion2'), 'hub exposes looksLikeIsConsentVersion2');
+  is(GDPR::IAB::TCFv2::Parser->can('looksLikeIsConsentVersion2'),
+    undef, 'Parser deliberately does not expose looksLikeIsConsentVersion2');
 
   done_testing;
 };

--- a/t/01-parse.t
+++ b/t/01-parse.t
@@ -16,7 +16,7 @@ subtest "bitfield" => sub {
     }
     'should not throw exception';
 
-    isa_ok $consent, 'GDPR::IAB::TCFv2', 'gdpr iab tcf v2 consent';
+    isa_ok $consent, 'GDPR::IAB::TCFv2::Parser', 'gdpr iab tcf v2 consent';
 
     is $consent->tc_string, $tc_string, 'should return the original tc string';
 
@@ -150,7 +150,7 @@ subtest "bitfield" => sub {
       }
       'should not throw exception';
 
-      isa_ok $consent, 'GDPR::IAB::TCFv2', 'gdpr iab tcf v2 consent';
+      isa_ok $consent, 'GDPR::IAB::TCFv2::Parser', 'gdpr iab tcf v2 consent';
 
       is $consent->tc_string, $tc_string, 'should return the original tc string';
 
@@ -198,7 +198,7 @@ subtest "bitfield" => sub {
       }
       'should not throw exception';
 
-      isa_ok $consent, 'GDPR::IAB::TCFv2', 'gdpr iab tcf v2 consent';
+      isa_ok $consent, 'GDPR::IAB::TCFv2::Parser', 'gdpr iab tcf v2 consent';
 
       is $consent->tc_string, $tc_string, 'should return the original tc string';
 
@@ -268,7 +268,7 @@ subtest "range" => sub {
     }
     'should not throw exception';
 
-    isa_ok $consent, 'GDPR::IAB::TCFv2', 'gdpr iab tcf v2 consent';
+    isa_ok $consent, 'GDPR::IAB::TCFv2::Parser', 'gdpr iab tcf v2 consent';
 
     is $consent->tc_string, $tc_string, 'should return the original tc string';
 
@@ -382,7 +382,7 @@ subtest "range" => sub {
     }
     'should not throw exception';
 
-    isa_ok $consent, 'GDPR::IAB::TCFv2', 'gdpr iab tcf v2 consent';
+    isa_ok $consent, 'GDPR::IAB::TCFv2::Parser', 'gdpr iab tcf v2 consent';
 
     is $consent->tc_string, $tc_string, 'should return the original tc string';
 
@@ -431,7 +431,7 @@ subtest "check publisher restriction" => sub {
     }
     'should not throw exception';
 
-    isa_ok $consent, 'GDPR::IAB::TCFv2', 'gdpr iab tcf v2 consent';
+    isa_ok $consent, 'GDPR::IAB::TCFv2::Parser', 'gdpr iab tcf v2 consent';
 
     is $consent->version, 2, 'should return version 2';
 
@@ -471,7 +471,7 @@ subtest "check publisher restriction" => sub {
     }
     'should not throw exception';
 
-    isa_ok $consent, 'GDPR::IAB::TCFv2', 'gdpr iab tcf v2 consent';
+    isa_ok $consent, 'GDPR::IAB::TCFv2::Parser', 'gdpr iab tcf v2 consent';
 
     is $consent->version, 2, 'should return version 2';
 
@@ -515,7 +515,7 @@ subtest "check publisher restriction" => sub {
     }
     'should not throw exception';
 
-    isa_ok $consent, 'GDPR::IAB::TCFv2', 'gdpr iab tcf v2 consent';
+    isa_ok $consent, 'GDPR::IAB::TCFv2::Parser', 'gdpr iab tcf v2 consent';
 
     is $consent->version, 2, 'should return version 2';
 

--- a/t/05-tcf-v23.t
+++ b/t/05-tcf-v23.t
@@ -94,8 +94,8 @@ subtest "MaxVendorId == 0 yields an empty vendor section" => sub {
 
   my $section;
   lives_ok {
-    $section
-      = $consent->_parse_vendor_bitfield_or_range($segment, GDPR::IAB::TCFv2::SEGMENT_TYPES->{DISCLOSED_VENDORS},);
+    $section = $consent->_parse_vendor_bitfield_or_range($segment,
+      GDPR::IAB::TCFv2::Parser::SEGMENT_TYPES->{DISCLOSED_VENDORS},);
   }
   'max_id=0 segment parses without error';
 
@@ -116,7 +116,7 @@ subtest "Disclosed Vendors helper rejects mis-typed payload" => sub {
   my $bad = '010' . ('0' x 16) . '0';
 
   throws_ok {
-    $consent->_parse_vendor_bitfield_or_range($bad, GDPR::IAB::TCFv2::SEGMENT_TYPES->{DISCLOSED_VENDORS},);
+    $consent->_parse_vendor_bitfield_or_range($bad, GDPR::IAB::TCFv2::Parser::SEGMENT_TYPES->{DISCLOSED_VENDORS},);
   }
   qr/invalid segment type/, 'helper croaks when payload header does not match expected type';
 };

--- a/t/11-iabtcfv2-shortcut.t
+++ b/t/11-iabtcfv2-shortcut.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+use Test::More;
+
+use iabtcfv2;
+
+my $tc_string
+  = 'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA.argAC0gAAAAAAAAAAAA';
+
+subtest 'tcf() returns a GDPR::IAB::TCFv2::Parser instance' => sub {
+  my $c = tcf($tc_string);
+  isa_ok $c, 'GDPR::IAB::TCFv2::Parser';
+  is $c->tc_string, $tc_string, 'tcf roundtrips the TC string';
+};
+
+subtest 'validator() returns a usable GDPR::IAB::TCFv2::Validator' => sub {
+  my $v = validator(vendor_id => 284, consent_purpose_ids => [1, 3],);
+  isa_ok $v, 'GDPR::IAB::TCFv2::Validator';
+
+  my $result = $v->validate($tc_string);
+  ok defined $result, 'validator->validate returns a defined result';
+};
+
+subtest 'exports landed in the caller namespace' => sub {
+  ok __PACKAGE__->can('tcf'),       'tcf is imported into main:: by use iabtcfv2';
+  ok __PACKAGE__->can('validator'), 'validator is imported into main:: by use iabtcfv2';
+};
+
+subtest 'no class-method surface on iabtcfv2' => sub {
+  is(iabtcfv2->can('Parse'), undef, 'iabtcfv2 deliberately does not expose Parse as a class method');
+};
+
+subtest 'representative one-liner roundtrip' => sub {
+  is tcf($tc_string)->cmp_id,           21,   'cmp_id';
+  is tcf($tc_string)->consent_language, 'EN', 'consent_language';
+  is tcf($tc_string)->policy_version,   2,    'policy_version';
+};
+
+done_testing;

--- a/t/90-bugs.t
+++ b/t/90-bugs.t
@@ -16,7 +16,7 @@ subtest "BUG index out of bounds on offset, see: https://github.com/peczenyj/GDP
   }
   'should not throw exception';
 
-  isa_ok $consent, 'GDPR::IAB::TCFv2', 'gdpr iab tcf v2 consent';
+  isa_ok $consent, 'GDPR::IAB::TCFv2::Parser', 'gdpr iab tcf v2 consent';
 
   done_testing;
 };


### PR DESCRIPTION
## Summary

- Move all parser code from `GDPR::IAB::TCFv2` to a new `GDPR::IAB::TCFv2::Parser` subpackage. `GDPR::IAB::TCFv2` becomes the documentation hub: thin `Parse` delegate plus the pre-parse sniff function `looksLikeIsConsentVersion2`.
- Add `lib/iabtcfv2.pm` as a pure-exporter short alias for one-liner use. Exports `tcf($s)` and `validator(%opts)`.
- Record the v0.510 `Validator->Validate` follow-up as a help-wanted item in `TODO.pod`.
- Regenerate `README.md` from the refreshed hub POD.

Implements the design at `docs/superpowers/specs/2026-05-13-tcfv2-parser-split-design.md` (gitignored per project convention).

## Breaking change

`GDPR::IAB::TCFv2->Parse(...)` now returns an object blessed into `GDPR::IAB::TCFv2::Parser`. Code relying on `ref($obj) eq 'GDPR::IAB::TCFv2'` or `$obj->isa('GDPR::IAB::TCFv2')` must use the `::Parser` namespace. All method calls, `TO_JSON` output, error messages, and CLI behavior are unchanged.

Target version: **v0.500** (maintainer-driven release; `$VERSION` left at `0.401` in this PR to keep `xt/version.t` consistency-check green — `tools/bump-version 0.500` will sweep all `.pm` files at release time).

## Design highlights

- **No `@ISA`, no class methods, no glob aliases** introduced. The hub's `looksLikeIsConsentVersion2` is an explicit sub definition (not an alias to Parser); `iabtcfv2.pm` is a pure `Exporter`-based module (no inheritance, no `Parse` class method).
- POD split by role: hub gets `COMPONENTS`, `INCOMPATIBLE CHANGES`, `ONE-LINER USAGE` (new) plus existing project-level sections; Parser gets the full per-method API reference.
- `iabtcfv2` is the short-alias module name (matches `bin/iabtcfv2`; avoids the generic `gdpr` top-level namespace).

## Test plan

- [x] `prove -lr t` green — 17561 tests (baseline 17548 + 13 new subtests)
- [x] `prove -lr xt` green — 98 author tests (tidy + perlcritic + POD coverage + version consistency + synopsis compile)
- [x] Hand-verified one-liner: `perl -Miabtcfv2 -E 'say tcf(shift)->cmp_id' "$tc"` → `21`
- [x] Hand-verified BC contract: `ref(GDPR::IAB::TCFv2->Parse($tc))` returns `'GDPR::IAB::TCFv2::Parser'`
- [x] Hand-verified `iabtcfv2->can('Parse')` returns `undef` (no class-method surface)
- [x] Hand-verified `MANIFEST` includes `Parser.pm`, `iabtcfv2.pm`, `t/11-iabtcfv2-shortcut.t`
- [x] `pod2markdown lib/GDPR/IAB/TCFv2.pm > README.md` produces the updated landing page

## Out of scope (per spec)

- **v0.510 micro-PR:** `Validator->Validate($s, %opts)` class-method shortcut — recorded in `TODO.pod` as a help-wanted item in this PR.
- **v0.600:** Parser/VendorConsent split — name `VendorConsent` pre-claimed in the spec.
- **Phase 9:** env-var / `.iabtcfv2rc` resolution inside `iabtcfv2::validator`. The current `validator(%opts)` API is forward-compatible.
- `cmp_validator` export in iabtcfv2 — not justified by current evidence.

## Maintainer handoff

Per `AGENTS.md`, this PR does **not** include the version bump or tag. After merge:

```sh
tools/bump-version 0.500
git cliff -o CHANGELOG.md
pod2markdown lib/GDPR/IAB/TCFv2.pm > README.md   # if any drift since merge
git commit -am "chore: prepare for v0.500 release"
# merge devel → main, push tag v0.500 → release workflow handles CPAN + GitHub Release
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)