### PR TITLE
chore: prepare for v0.530 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [0.530] - 2026-05-28
+
+### Features
+
+- *(validator)* Cross-language validator parity with the Go lib-gdpr redesign branch (`validator_strict.go`)
+  - Auto-enable `verify_disclosed_vendors` when `min_tcf_policy_version >= 5`, and run the mandatory disclosed-vendors check independently of it (mirrors Go `New` + `yieldMandatoryDisclosedVendors`).
+  - Strictly-after v2.3 deadline boundary (`created > TCF_V23_DEADLINE`) matching Go `created.After(v23Deadline)`; the parser's `is_v23` keeps `>=` for its own strict-parse gate.
+  - Single `PolicyVersionTooLow` when both the policy floor and the v2.3 date rule apply (`_check_policy_version`, mirrors Go `yieldPolicyVersionFailure`).
+  - Global vendor gate emitting `ReasonVendorNotAllowed` when a vendor has neither vendor-consent nor vendor-LI — short-circuits before per-purpose checks in both fail-fast and exhaustive modes.
+  - Flexible-purpose `_flexible_failure` follows Go `runFlexibleCheck`'s effective legal basis: spec carve-out (P1, or P3–6 at policy ≥ 4) forces consent; `RequireConsent`/`RequireLI` override; `NotAllowed` surfaces `ReasonPublisherRestrictionNotAllowed`; carve-out outranks the generic LI reason.
+- *(cmp)* Add `CMPDeleted` / `CMPUnknown` reason codes and `CMPValidator->state` (active/deleted/unknown); validator maps CMP lifecycle state to these reasons.
+- *(tests)* `t/18-go-parity.t` pinning each rule to its Go counterpart; updates to `t/06` and `t/17` for the aligned behavior; validator golden corpus regenerated.
+
+### Documentation
+
+- Claim SLSA Build Level 2
+
 ## [0.520] - 2026-05-18
 
 ### Bug Fixes
@@ -6,6 +23,8 @@
 
 ### Other
 
+- Merge branch 'release/0.520'
+- Update changelog
 - Bump version
 - Remove extra test, not needed
 - Update changelog

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,5 +20,5 @@ keywords:
   - consent
   - privacy
   - adtech
-version: "0.520"
-date-released: "2026-05-18"
+version: "0.530"
+date-released: "2026-05-28"

--- a/MANIFEST
+++ b/MANIFEST
@@ -44,6 +44,7 @@ t/14-cmp-validator.t
 t/15-validator-reason.t
 t/16-validator-failures.t
 t/17-v23-deadline.t
+t/18-go-parity.t
 t/90-bugs.t
 t/99-pod.t
 t/corpus/cmp-list.json

--- a/lib/GDPR/IAB/TCFv2.pm
+++ b/lib/GDPR/IAB/TCFv2.pm
@@ -1,4 +1,4 @@
-package GDPR::IAB::TCFv2 0.520;
+package GDPR::IAB::TCFv2 0.530;
 
 use v5.12;
 use warnings;

--- a/lib/GDPR/IAB/TCFv2/BitField.pm
+++ b/lib/GDPR/IAB/TCFv2/BitField.pm
@@ -1,4 +1,4 @@
-package GDPR::IAB::TCFv2::BitField 0.520;
+package GDPR::IAB::TCFv2::BitField 0.530;
 use v5.12;
 use warnings;
 use integer;

--- a/lib/GDPR/IAB/TCFv2/BitUtils.pm
+++ b/lib/GDPR/IAB/TCFv2/BitUtils.pm
@@ -1,4 +1,4 @@
-package GDPR::IAB::TCFv2::BitUtils 0.520;
+package GDPR::IAB::TCFv2::BitUtils 0.530;
 use v5.12;
 use warnings;
 use integer;

--- a/lib/GDPR/IAB/TCFv2/CMPValidator.pm
+++ b/lib/GDPR/IAB/TCFv2/CMPValidator.pm
@@ -1,4 +1,4 @@
-package GDPR::IAB::TCFv2::CMPValidator 0.520;
+package GDPR::IAB::TCFv2::CMPValidator 0.530;
 
 use v5.12;
 use warnings;

--- a/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/Purpose.pm
@@ -1,4 +1,4 @@
-package GDPR::IAB::TCFv2::Constants::Purpose 0.520;
+package GDPR::IAB::TCFv2::Constants::Purpose 0.530;
 use v5.12;
 use warnings;
 

--- a/lib/GDPR/IAB/TCFv2/Constants/RestrictionType.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/RestrictionType.pm
@@ -1,4 +1,4 @@
-package GDPR::IAB::TCFv2::Constants::RestrictionType 0.520;
+package GDPR::IAB::TCFv2::Constants::RestrictionType 0.530;
 use v5.12;
 use warnings;
 

--- a/lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
+++ b/lib/GDPR/IAB/TCFv2/Constants/SpecialFeature.pm
@@ -1,4 +1,4 @@
-package GDPR::IAB::TCFv2::Constants::SpecialFeature 0.520;
+package GDPR::IAB::TCFv2::Constants::SpecialFeature 0.530;
 use v5.12;
 use warnings;
 

--- a/lib/GDPR/IAB/TCFv2/Parser.pm
+++ b/lib/GDPR/IAB/TCFv2/Parser.pm
@@ -1,4 +1,4 @@
-package GDPR::IAB::TCFv2::Parser 0.520;
+package GDPR::IAB::TCFv2::Parser 0.530;
 
 use v5.12;
 use warnings;

--- a/lib/GDPR/IAB/TCFv2/Publisher.pm
+++ b/lib/GDPR/IAB/TCFv2/Publisher.pm
@@ -1,4 +1,4 @@
-package GDPR::IAB::TCFv2::Publisher 0.520;
+package GDPR::IAB::TCFv2::Publisher 0.530;
 use v5.12;
 use warnings;
 

--- a/lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm
+++ b/lib/GDPR/IAB/TCFv2/PublisherRestrictions.pm
@@ -1,4 +1,4 @@
-package GDPR::IAB::TCFv2::PublisherRestrictions 0.520;
+package GDPR::IAB::TCFv2::PublisherRestrictions 0.530;
 use v5.12;
 use warnings;
 

--- a/lib/GDPR/IAB/TCFv2/PublisherTC.pm
+++ b/lib/GDPR/IAB/TCFv2/PublisherTC.pm
@@ -1,4 +1,4 @@
-package GDPR::IAB::TCFv2::PublisherTC 0.520;
+package GDPR::IAB::TCFv2::PublisherTC 0.530;
 use v5.12;
 use warnings;
 

--- a/lib/GDPR/IAB/TCFv2/RangeSection.pm
+++ b/lib/GDPR/IAB/TCFv2/RangeSection.pm
@@ -1,4 +1,4 @@
-package GDPR::IAB::TCFv2::RangeSection 0.520;
+package GDPR::IAB::TCFv2::RangeSection 0.530;
 use v5.12;
 use warnings;
 use integer;

--- a/lib/GDPR/IAB/TCFv2/Validator.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator.pm
@@ -1,4 +1,4 @@
-package GDPR::IAB::TCFv2::Validator 0.520;
+package GDPR::IAB::TCFv2::Validator 0.530;
 
 use v5.12;
 use warnings;

--- a/lib/GDPR/IAB/TCFv2/Validator/Failure.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Failure.pm
@@ -1,4 +1,4 @@
-package GDPR::IAB::TCFv2::Validator::Failure 0.520;
+package GDPR::IAB::TCFv2::Validator::Failure 0.530;
 
 use v5.12;
 use warnings;

--- a/lib/GDPR/IAB/TCFv2/Validator/Reason.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Reason.pm
@@ -1,4 +1,4 @@
-package GDPR::IAB::TCFv2::Validator::Reason 0.520;
+package GDPR::IAB::TCFv2::Validator::Reason 0.530;
 use v5.12;
 use warnings;
 

--- a/lib/GDPR/IAB/TCFv2/Validator/Result.pm
+++ b/lib/GDPR/IAB/TCFv2/Validator/Result.pm
@@ -1,4 +1,4 @@
-package GDPR::IAB::TCFv2::Validator::Result 0.520;
+package GDPR::IAB::TCFv2::Validator::Result 0.530;
 
 use v5.12;
 use warnings;

--- a/lib/iabtcfv2.pm
+++ b/lib/iabtcfv2.pm
@@ -1,4 +1,4 @@
-package iabtcfv2 0.520;
+package iabtcfv2 0.530;
 
 use v5.12;
 use warnings;


### PR DESCRIPTION
Release-prep PR for **v0.530**. Per `AGENTS.md` this is a `feat/*` PR into `devel`; the owner handles the devel → main merge and the `v0.530` tag push.

## Bump

- `$VERSION` bumped to `0.530` across all 17 `lib/**.pm` via `tools/bump-version 0.530`
- `CITATION.cff`: `version: "0.530"`, `date-released: "2026-05-28"`
- `CHANGELOG.md`: regenerated with `git cliff --tag v0.530`, then hand-cleaned to summarize the squash-merged #138 body (per `CONTRIBUTING`'s "sanity-check the output" guidance for git-cliff slurping commit bodies)
- `MANIFEST`: adds `t/18-go-parity.t` (was missing from #138)
- `README.md`: regenerated from POD via `pod2markdown lib/GDPR/IAB/TCFv2.pm > README.md` — byte-identical to the existing checked-in file (no diff)

## Highlights since v0.520

- **`feat(validator)`: cross-language parity with Go lib-gdpr redesign** (#138) — `validator_strict.go` + surrounding gates
  - Auto-enable `verify_disclosed_vendors` when `min_tcf_policy_version >= 5`; mandatory disclosed-vendors runs independently of it (Go `New` + `yieldMandatoryDisclosedVendors`)
  - Strictly-after v2.3 deadline boundary (`created > TCF_V23_DEADLINE`) matching Go `created.After(v23Deadline)`
  - Single `PolicyVersionTooLow` when both floor and v2.3 date rule apply (`_check_policy_version`)
  - Global vendor gate `ReasonVendorNotAllowed` — short-circuits before per-purpose checks
  - `_flexible_failure` follows Go `runFlexibleCheck` effective-basis: carve-out forces consent, `RequireConsent`/`RequireLI` override, `NotAllowed` surfaces `ReasonPublisherRestrictionNotAllowed`
- **`feat(cmp)`**: `CMPDeleted` / `CMPUnknown` reason codes; `CMPValidator->state` (active/deleted/unknown)
- **`tests`**: `t/18-go-parity.t` pinning each rule to its Go counterpart
- **`docs`**: claim SLSA Build Level 2 (#137)

## Local pre-release gate (all green)

- `perl Makefile.PL && make` ✓
- `make test` — 21 files, 10415 tests, PASS
- `prove -lr xt` — 4 files, 99 tests, PASS (critic + tidy + synopsis + version)
- `make manifest` — added `t/18-go-parity.t`
- `make dist` — produced `GDPR-IAB-TCFv2-0.530.tar.gz` (68 files, no `.bak`/`AGENTS.md`/`MYMETA.*` junk, `t/18-go-parity.t` included)

## After merge

1. PR `devel → main`, merge as a merge commit
2. `git checkout main && git pull --ff-only`
3. `git tag -a v0.530 -m "Release v0.530 — <one-line summary>"`
4. `git push origin v0.530` — triggers `release.yml` (CPAN upload + GitHub Release)

## Note: incident during prep

The initial `git push -u origin feat/release-prep-0.530` accidentally landed on `refs/heads/devel` because the local branch had been created with `git checkout -b feat/release-prep-0.530 origin/devel`, which set its upstream to `origin/devel`. I rolled `origin/devel` back to `0b862ad` via `git push origin +0b862ad:devel` and re-pushed the work to a proper `feat/release-prep-0.530` ref (this PR). No other refs were affected. The mistake and remediation were surfaced and approved at the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)