### PR TITLE
test(golden): wrap per-entry checks in subtest to reduce memory on tight smokers

### DIFF
--- a/t/07-golden.t
+++ b/t/07-golden.t
@@ -40,43 +40,45 @@ while (my $line_json = <$fh>) {
 
   $count++;
 
-  if ($entry->{expect_failure}) {
-    throws_ok { GDPR::IAB::TCFv2->Parse($tc_string); }
-    qr/\Q$entry->{error_match}\E/, "String $count should fail as expected";
-  }
-  else {
+  # Grouping each entry under a subtest collapses ~7 ok-records into 1 at the
+  # outer level and lets Test2 release per-ok history between iterations.
+  # Important for memory-tight smokers (e.g. OmniOS/Solaris on threaded perl).
+  subtest "String $count" => sub {
+    if ($entry->{expect_failure}) {
+      throws_ok { GDPR::IAB::TCFv2->Parse($tc_string); }
+      qr/\Q$entry->{error_match}\E/, "should fail as expected";
+      return;
+    }
+
     my $consent;
     lives_ok {
       $consent = GDPR::IAB::TCFv2->Parse($tc_string, json => {boolean_values => [JSON::PP::false, JSON::PP::true]});
     }
-    "String $count parsed successfully";
+    "parsed successfully";
 
-    next unless $consent;
+    return unless $consent;
 
     my $tests = $entry->{tests};
 
-    # Test JSON representation
-    is_deeply_with_diag($consent->TO_JSON, $tests->{to_json}, "String $count: TO_JSON match");
+    is_deeply_with_diag($consent->TO_JSON, $tests->{to_json}, "TO_JSON match");
 
-    # Test metadata
-    is($consent->version,         $tests->{metadata}->{version},       "String $count: version match");
-    is($consent->cmp_id,          $tests->{metadata}->{cmp_id},        "String $count: cmp_id match");
-    is(scalar($consent->created), $tests->{metadata}->{created_epoch}, "String $count: created match");
+    is($consent->version,         $tests->{metadata}->{version},       "version match");
+    is($consent->cmp_id,          $tests->{metadata}->{cmp_id},        "cmp_id match");
+    is(scalar($consent->created), $tests->{metadata}->{created_epoch}, "created match");
 
-    # Test sampling
     my $sampling = $tests->{sampling};
     foreach my $key (keys %{$sampling}) {
       if ($key eq 'purpose_1_consent') {
-        is(!!$consent->is_purpose_consent_allowed(1), !!$sampling->{$key}, "String $count: $key match");
+        is(!!$consent->is_purpose_consent_allowed(1), !!$sampling->{$key}, "$key match");
       }
       elsif ($key eq 'vendor_284_consent') {
-        is(!!$consent->vendor_consent(284), !!$sampling->{$key}, "String $count: $key match");
+        is(!!$consent->vendor_consent(284), !!$sampling->{$key}, "$key match");
       }
       elsif ($key eq 'vendor_284_purpose_1_allowed' && $consent->can('is_vendor_consent_allowed')) {
-        is(!!$consent->is_vendor_consent_allowed(284, 1), !!$sampling->{$key}, "String $count: $key match");
+        is(!!$consent->is_vendor_consent_allowed(284, 1), !!$sampling->{$key}, "$key match");
       }
     }
-  }
+  };
 }
 
 sub is_deeply_with_diag {


### PR DESCRIPTION
## Summary

- `t/07-golden.t` was failing on BINGOS's Solaris/OmniOS smoker (Perl 5.26.1 threaded, 64-bit) with `Out of memory!` after producing **all 7224 subtests** but before `done_testing()` could fire — see [CPAN Testers report `f952c408`](https://www.cpantesters.org/cpan/report/f952c408-4f72-11f1-a3bc-a055f9c4ba34).
- Root cause is environmental: Test2 retains per-ok name strings until the plan ends, so a flat run over the 1024-entry corpus accumulates measurable state and overruns the smoker's memory cap right at the tail.
- Wrapping each entry in a `subtest` collapses ~7 outer ok-records into 1 per entry, letting Test2 release per-ok history between iterations. Outer plan: ~7224 → 1024. No assertion semantics changed.

## Test plan

- [x] `prove -l t/07-golden.t` — 1024 tests pass
- [x] `prove -l t/` — 10,400 tests pass across 20 files
- [x] `prove -l xt/` — 99 tests pass (critic, spelling, synopsis, tidy, version)
- [ ] Watch CPAN Testers for next BINGOS smoke after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)