### PR TITLE
fix: stop EUMM installing CONTRIBUTING and TODO as modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ The script refuses to downgrade and refuses to run if any `.pm` is missing `$VER
 
 ## Release flow
 
-Documented in `CONTRIBUTING.pod`. Summary: bump `$VERSION` across `lib/**.pm` with `tools/bump-version <new-version>`, run `git cliff -o CHANGELOG.md` (config in `cliff.toml` — uses Conventional Commits), regenerate `README.md` from POD with `pod2markdown lib/GDPR/IAB/TCFv2.pm > README.md`. 
+Documented in `CONTRIBUTING`. Summary: bump `$VERSION` across `lib/**.pm` with `tools/bump-version <new-version>`, run `git cliff -o CHANGELOG.md` (config in `cliff.toml` — uses Conventional Commits), regenerate `README.md` from POD with `pod2markdown lib/GDPR/IAB/TCFv2.pm > README.md`. 
 
 The release process is **automated**: once `devel` is merged to `main`, pushing a tag (`v*`) triggers a GitHub Action (`.github/workflows/release.yml`) that builds the distribution, uploads to CPAN (PAUSE), and creates a GitHub Release with the tarball attached.
 

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -1,5 +1,5 @@
 # To read this file, run:
-#    perldoc CONTRIBUTING.pod
+#    perldoc ./CONTRIBUTING
 
 =encoding utf8
 
@@ -19,7 +19,7 @@ The documentation is written using the
 L<POD|http://perldoc.perl.org/perlpod.html> format. Use the C<perldoc> tool
 to render it in a terminal:
 
-    perldoc CONTRIBUTING.pod
+    perldoc ./CONTRIBUTING
 
 =head1 PROJECT STATUS
 
@@ -32,7 +32,7 @@ as B<help-wanted> issues on GitHub.
 
 If you are looking for a place to contribute, the
 L<help-wanted issues|https://github.com/peczenyj/GDPR-IAB-TCFv2/issues?q=is%3Aopen+label%3Ahelp-wanted>
-are the curated entry point. F<TODO.pod> at the repository root has
+are the curated entry point. F<TODO> at the repository root has
 the full ecosystem and roadmap context, including suggested API
 sketches and test scopes for each item.
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -3,7 +3,7 @@ bin/iabtcfv2
 CHANGELOG.md
 CITATION.cff
 CODE_OF_CONDUCT.md
-CONTRIBUTING.pod
+CONTRIBUTING
 lib/GDPR/IAB/TCFv2.pm
 lib/GDPR/IAB/TCFv2/BitField.pm
 lib/GDPR/IAB/TCFv2/BitUtils.pm
@@ -51,4 +51,4 @@ t/corpus/gdpr_subset.txt
 t/corpus/golden.jsonl.gz
 t/corpus/validator_scenarios.pl
 t/generate_golden.pl
-TODO.pod
+TODO

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ ideas in ["ECOSYSTEM"](#ecosystem) -- is now tracked as `help-wanted` issues on
 GitHub.
 
 Patches and PRs from the community are welcome and will continue to be
-reviewed. See `TODO.pod` at the repository root for the full
-help-wanted list and `CONTRIBUTING.pod` for the patching workflow.
+reviewed. See `TODO` at the repository root for the full
+help-wanted list and `CONTRIBUTING` for the patching workflow.
 
 # SYNOPSIS
 
@@ -330,7 +330,7 @@ distributions rather than features of `GDPR::IAB::TCFv2` itself.
 
 The `help-wanted` issues on GitHub track each of these ideas; see
 [https://github.com/peczenyj/GDPR-IAB-TCFv2/issues?q=label%3Aecosystem](https://github.com/peczenyj/GDPR-IAB-TCFv2/issues?q=label%3Aecosystem)
-and `TODO.pod` for context.
+and `TODO` for context.
 
 # SEE ALSO
 

--- a/TODO
+++ b/TODO
@@ -1,5 +1,5 @@
 # To read this file, run:
-#    perldoc TODO.pod
+#    perldoc ./TODO
 
 =encoding utf8
 
@@ -787,7 +787,7 @@ effort and surfaces any spec questions early.
 
 =item 3.
 
-Follow the patching workflow in F<CONTRIBUTING.pod>: branch from
+Follow the patching workflow in F<CONTRIBUTING>: branch from
 C<devel>, run the full test suite (C<prove -lr t> plus
 C<AUTHOR_TESTING=1 prove -lr xt>), open a PR.
 
@@ -823,7 +823,7 @@ caching is a deployment concern, not a library concern.
 =head1 SEE ALSO
 
 L<GDPR::IAB::TCFv2>, L<GDPR::IAB::TCFv2::Validator>,
-L<GDPR::IAB::TCFv2::CMPValidator>, F<CONTRIBUTING.pod>,
+L<GDPR::IAB::TCFv2::CMPValidator>, F<CONTRIBUTING>,
 F<CHANGELOG.md>.
 
 =cut

--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -57,8 +57,8 @@ ideas in L</ECOSYSTEM> -- is now tracked as C<help-wanted> issues on
 GitHub.
 
 Patches and PRs from the community are welcome and will continue to be
-reviewed. See F<TODO.pod> at the repository root for the full
-help-wanted list and F<CONTRIBUTING.pod> for the patching workflow.
+reviewed. See F<TODO> at the repository root for the full
+help-wanted list and F<CONTRIBUTING> for the patching workflow.
 
 =head1 SYNOPSIS
 
@@ -355,7 +355,7 @@ business validation through DFV.
 
 The C<help-wanted> issues on GitHub track each of these ideas; see
 L<https://github.com/peczenyj/GDPR-IAB-TCFv2/issues?q=label%3Aecosystem>
-and F<TODO.pod> for context.
+and F<TODO> for context.
 
 =head1 SEE ALSO
 

--- a/tools/bump-version
+++ b/tools/bump-version
@@ -12,7 +12,7 @@
 #     tools/bump-version 0.402
 #
 # Does NOT touch CHANGELOG, run git-cliff, commit, tag, or push.
-# Those steps remain manual per CONTRIBUTING.pod.
+# Those steps remain manual per CONTRIBUTING.
 
 use strict;
 use warnings;


### PR DESCRIPTION
## Summary

`ExtUtils::MakeMaker` auto-harvests every `*.pm`/`*.pod` file in the distribution. The root-level `CONTRIBUTING.pod` and `TODO.pod` were therefore installed as bogus POD documents — `GDPR::IAB::CONTRIBUTING` and `GDPR::IAB::TODO` (EUMM maps top-level pod into the namespace parent dir derived from `NAME`).

This is the same class of bug as [MooX-Role-Parameterized issue #22](https://github.com/peczenyj/MooX-Role-Parameterized/issues/22).

## Fix

Drop the `.pod` extension from both files. They still ship in the tarball (still listed in `MANIFEST`), but EUMM no longer treats them as installable modules.

- `CONTRIBUTING.pod` → `CONTRIBUTING`, `TODO.pod` → `TODO`
- `MANIFEST` entries updated
- In-file `perldoc X.pod` hints → `perldoc ./X` (without the extension, `perldoc` searches `@INC` for a module instead of reading the file)
- POD `F<>` filename links and prose mentions updated in `lib/GDPR/IAB/TCFv2.pm`, `README.md`, `AGENTS.md`, `tools/bump-version`

## Verification

`perl Makefile.PL && make` now copies only `lib/` modules and `bin/iabtcfv2` into `blib/` — no `CONTRIBUTING`/`TODO`. The bogus `GDPR::IAB::CONTRIBUTING` / `GDPR::IAB::TODO` installs are gone.

## Notes

- `.claude/settings.local.json` has two now-stale allowlist entries (`podchecker CONTRIBUTING.pod`, `perldoc -F TODO.pod`) — left untouched (local tooling config).
- `CHANGELOG.md` is git-cliff-generated and was not hand-edited; the `fix:` commit prefix will produce an entry on the next `git cliff` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)