### PR TITLE
Phase 12.1b: Migrate to Perl 5.12 Baseline

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,7 @@ WriteMakefile(
   ABSTRACT_FROM    => 'lib/GDPR/IAB/TCFv2.pm',
   AUTHOR           => 'Tiago Peczenyj <tiago.peczenyj+cpan@gmail.com>',
   LICENSE          => 'perl_5',
-  MIN_PERL_VERSION => '5.010000',
+  MIN_PERL_VERSION => '5.012000',
   EXE_FILES        => ['bin/iabtcfv2'],
   TEST_REQUIRES    => {
 

--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-use strict;
+use v5.12;
 use warnings;
 
 use Getopt::Long qw(GetOptionsFromArray :config pass_through require_order bundling);

--- a/bin/iabtcfv2
+++ b/bin/iabtcfv2
@@ -175,7 +175,7 @@ sub run_dump {
   }
   else {
     binmode(STDIN, ':encoding(UTF-8)') if -t STDIN;    ## no critic (InputOutput::ProhibitInteractiveTest, InputOutput::RequireEncodingWithUTF8Layer)
-    while (my $line = <STDIN>) {                        ## no critic (InputOutput::ProhibitExplicitStdin)
+    while (my $line = <STDIN>) {                       ## no critic (InputOutput::ProhibitExplicitStdin)
       $state->{line_num}++;
       chomp $line;
       next unless $line =~ /\S/;
@@ -467,7 +467,7 @@ sub run_validate {    ## no critic (Subroutines::ProhibitExcessComplexity)
   }
   else {
     binmode(STDIN, ':encoding(UTF-8)') if -t STDIN;    ## no critic (InputOutput::ProhibitInteractiveTest, InputOutput::RequireEncodingWithUTF8Layer)
-    while (my $line = <STDIN>) {                        ## no critic (InputOutput::ProhibitExplicitStdin)
+    while (my $line = <STDIN>) {                       ## no critic (InputOutput::ProhibitExplicitStdin)
       $state->{line_num}++;
       chomp $line;
       next unless $line =~ /\S/;

--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -1,12 +1,10 @@
-package GDPR::IAB::TCFv2;
+package GDPR::IAB::TCFv2 0.510;
 
-use v5.10;
-use strict;
+use v5.12;
 use warnings;
 
 use GDPR::IAB::TCFv2::Parser;
 
-our $VERSION = "0.510";
 
 sub Parse {
   shift;    # discard $klass — force GDPR::IAB::TCFv2::Parser as leaf class

--- a/lib/GDPR/IAB/TCFv2/BitField.pm
+++ b/lib/GDPR/IAB/TCFv2/BitField.pm
@@ -1,6 +1,5 @@
-package GDPR::IAB::TCFv2::BitField;
-use v5.10;
-use strict;
+package GDPR::IAB::TCFv2::BitField 0.510;
+use v5.12;
 use warnings;
 use integer;
 use bytes;
@@ -8,7 +7,6 @@ use bytes;
 use GDPR::IAB::TCFv2::BitUtils qw<is_set>;
 use Carp                       qw<croak>;
 
-our $VERSION = "0.510";
 
 sub Parse {
   my ($klass, %args) = @_;

--- a/lib/GDPR/IAB/TCFv2/BitUtils.pm
+++ b/lib/GDPR/IAB/TCFv2/BitUtils.pm
@@ -1,7 +1,5 @@
-package GDPR::IAB::TCFv2::BitUtils;
-use v5.10;
-use v5.10;
-use strict;
+package GDPR::IAB::TCFv2::BitUtils 0.510;
+use v5.12;
 use warnings;
 use integer;
 use bytes;
@@ -10,11 +8,10 @@ use Math::BigInt;
 use Carp qw(croak confess);
 
 require Exporter;
-use base qw<Exporter>;
+use parent qw<Exporter>;
 
 use constant ASCII_OFFSET => ord('A');
 
-our $VERSION = "0.510";
 
 our @EXPORT_OK = qw<is_set
   get_uint2

--- a/lib/GDPR/IAB/TCFv2/BitUtils.pm
+++ b/lib/GDPR/IAB/TCFv2/BitUtils.pm
@@ -12,6 +12,14 @@ use parent qw<Exporter>;
 
 use constant ASCII_OFFSET => ord('A');
 
+our $CAN_PACK_QUADS;
+our $CAN_FORCE_BIG_ENDIAN;
+
+BEGIN {
+  $CAN_PACK_QUADS       = !!eval { pack 'Q>', 1 };
+  $CAN_FORCE_BIG_ENDIAN = !!eval { pack 'S>', 1 };
+}
+
 our @EXPORT_OK = qw<is_set
   get_uint2
   get_uint3
@@ -103,23 +111,23 @@ sub _get_bits {
 
   # Unpack into a native integer and shift.
   # For up to 36 bits, we might need up to 6 bytes if it spans boundaries.
-  if ($num_bytes == 1) {
-    $val = unpack("C", $raw);
+  if ($CAN_FORCE_BIG_ENDIAN) {
+    if ($num_bytes == 1) {
+      $val = unpack("C", $raw);
+    }
+    elsif ($num_bytes == 2) {
+      $val = unpack("n", $raw);
+    }
+    elsif ($num_bytes == 3) {
+      $val = unpack("N", "\0" . $raw);
+    }
+    elsif ($num_bytes == 4) {
+      $val = unpack("N", $raw);
+    }
   }
-  elsif ($num_bytes == 2) {
-    $val = unpack("n", $raw);
-  }
-  elsif ($num_bytes == 3) {
-    $val = unpack("N", "\0" . $raw);
-  }
-  elsif ($num_bytes == 4) {
-    $val = unpack("N", $raw);
-  }
-  elsif ($num_bytes <= 8) {
 
-    # Use Math::BigInt for 32-bit Perls or 36-bit values that might overflow IV
-    state $can_pack_quads = !!eval { my $f = pack 'Q>'; 1 };
-    if ($can_pack_quads && $num_bytes <= 8) {
+  if (!defined($val) && $num_bytes <= 8) {
+    if ($CAN_PACK_QUADS) {
       my $padding = "\0" x (8 - $num_bytes);
       $val = unpack("Q>", $padding . $raw);
     }

--- a/lib/GDPR/IAB/TCFv2/CMPValidator.pm
+++ b/lib/GDPR/IAB/TCFv2/CMPValidator.pm
@@ -1,13 +1,11 @@
-package GDPR::IAB::TCFv2::CMPValidator;
+package GDPR::IAB::TCFv2::CMPValidator 0.510;
 
-use v5.10;
-use strict;
+use v5.12;
 use warnings;
 
 use Carp         qw<croak carp>;
 use Scalar::Util qw<blessed>;
 
-our $VERSION = "0.510";
 
 # JSON::PP and Time::Piece are loaded lazily (see load_from_data and
 # _parse_date). They are listed under META "recommends" rather than

--- a/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
@@ -91,7 +91,6 @@ GDPR::IAB::TCFv2::Constants::Purpose - TCF v2.3 purposes
 
 =head1 SYNOPSIS
 
-    use strict;
     use warnings;
     
     use GDPR::IAB::TCFv2::Constants::Purpose qw<:all>;

--- a/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
@@ -1,12 +1,10 @@
-package GDPR::IAB::TCFv2::Constants::Purpose;
-use v5.10;
-use strict;
+package GDPR::IAB::TCFv2::Constants::Purpose 0.510;
+use v5.12;
 use warnings;
 
 require Exporter;
-use base qw<Exporter>;
+use parent qw<Exporter>;
 
-our $VERSION = "0.510";
 
 use constant {
 

--- a/lib/GDPR/IAB/TCFv2/Constants/RestrictionType.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/RestrictionType.pm
@@ -32,7 +32,6 @@ GDPR::IAB::TCFv2::Constants::RestrictionType - TCF v2.3 publisher restriction ty
 
 =head1 SYNOPSIS
 
-    use strict;
     use warnings;
     
     use GDPR::IAB::TCFv2::Constants::RestrictionType qw<:all>;

--- a/lib/GDPR/IAB/TCFv2/Constants/RestrictionType.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/RestrictionType.pm
@@ -1,12 +1,10 @@
-package GDPR::IAB::TCFv2::Constants::RestrictionType;
-use v5.10;
-use strict;
+package GDPR::IAB::TCFv2::Constants::RestrictionType 0.510;
+use v5.12;
 use warnings;
 
 require Exporter;
-use base qw<Exporter>;
+use parent qw<Exporter>;
 
-our $VERSION = "0.510";
 
 use constant {NotAllowed => 0, RequireConsent => 1, RequireLegitimateInterest => 2,};
 

--- a/lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
@@ -1,12 +1,10 @@
-package GDPR::IAB::TCFv2::Constants::SpecialFeature;
-use v5.10;
-use strict;
+package GDPR::IAB::TCFv2::Constants::SpecialFeature 0.510;
+use v5.12;
 use warnings;
 
 require Exporter;
-use base qw<Exporter>;
+use parent qw<Exporter>;
 
-our $VERSION = "0.510";
 
 use constant {
 

--- a/lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
@@ -43,7 +43,6 @@ GDPR::IAB::TCFv2::Constants::SpecialFeature - TCF v2.3 special features
 
 =head1 SYNOPSIS
 
-    use strict;
     use warnings;
     
     use GDPR::IAB::TCFv2::Constants::SpecialFeature qw<:all>;

--- a/lib/GDPR/IAB/TCFv2/Parser.pm
+++ b/lib/GDPR/IAB/TCFv2/Parser.pm
@@ -906,7 +906,6 @@ GDPR::IAB::TCFv2::Parser - bit-stream parser for TCF v2.3 consent strings
 
 The purpose of this package is to parse Transparency & Consent String (TC String) as defined by IAB version 2.
 
-    use strict;
     use warnings;
 
     use GDPR::IAB::TCFv2::Parser;
@@ -1354,7 +1353,6 @@ Will serialize the consent object into a hash reference. The objective is to be 
 
 With option C<convert_blessed>, the encoder will call this method.
 
-    use strict;
     use warnings;
     use feature qw<say>;
 

--- a/lib/GDPR/IAB/TCFv2/Parser.pm
+++ b/lib/GDPR/IAB/TCFv2/Parser.pm
@@ -1,7 +1,6 @@
-package GDPR::IAB::TCFv2::Parser;
+package GDPR::IAB::TCFv2::Parser 0.510;
 
-use v5.10;
-use strict;
+use v5.12;
 use warnings;
 use integer;
 use bytes;
@@ -23,7 +22,6 @@ use GDPR::IAB::TCFv2::Publisher;
 use GDPR::IAB::TCFv2::RangeSection;
 use GDPR::IAB::TCFv2::Constants::RestrictionType qw<:all>;
 
-our $VERSION = "0.510";
 
 use constant {
   CONSENT_STRING_TCF_V2   => {SEPARATOR => quotemeta q<.>, PREFIX => q<C>, MIN_BYTE_SIZE => 29,},

--- a/lib/GDPR/IAB/TCFv2/Publisher.pm
+++ b/lib/GDPR/IAB/TCFv2/Publisher.pm
@@ -1,6 +1,5 @@
-package GDPR::IAB::TCFv2::Publisher;
-use v5.10;
-use strict;
+package GDPR::IAB::TCFv2::Publisher 0.510;
+use v5.12;
 use warnings;
 
 use Carp qw<croak>;
@@ -8,7 +7,6 @@ use Carp qw<croak>;
 use GDPR::IAB::TCFv2::PublisherRestrictions;
 use GDPR::IAB::TCFv2::PublisherTC;
 
-our $VERSION = "0.510";
 
 sub Parse {
   my ($klass, %args) = @_;

--- a/lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm
+++ b/lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm
@@ -1,6 +1,5 @@
-package GDPR::IAB::TCFv2::PublisherRestrictions;
-use v5.10;
-use strict;
+package GDPR::IAB::TCFv2::PublisherRestrictions 0.510;
+use v5.12;
 use warnings;
 
 use Carp qw<croak>;
@@ -11,7 +10,6 @@ use GDPR::IAB::TCFv2::BitUtils qw<
   get_uint12
 >;
 
-our $VERSION = "0.510";
 
 use constant ASSUMED_MAX_VENDOR_ID => 0x7FFF;    # 32767 or (1 << 15) -1
 

--- a/lib/GDPR/IAB/TCFv2/PublisherTC.pm
+++ b/lib/GDPR/IAB/TCFv2/PublisherTC.pm
@@ -1,6 +1,5 @@
-package GDPR::IAB::TCFv2::PublisherTC;
-use v5.10;
-use strict;
+package GDPR::IAB::TCFv2::PublisherTC 0.510;
+use v5.12;
 use warnings;
 
 use Carp qw<croak>;
@@ -10,7 +9,6 @@ use GDPR::IAB::TCFv2::BitUtils qw<is_set
   get_uint6
 >;
 
-our $VERSION = "0.510";
 
 use constant {
   SEGMENT_TYPE_PUBLISHER_TC => 3,

--- a/lib/GDPR/IAB/TCFv2/RangeSection.pm
+++ b/lib/GDPR/IAB/TCFv2/RangeSection.pm
@@ -1,6 +1,5 @@
-package GDPR::IAB::TCFv2::RangeSection;
-use v5.10;
-use strict;
+package GDPR::IAB::TCFv2::RangeSection 0.510;
+use v5.12;
 use warnings;
 use integer;
 use bytes;
@@ -8,7 +7,6 @@ use bytes;
 use GDPR::IAB::TCFv2::BitUtils qw<is_set get_uint12 get_uint16>;
 use Carp                       qw<croak>;
 
-our $VERSION = "0.510";
 
 sub Parse {
   my ($klass, %args) = @_;

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -1,7 +1,6 @@
-package GDPR::IAB::TCFv2::Validator;
+package GDPR::IAB::TCFv2::Validator 0.510;
 
-use v5.10;
-use strict;
+use v5.12;
 use warnings;
 
 use Carp         qw<croak>;
@@ -12,7 +11,6 @@ use GDPR::IAB::TCFv2::Validator::Failure;
 use GDPR::IAB::TCFv2::Validator::Reason qw<:all>;
 use GDPR::IAB::TCFv2::Validator::Result;
 
-our $VERSION = "0.510";
 
 sub new {
   my ($klass, %args) = @_;

--- a/lib/GDPR/IAB/TCFv2/Validator/Failure.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Failure.pm
@@ -1,14 +1,12 @@
-package GDPR::IAB::TCFv2::Validator::Failure;
+package GDPR::IAB::TCFv2::Validator::Failure 0.510;
 
-use v5.10;
-use strict;
+use v5.12;
 use warnings;
 
 use overload
   '""'     => sub { $_[0]->{message} },
   fallback => 1;
 
-our $VERSION = "0.510";
 
 sub new {
   my ($klass, %args) = @_;

--- a/lib/GDPR/IAB/TCFv2/Validator/Reason.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Reason.pm
@@ -1,12 +1,10 @@
-package GDPR::IAB::TCFv2::Validator::Reason;
-use v5.10;
-use strict;
+package GDPR::IAB::TCFv2::Validator::Reason 0.510;
+use v5.12;
 use warnings;
 
 require Exporter;
-use base qw<Exporter>;
+use parent qw<Exporter>;
 
-our $VERSION = "0.510";
 
 use constant {
 

--- a/lib/GDPR/IAB/TCFv2/Validator/Reason.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Reason.pm
@@ -136,7 +136,6 @@ GDPR::IAB::TCFv2::Validator::Reason - machine-readable validation-failure codes
 
 =head1 SYNOPSIS
 
-    use strict;
     use warnings;
 
     use GDPR::IAB::TCFv2::Validator::Reason qw<:all>;

--- a/lib/GDPR/IAB/TCFv2/Validator/Result.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Result.pm
@@ -1,7 +1,6 @@
-package GDPR::IAB::TCFv2::Validator::Result;
+package GDPR::IAB::TCFv2::Validator::Result 0.510;
 
-use v5.10;
-use strict;
+use v5.12;
 use warnings;
 
 use overload
@@ -15,7 +14,6 @@ use overload
   return join($sep, map { $_->message } @{$self->{failures} || []});
   };
 
-our $VERSION = "0.510";
 
 sub new {
   my ($klass, %args) = @_;

--- a/lib/iabtcfv2.pm
+++ b/lib/iabtcfv2.pm
@@ -26,13 +26,13 @@ iabtcfv2 - Pure-exporter short alias for one-liner and shell use
 
 =head1 SYNOPSIS
 
-    # From the shell:
-    perl -Miabtcfv2 -E 'say tcf(shift)->cmp_id' "CLc..."
-
-    # In a script:
     use iabtcfv2;
+    my $tc_string = 'CLc...';
     my $c = tcf($tc_string);
     my $v = validator(vendor_id => 284);
+
+    # From the shell:
+    # perl -Miabtcfv2 -E 'say tcf(shift)->cmp_id' "CLc..."
 
 =head1 DESCRIPTION
 

--- a/lib/iabtcfv2.pm
+++ b/lib/iabtcfv2.pm
@@ -1,7 +1,6 @@
-package iabtcfv2;
+package iabtcfv2 0.510;
 
-use v5.10;
-use strict;
+use v5.12;
 use warnings;
 
 use GDPR::IAB::TCFv2::Parser;
@@ -9,8 +8,7 @@ use GDPR::IAB::TCFv2::Validator;
 
 use Exporter qw(import);
 
-our @EXPORT  = qw(tcf validator);
-our $VERSION = "0.510";
+our @EXPORT = qw(tcf validator);
 
 sub tcf       { GDPR::IAB::TCFv2::Parser->Parse(@_) }
 sub validator { GDPR::IAB::TCFv2::Validator->new(@_) }

--- a/tools/bump-version
+++ b/tools/bump-version
@@ -1,11 +1,11 @@
 #!/usr/bin/env perl
 # tools/bump-version — release helper for GDPR-IAB-TCFv2
 #
-# Rewrites every `our $VERSION = "..."` declaration under lib/ to
+# Rewrites every `package Name VERSION;` declaration under lib/ to
 # the version passed on the command line. Refuses to run if the
 # new version is not strictly greater than the current dist version
 # (PAUSE-style sanity check) or if any .pm under lib/ is missing
-# the `$VERSION` line entirely (means the file drifted out of sync;
+# the `VERSION` in the package line entirely (means the file drifted out of sync;
 # author should investigate before bumping).
 #
 # Usage:
@@ -33,14 +33,14 @@ die "bump-version: cannot find $dist_pm (run from the repo root)\n"
     unless -f $dist_pm;
 
 my $current_version = read_version($dist_pm);
-die "bump-version: $dist_pm has no \$VERSION declaration\n"
+die "bump-version: $dist_pm has no VERSION in package declaration\n"
     unless defined $current_version;
 
 my $cur_v = version->parse($current_version);
 die "bump-version: refusing to downgrade ($current_version -> $new_version)\n"
     if $new_v <= $cur_v;
 
-# Collect every .pm under lib/, verify each declares $VERSION.
+# Collect every .pm under lib/, verify each declares a package version.
 my @pms;
 File::Find::find(
     {
@@ -61,9 +61,9 @@ for my $pm (@pms) {
     push @missing, $pm unless defined read_version($pm);
 }
 if (@missing) {
-    die "bump-version: the following files have no \$VERSION line:\n"
+    die "bump-version: the following files have no VERSION in their package line:\n"
         . join('', map { "  $_\n" } @missing)
-        . "Add `our \$VERSION = \"$current_version\";` to each before bumping.\n";
+        . "Add `package Name \"$current_version\";` to each before bumping.\n";
 }
 
 my @unwritable;
@@ -89,9 +89,9 @@ sub read_version {
     my $file = shift;
     open my $fh, '<', $file or die "open $file: $!\n";
     while (my $line = <$fh>) {
-        if ($line =~ /^\s*our\s+\$VERSION\s*=\s*(["'])([^"']+)\1\s*;/) {
+        if ($line =~ /^\s*package\s+(?:[\w:]+)\s+([^; ]+)\s*;/) {
             close $fh;
-            return $2;
+            return $1;
         }
     }
     close $fh;
@@ -106,11 +106,11 @@ sub rewrite_version {
 
     my $changed = 0;
     for my $line (@lines) {
-        if ($line =~ s/^(\s*our\s+\$VERSION\s*=\s*)(["'])[^"']+\2(\s*;)/$1"$version"$3/) {
+        if ($line =~ s/^(\s*package\s+[\w:]+\s+)([^; ]+)(\s*;)/$1$version$3/) {
             $changed++;
         }
     }
-    die "bump-version: failed to rewrite \$VERSION in $file\n" unless $changed;
+    die "bump-version: failed to rewrite VERSION in $file\n" unless $changed;
 
     open my $out, '>', $file or die "open >$file: $!\n";
     print {$out} @lines;
@@ -121,8 +121,8 @@ sub usage {
     return <<'EOF';
 Usage: tools/bump-version <new-version>
 
-Rewrites `our $VERSION = "..."` in every lib/**/*.pm to <new-version>.
-Refuses to downgrade. Refuses to run if any file is missing $VERSION.
+Rewrites `package Name VERSION;` in every lib/**/*.pm to <new-version>.
+Refuses to downgrade. Refuses to run if any file is missing the package version.
 
 Example:
     tools/bump-version 0.402


### PR DESCRIPTION
This PR establishes Perl 5.12 as the minimum version.
- Update MIN_PERL_VERSION to 5.012000.
- Adopt 'use v5.12;' (implies strict).
- Modernize inheritance with 'use parent'.
- Modern package version syntax.
- Updated tools/bump-version.

Fixes #132