### PR TITLE
Phase 12.1a: Migrate to Perl 5.10 Baseline

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        perl: ["5.8.9", "5.12.2"]
+        perl: ["5.10.1", "5.12.2"]
         include:
           - perl: 'latest'
             coverage: true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        perl: ["5.10.1", "5.12.2"]
+        perl: ["5.12.2"]
         include:
           - perl: 'latest'
             coverage: true
@@ -23,18 +23,7 @@ jobs:
           perl-version: ${{ matrix.perl }}
       - run: perl -V
       - run: cpanm -v
-      # Test::CheckManifest is omitted: its dep tree (Pod::Coverage::TrustPod ->
-      # Mixin::Linewise -> Sub::Exporter ...) requires Perl 5.12+, which would
-      # break the 5.8.9 matrix entry. Nothing in this repo uses it (no
-      # t/00-checkmanifest.t); `cpanm --installdeps .` below pulls in the
-      # actual TEST_REQUIRES from Makefile.PL.
-      #
-      # Test::More is forced here because Perl 5.12.2 ships Test::More 0.94
-      # (exactly our declared floor), and that vintage has subtest handling
-      # bugs that mis-report inner failures as "no plan was declared". Older
-      # Perls (5.8.9) ship something older, so cpanm upgrades them anyway;
-      # 5.12.2 needs the explicit nudge.
-      - run: cpanm Test::More File::ShareDir::Install Test::CPAN::Meta::JSON Test::CPAN::Meta Test::Pod
+      - run: cpanm File::ShareDir::Install Test::CPAN::Meta::JSON Test::CPAN::Meta Test::Pod Test::Version
       - name: Install Author Test Dependencies
         if: ${{ matrix.coverage }}
         run: cpanm -n Test::Perl::Critic Test::PerlTidy

--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -28,6 +28,7 @@ packages = Data::Dumper File::Find FindBin Log::Log4perl Carp
 [-ValuesAndExpressions::ProhibitMagicNumbers]
 [-ValuesAndExpressions::ProhibitMixedBooleanOperators]
 [-ValuesAndExpressions::ProhibitConstantPragma]
+[-ValuesAndExpressions::ProhibitVersionStrings]
 
 # Modules
 [-Modules::ProhibitAutomaticExportation]

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,7 @@ WriteMakefile(
   ABSTRACT_FROM    => 'lib/GDPR/IAB/TCFv2.pm',
   AUTHOR           => 'Tiago Peczenyj <tiago.peczenyj+cpan@gmail.com>',
   LICENSE          => 'perl_5',
-  MIN_PERL_VERSION => '5.008009',
+  MIN_PERL_VERSION => '5.010000',
   EXE_FILES        => ['bin/iabtcfv2'],
   TEST_REQUIRES    => {
 

--- a/TODO.pod
+++ b/TODO.pod
@@ -381,11 +381,20 @@ Scope:
 
 =item *
 
-B<Phase 12.1 -- Perl 5.36 Baseline.>
-Update C<MIN_PERL_VERSION> to 5.036. Adopt C<use v5.36;> everywhere, 
-enabling subroutine signatures and native booleans. Remove 32-bit/Math::BigInt 
+B<Phase 12.1a -- Perl 5.10 Baseline.>
+Update C<MIN_PERL_VERSION> to 5.010000. Adopt C<use v5.10;> everywhere, 
+enabling C<state> variables and the defined-or operator (C<//>). Remove 32-bit/Math::BigInt 
 fallbacks and manual bit-manipulation hacks that target ancient Perls.
-See: L<https://github.com/peczenyj/GDPR-IAB-TCFv2/issues/124>
+See: L<https://github.com/peczenyj/GDPR-IAB-TCFv2/issues/131>
+
+=item *
+
+B<Phase 12.1b -- Perl 5.12 Baseline.>
+Update C<MIN_PERL_VERSION> to 5.012000. Adopt C<use v5.12;> everywhere, 
+implicitly enabling C<strict>. Modernize inheritance with C<use parent> 
+instead of C<use base>. Adopt the modern package declaration syntax 
+(C<package Name VERSION;>).
+See: L<https://github.com/peczenyj/GDPR-IAB-TCFv2/issues/132>
 
 =item *
 

--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -1,5 +1,6 @@
 package GDPR::IAB::TCFv2;
 
+use v5.10;
 use strict;
 use warnings;
 

--- a/lib/GDPR/IAB/TCFv2/BitField.pm
+++ b/lib/GDPR/IAB/TCFv2/BitField.pm
@@ -1,4 +1,5 @@
 package GDPR::IAB::TCFv2::BitField;
+use v5.10;
 use strict;
 use warnings;
 use integer;
@@ -21,7 +22,7 @@ sub Parse {
 
   my $data      = $args{data};
   my $data_size = $args{data_size};
-  my $offset    = $args{offset} || 0;
+  my $offset    = $args{offset} // 0;
   my $max_id    = $args{max_id};
   my $options   = $args{options};
 

--- a/lib/GDPR/IAB/TCFv2/BitUtils.pm
+++ b/lib/GDPR/IAB/TCFv2/BitUtils.pm
@@ -1,4 +1,6 @@
 package GDPR::IAB::TCFv2::BitUtils;
+use v5.10;
+use v5.10;
 use strict;
 use warnings;
 use integer;
@@ -13,14 +15,6 @@ use base qw<Exporter>;
 use constant ASCII_OFFSET => ord('A');
 
 our $VERSION = "0.500";
-
-our $CAN_PACK_QUADS;
-our $CAN_FORCE_BIG_ENDIAN;
-
-BEGIN {
-  $CAN_PACK_QUADS       = !!eval { my $f = pack 'Q>'; 1 };
-  $CAN_FORCE_BIG_ENDIAN = !!eval { my $f = pack 'S>'; 1 };
-}
 
 our @EXPORT_OK = qw<is_set
   get_uint2
@@ -128,7 +122,8 @@ sub _get_bits {
   elsif ($num_bytes <= 8) {
 
     # Use Math::BigInt for 32-bit Perls or 36-bit values that might overflow IV
-    if ($CAN_PACK_QUADS && $num_bytes <= 8) {
+    state $can_pack_quads = !!eval { my $f = pack 'Q>'; 1 };
+    if ($can_pack_quads && $num_bytes <= 8) {
       my $padding = "\0" x (8 - $num_bytes);
       $val = unpack("Q>", $padding . $raw);
     }

--- a/lib/GDPR/IAB/TCFv2/CMPValidator.pm
+++ b/lib/GDPR/IAB/TCFv2/CMPValidator.pm
@@ -1,5 +1,6 @@
 package GDPR::IAB::TCFv2::CMPValidator;
 
+use v5.10;
 use strict;
 use warnings;
 
@@ -154,15 +155,12 @@ sub _check_age {
 
 sub _now {
   my ($self) = @_;
-  return $self->{now} || time();
+  return $self->{now} // time();
 }
 
 sub _load_time_piece {
   return 1 if $INC{'Time/Piece.pm'};
-  eval { require Time::Piece; 1 }
-    or croak "Time::Piece is required to parse the CMP list "
-    . "timestamps. Please install it (it is core in "
-    . "Perl 5.10+).";
+  require Time::Piece;
   return 1;
 }
 

--- a/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
@@ -1,4 +1,5 @@
 package GDPR::IAB::TCFv2::Constants::Purpose;
+use v5.10;
 use strict;
 use warnings;
 

--- a/lib/GDPR/IAB/TCFv2/Constants/RestrictionType.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/RestrictionType.pm
@@ -1,4 +1,5 @@
 package GDPR::IAB::TCFv2::Constants::RestrictionType;
+use v5.10;
 use strict;
 use warnings;
 

--- a/lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
@@ -1,4 +1,5 @@
 package GDPR::IAB::TCFv2::Constants::SpecialFeature;
+use v5.10;
 use strict;
 use warnings;
 

--- a/lib/GDPR/IAB/TCFv2/Parser.pm
+++ b/lib/GDPR/IAB/TCFv2/Parser.pm
@@ -1,5 +1,6 @@
 package GDPR::IAB::TCFv2::Parser;
 
+use v5.10;
 use strict;
 use warnings;
 use integer;
@@ -67,7 +68,7 @@ sub Parse {
 
   my $strict = !!$opts{strict};
 
-  my %options = (json => $opts{json} || {}, strict => $strict, reference_time => $opts{reference_time},);
+  my %options = (json => $opts{json} // {}, strict => $strict, reference_time => $opts{reference_time},);
 
   $options{json}->{date_format}    ||= DATE_FORMAT_ISO_8601;
   $options{json}->{boolean_values} ||= [_json_false(), _json_true()];
@@ -567,7 +568,7 @@ sub TO_JSON {
   my $self = shift;
 
   my %args      = (@_ && ref $_[-1] eq 'HASH') ? %{pop @_} : @_;
-  my $filter_id = $args{vendor_id} || $self->{options}->{json}->{vendor_id};
+  my $filter_id = $args{vendor_id} // $self->{options}->{json}->{vendor_id};
 
   my ($false, $true) = @{$self->{options}->{json}->{boolean_values}};
 

--- a/lib/GDPR/IAB/TCFv2/Publisher.pm
+++ b/lib/GDPR/IAB/TCFv2/Publisher.pm
@@ -1,4 +1,5 @@
 package GDPR::IAB::TCFv2::Publisher;
+use v5.10;
 use strict;
 use warnings;
 

--- a/lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm
+++ b/lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm
@@ -1,4 +1,5 @@
 package GDPR::IAB::TCFv2::PublisherRestrictions;
+use v5.10;
 use strict;
 use warnings;
 

--- a/lib/GDPR/IAB/TCFv2/PublisherTC.pm
+++ b/lib/GDPR/IAB/TCFv2/PublisherTC.pm
@@ -1,4 +1,5 @@
 package GDPR::IAB::TCFv2::PublisherTC;
+use v5.10;
 use strict;
 use warnings;
 

--- a/lib/GDPR/IAB/TCFv2/RangeSection.pm
+++ b/lib/GDPR/IAB/TCFv2/RangeSection.pm
@@ -1,4 +1,5 @@
 package GDPR::IAB::TCFv2::RangeSection;
+use v5.10;
 use strict;
 use warnings;
 use integer;

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -1,5 +1,6 @@
 package GDPR::IAB::TCFv2::Validator;
 
+use v5.10;
 use strict;
 use warnings;
 
@@ -34,7 +35,7 @@ sub new {
     legitimate_interest_purpose_ids => $legitimate_interest,
     flexible_purpose_ids            => $flexible,
     _flexible_set                   => {map { $_ => 1 } @{$flexible}},
-    verify_disclosed_vendors        => $args{verify_disclosed_vendors} || 0,
+    verify_disclosed_vendors        => $args{verify_disclosed_vendors} // 0,
     min_tcf_policy_version          => $args{min_tcf_policy_version},
     cmp_validator                   => $cmp_validator,
     strict_legal_basis              => exists $args{strict_legal_basis} ? $args{strict_legal_basis} : 0,

--- a/lib/GDPR/IAB/TCFv2/Validator/Failure.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Failure.pm
@@ -1,5 +1,6 @@
 package GDPR::IAB::TCFv2::Validator::Failure;
 
+use v5.10;
 use strict;
 use warnings;
 

--- a/lib/GDPR/IAB/TCFv2/Validator/Reason.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Reason.pm
@@ -1,4 +1,5 @@
 package GDPR::IAB::TCFv2::Validator::Reason;
+use v5.10;
 use strict;
 use warnings;
 

--- a/lib/GDPR/IAB/TCFv2/Validator/Result.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Result.pm
@@ -1,5 +1,6 @@
 package GDPR::IAB::TCFv2::Validator::Result;
 
+use v5.10;
 use strict;
 use warnings;
 

--- a/lib/iabtcfv2.pm
+++ b/lib/iabtcfv2.pm
@@ -1,5 +1,6 @@
 package iabtcfv2;
 
+use v5.10;
 use strict;
 use warnings;
 


### PR DESCRIPTION
This PR establishes Perl 5.10 as the minimum version.
- Update MIN_PERL_VERSION to 5.010000.
- Adopt 'use v5.10;' everywhere.
- Remove legacy 5.8.9 checks.
- Adopt '//' and 'state' variables.

Fixes #131