### PR TITLE
ci: drop CODECOV_TOKEN, rely on tokenless upload

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,5 +49,3 @@ jobs:
         with:
           files: ./cover_db/cobertura.xml
           fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Follow-up to #141. This is a public repo, so Codecov accepts tokenless uploads using GitHub as a trusted OIDC source — the `CODECOV_TOKEN` env on the upload step is unnecessary and is removed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)